### PR TITLE
perf(modarith): strength-reduce the Goldilocks Solinas hi_lo·ε to shift+sub

### DIFF
--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/SolinasReducer.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/SolinasReducer.cpp
@@ -55,9 +55,12 @@ Value SolinasReducer::reduce(Value lo, Value hi) {
   Value t0Corr = arith::SubIOp::create(b, t0Raw, epsilon);
   Value t0 = arith::SelectOp::create(b, borrow, t0Corr, t0Raw);
 
-  // t1 = hi_lo · ε < 2^64 (both factors < 2^32), so the narrow multiply is
-  // exact — no high half needed.
-  Value t1 = arith::MulIOp::create(b, hiLo, epsilon);
+  // t1 = hi_lo · ε. Since ε = 2^32 - 1 and hi_lo < 2^32, this is
+  // (hi_lo << 32) - hi_lo, exact in 64 bits (hi_lo << 32 < 2^64, no borrow).
+  // Strength-reduced to shift+sub: ptxas keeps the multiply-by-immediate as a
+  // 64-bit IMAD otherwise, paid on every Goldilocks field multiply.
+  Value t1 =
+      arith::SubIOp::create(b, arith::ShLIOp::create(b, hiLo, half), hiLo);
 
   // t2 = t0 + t1; an add carry again means a 2^64 ≡ ε wrap, corrected by +ε.
   auto add = arith::AddUIExtendedOp::create(b, t0, t1);

--- a/tests/Dialect/ModArith/mod_arith_to_arith.mlir
+++ b/tests/Dialect/ModArith/mod_arith_to_arith.mlir
@@ -329,7 +329,8 @@ func.func @test_lower_mul_goldilocks(%lhs : !Goldilocks, %rhs : !Goldilocks)
   // CHECK:      %[[T0RAW:.*]] = arith.subi %[[LO]], %[[HIHI]] : i64
   // CHECK:      %[[T0COR:.*]] = arith.subi %[[T0RAW]], %{{.*}} : i64
   // CHECK:      %[[T0:.*]] = arith.select %[[BORROW]], %[[T0COR]], %[[T0RAW]] : i64
-  // CHECK:      %[[T1:.*]] = arith.muli %[[HILO]], %{{.*}} : i64
+  // CHECK:      %[[T1SHL:.*]] = arith.shli %[[HILO]], %{{.*}} : i64
+  // CHECK:      %[[T1:.*]] = arith.subi %[[T1SHL]], %[[HILO]] : i64
   // CHECK:      %[[SUM:.*]], %[[CARRY:.*]] = arith.addui_extended %[[T0]], %[[T1]] : i64, i1
   // CHECK:      %[[T2COR:.*]] = arith.addi %[[SUM]], %{{.*}} : i64
   // CHECK:      %[[T2:.*]] = arith.select %[[CARRY]], %[[T2COR]], %[[SUM]] : i64
@@ -355,7 +356,8 @@ func.func @test_lower_square_goldilocks(%lhs : !Goldilocks) -> !Goldilocks {
   // CHECK:      %[[T0RAW:.*]] = arith.subi %[[LO]], %[[HIHI]] : i64
   // CHECK:      %[[T0COR:.*]] = arith.subi %[[T0RAW]], %{{.*}} : i64
   // CHECK:      %[[T0:.*]] = arith.select %[[BORROW]], %[[T0COR]], %[[T0RAW]] : i64
-  // CHECK:      %[[T1:.*]] = arith.muli %[[HILO]], %{{.*}} : i64
+  // CHECK:      %[[T1SHL:.*]] = arith.shli %[[HILO]], %{{.*}} : i64
+  // CHECK:      %[[T1:.*]] = arith.subi %[[T1SHL]], %[[HILO]] : i64
   // CHECK:      %[[SUM:.*]], %[[CARRY:.*]] = arith.addui_extended %[[T0]], %[[T1]] : i64, i1
   // CHECK:      %[[T2COR:.*]] = arith.addi %[[SUM]], %{{.*}} : i64
   // CHECK:      %[[T2:.*]] = arith.select %[[CARRY]], %[[T2COR]], %[[SUM]] : i64


### PR DESCRIPTION
## What

`SolinasReducer::reduce` computed `t1 = hi_lo · ε` with `arith.muli`. Since `ε = 2^32 - 1` and `hi_lo < 2^32`, this equals `(hi_lo << 32) - hi_lo` exactly in 64 bits (no borrow), so emit `shli` + `subi` instead.

## Why

ptxas does **not** strength-reduce the multiply-by-immediate — it stays a 64-bit `IMAD`, paid on **every Goldilocks field multiply's reduction**. Found via an op-for-op SASS comparison of the zisk-zorch Poseidon2 GPU leaf hash vs pil2-stark (zkx did ~7× the IMAD; zkx SASS had 0 `SHF`, pil2 148).

## Validation (RTX 5090, A41)

- **Byte-identical** — golden byte-match preserved (zisk-zorch Poseidon2 commit, `verified=true` at W8/W12/W16).
- The hottest Goldilocks-mul kernel (Poseidon2 leaf hash) drops **255 → 94 registers/thread** and **16% → 39%** achieved occupancy.
- That kernel isn't occupancy-bound at 2^23 so its own wall-clock is ~unchanged (−1.2%), but the register/occupancy headroom benefits occupancy-bound Goldilocks kernels (NTT/MSM/Poseidon2) broadly.

Updates the `mod_arith_to_arith` FileCheck (mul + square) for the shift+sub sequence; CI's lit run is the gate on the exact IR.

Context: fractalyze/zisk-zorch#30.