### PR TITLE
build: bump zk_dtypes to a5bd0ad873a7

### DIFF
--- a/third_party/zk_dtypes/workspace.bzl
+++ b/third_party/zk_dtypes/workspace.bzl
@@ -17,8 +17,8 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def repo():
-    ZK_DTYPES_COMMIT = "4b0d7c5c80179b3eaf77c7cbe815bb6f2e376741"
-    ZK_DTYPES_SHA256 = "f7a129c165260b99da39721cc3e09f6b3251618b6a4837ae669be77686d27178"
+    ZK_DTYPES_COMMIT = "a5bd0ad873a76b5273a42e9fe0dc7c1935a77c4e"
+    ZK_DTYPES_SHA256 = "07978d464e312aed69af91e550fb1b82fb02f934943a3b5550b7bae0d289262a"
     http_archive(
         name = "zk_dtypes",
         sha256 = ZK_DTYPES_SHA256,


### PR DESCRIPTION
Automated pin bump of `zk_dtypes` to [`a5bd0ad873a7`](https://github.com/fractalyze/zk_dtypes/commit/a5bd0ad873a76b5273a42e9fe0dc7c1935a77c4e).