### PR TITLE
ci: also dispatch pin-bump to stablehlo_fork

### DIFF
--- a/.github/workflows/notify-downstream.yml
+++ b/.github/workflows/notify-downstream.yml
@@ -18,3 +18,12 @@ jobs:
             -f event_type=pin-bump \
             -f 'client_payload[source_repo]=prime-ir' \
             -f 'client_payload[commit]=${{ github.sha }}'
+
+      - name: Dispatch pin-bump to stablehlo_fork
+        env:
+          GH_TOKEN: ${{ secrets.BUMPER_GH_PAT }}
+        run: |
+          gh api repos/fractalyze/stablehlo_fork/dispatches \
+            -f event_type=pin-bump \
+            -f 'client_payload[source_repo]=prime-ir' \
+            -f 'client_payload[commit]=${{ github.sha }}'


### PR DESCRIPTION
prime-ir already dispatches `pin-bump` to `fractalyze/stablehlo` (ZKX stack). Add a second dispatch to `fractalyze/stablehlo_fork` so prime-ir main commits also feed the jax_fork pin chain: **prime-ir → stablehlo_fork → xla_fork → jax_fork**. The existing stablehlo dispatch is untouched.

Receiver side is stablehlo_fork's new `pin-bump.yml` (sibling PR).