### PR TITLE
fix(dialect/ec): rebuild memref descriptor for count-changing bitcast

### DIFF
--- a/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToLLVM/EllipticCurveToLLVM.cpp
+++ b/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToLLVM/EllipticCurveToLLVM.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "mlir/Conversion/ConvertToLLVM/ToLLVMInterface.h"
 #include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
+#include "mlir/Conversion/LLVMCommon/MemRefBuilder.h"
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -117,15 +118,102 @@ struct ConvertBitcast : public ConvertOpToLLVMPattern<BitcastOp> {
   LogicalResult
   matchAndRewrite(BitcastOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // For memref/tensor types, use unrealized_conversion_cast which will be
-    // cleaned up by reconcile-unrealized-casts pass. The underlying memory is
-    // the same, just viewed differently.
     Type convertedOutputType = typeConverter->convertType(op.getType());
     if (!convertedOutputType) {
       return op.emitOpError("failed to convert output type");
     }
+
+    // Memref bitcasts (produced by bufferization) reinterpret one buffer as a
+    // tensor of N points <-> N*K coordinates. The element COUNT changes (K
+    // coordinates per point), so the descriptor must be rebuilt with
+    // sizes/strides/offset in the output element's units. A plain
+    // unrealized_conversion_cast preserves the input descriptor — sizes still
+    // in input-element units — and any later dealloc/copy then computes the
+    // wrong byte count (heap corruption). Mirrors
+    // field::ConvertBitcast::convertMemRefBitcast.
+    if (isa<MemRefType>(op.getInput().getType()))
+      return convertMemRefBitcast(op, adaptor, rewriter, convertedOutputType);
+
+    // Value-level reinterpret: the memory is identical and the input already
+    // has the right LLVM struct type. reconcile-unrealized-casts cleans it up.
     rewriter.replaceOpWithNewOp<UnrealizedConversionCastOp>(
         op, convertedOutputType, adaptor.getInput());
+    return success();
+  }
+
+private:
+  // Number of base-field coordinates an element type spans: an EC point has
+  // getNumCoords() (affine 2, jacobian 3, xyzz 4); a field coordinate is 1.
+  static unsigned getNumCoords(Type elementType) {
+    if (auto pt = dyn_cast<PointTypeInterface>(elementType))
+      return pt.getNumCoords();
+    return 1;
+  }
+
+  LogicalResult convertMemRefBitcast(BitcastOp op, OpAdaptor adaptor,
+                                     ConversionPatternRewriter &rewriter,
+                                     Type convertedOutputType) const {
+    Location loc = op.getLoc();
+    auto inputMemRef = cast<MemRefType>(op.getInput().getType());
+    auto outputMemRef = cast<MemRefType>(op.getType());
+
+    auto llvmDescTy = dyn_cast<LLVM::LLVMStructType>(convertedOutputType);
+    if (!llvmDescTy)
+      return failure();
+
+    MemRefDescriptor inputDesc(adaptor.getInput());
+
+    // Same-shape reinterpret: descriptor unchanged. Unreachable for EC -- a
+    // point has K>=2 coords, so point<->coordinate element counts always
+    // differ -- but kept as a defensive mirror of field::convertMemRefBitcast,
+    // where the equal-byte-size case (e.g. ef4 <-> i128) is reachable.
+    if (inputMemRef.getShape() == outputMemRef.getShape()) {
+      rewriter.replaceOp(op, adaptor.getInput());
+      return success();
+    }
+
+    // Point tensor <-> coordinate tensor: rebuild the descriptor sharing the
+    // buffer, adjusting offset by the coordinate-count ratio and resetting
+    // sizes/strides to the contiguous output shape.
+    auto outputDesc = MemRefDescriptor::poison(rewriter, loc, llvmDescTy);
+
+    // Same underlying memory — pointers are shared.
+    outputDesc.setAllocatedPtr(rewriter, loc,
+                               inputDesc.allocatedPtr(rewriter, loc));
+    outputDesc.setAlignedPtr(rewriter, loc,
+                             inputDesc.alignedPtr(rewriter, loc));
+
+    // Adjust offset: offset_out = offset_in × coordsIn / coordsOut, where
+    // coords is the base-field coordinate count of the respective element type.
+    unsigned coordsIn = getNumCoords(inputMemRef.getElementType());
+    unsigned coordsOut = getNumCoords(outputMemRef.getElementType());
+
+    Value offset = inputDesc.offset(rewriter, loc);
+    if (coordsIn != coordsOut) {
+      Type idxTy = getTypeConverter()->getIndexType();
+      if (coordsOut > coordsIn) {
+        // coords -> point: divide offset (output counts fewer, larger elems).
+        Value ratio =
+            createIndexAttrConstant(rewriter, loc, idxTy, coordsOut / coordsIn);
+        offset = LLVM::SDivOp::create(rewriter, loc, offset, ratio);
+      } else {
+        // point -> coords: multiply offset (output counts more, smaller elems).
+        Value ratio =
+            createIndexAttrConstant(rewriter, loc, idxTy, coordsIn / coordsOut);
+        offset = LLVM::MulOp::create(rewriter, loc, offset, ratio);
+      }
+    }
+    outputDesc.setOffset(rewriter, loc, offset);
+
+    // Sizes: from the static output shape.
+    for (int64_t i = 0, e = outputMemRef.getRank(); i < e; ++i)
+      outputDesc.setConstantSize(rewriter, loc, i, outputMemRef.getDimSize(i));
+
+    // Strides: output has identity layout (contiguous), stride = 1.
+    for (int64_t i = 0, e = outputMemRef.getRank(); i < e; ++i)
+      outputDesc.setConstantStride(rewriter, loc, i, 1);
+
+    rewriter.replaceOp(op, Value(outputDesc));
     return success();
   }
 };

--- a/tests/Dialect/EllipticCurve/elliptic_curve_to_llvm.mlir
+++ b/tests/Dialect/EllipticCurve/elliptic_curve_to_llvm.mlir
@@ -52,3 +52,77 @@ func.func @test_to_coords_g2(%affine: !g2affinem, %jacobian: !g2jacobianm, %xyzz
   %xyzz_coords:4 = elliptic_curve.to_coords %xyzz : (!g2xyzzm) -> (!llvm.struct<(i256, i256)>, !llvm.struct<(i256, i256)>, !llvm.struct<(i256, i256)>, !llvm.struct<(i256, i256)>)
   return
 }
+
+// -----
+
+// Memref bitcast descriptor rebuild tests.
+//
+// After bufferization, elliptic_curve.bitcast operates on memrefs, reinterpreting
+// one buffer as N points <-> N*K contiguous coordinates.  ConvertBitcast must
+// build a NEW descriptor with sizes/strides/offset in the OUTPUT element's units.
+// Before the fix, an unrealized_conversion_cast forwarded the input descriptor
+// unchanged — leaving sizes in input-element units — so a later dealloc/copy
+// computed the wrong byte count (heap corruption: munmap_chunk invalid pointer).
+// Mirrors tests/Dialect/Field/ext_field_to_llvm.mlir.
+//
+// -split-input-file parses each chunk independently, so the standard-form G1
+// types are redefined locally here (the bn254_defs.mlir aliases live in the
+// first chunk only).
+
+!PF = !field.pf<21888242871839275222246405745257275088696311157297823662689037894645226208583:i256>
+#curve = #elliptic_curve.sw<0:i256, 3:i256, (1:i256, 2:i256)> : !PF
+!affine = !elliptic_curve.affine<#curve>
+!jacobian = !elliptic_curve.jacobian<#curve>
+
+// Pack: memref<8x!PF> -> memref<4x!affine>  (2 coords per affine point)
+//
+// Descriptor fields:
+//   allocPtr / alignedPtr — passed through from input
+//   offset   = sdiv(input_offset, 2)
+//   sizes[0] = 4  (static, from output type)
+//   strides[0] = 1  (identity layout)
+//
+// CHECK-LABEL: @bitcast_pf_to_affine
+//       CHECK:   llvm.mlir.poison
+//       CHECK:   llvm.insertvalue {{%.+}}, {{%.+}}[0]
+//       CHECK:   llvm.insertvalue {{%.+}}, {{%.+}}[1]
+//       CHECK:   [[R2_U:%.+]] = llvm.mlir.constant(2 : index) : i64
+//       CHECK:   llvm.sdiv {{%.+}}, [[R2_U]] : i64
+//       CHECK:   llvm.insertvalue {{%.+}}, {{%.+}}[2]
+//       CHECK:   [[SZ4:%.+]] = llvm.mlir.constant(4 : index) : i64
+//       CHECK:   llvm.insertvalue [[SZ4]], {{%.+}}[3, 0]
+//       CHECK:   [[ST1_U:%.+]] = llvm.mlir.constant(1 : index) : i64
+//       CHECK:   llvm.insertvalue [[ST1_U]], {{%.+}}[4, 0]
+func.func @bitcast_pf_to_affine(%arg0: memref<8x!PF>) -> memref<4x!affine> {
+  %0 = elliptic_curve.bitcast %arg0 : memref<8x!PF> -> memref<4x!affine>
+  return %0 : memref<4x!affine>
+}
+
+// Unpack: memref<4x!affine> -> memref<8x!PF>  (2 coords per affine point)
+//
+// offset = mul(input_offset, 2),  sizes[0] = 8,  strides[0] = 1
+//
+// CHECK-LABEL: @bitcast_affine_to_pf
+//       CHECK:   [[R2_D:%.+]] = llvm.mlir.constant(2 : index) : i64
+//       CHECK:   llvm.mul {{%.+}}, [[R2_D]] : i64
+//       CHECK:   llvm.insertvalue {{%.+}}, {{%.+}}[2]
+//       CHECK:   [[SZ8:%.+]] = llvm.mlir.constant(8 : index) : i64
+//       CHECK:   llvm.insertvalue [[SZ8]], {{%.+}}[3, 0]
+//       CHECK:   [[ST1_D:%.+]] = llvm.mlir.constant(1 : index) : i64
+//       CHECK:   llvm.insertvalue [[ST1_D]], {{%.+}}[4, 0]
+func.func @bitcast_affine_to_pf(%arg0: memref<4x!affine>) -> memref<8x!PF> {
+  %0 = elliptic_curve.bitcast %arg0 : memref<4x!affine> -> memref<8x!PF>
+  return %0 : memref<8x!PF>
+}
+
+// Jacobian: memref<6x!PF> -> memref<2x!jacobian>  (3 coords per point)
+//
+// CHECK-LABEL: @bitcast_pf_to_jacobian
+//       CHECK:   [[R3:%.+]] = llvm.mlir.constant(3 : index) : i64
+//       CHECK:   llvm.sdiv {{%.+}}, [[R3]] : i64
+//       CHECK:   [[SZ2:%.+]] = llvm.mlir.constant(2 : index) : i64
+//       CHECK:   llvm.insertvalue [[SZ2]], {{%.+}}[3, 0]
+func.func @bitcast_pf_to_jacobian(%arg0: memref<6x!PF>) -> memref<2x!jacobian> {
+  %0 = elliptic_curve.bitcast %arg0 : memref<6x!PF> -> memref<2x!jacobian>
+  return %0 : memref<2x!jacobian>
+}


### PR DESCRIPTION
## Problem

`elliptic_curve.bitcast` reinterprets a buffer as `N` points ↔ `N*K` contiguous coordinates (`tensor<N*K x F> ↔ tensor<N x Point>`, `K` = coords per point). After bufferization it becomes a **count-changing memref bitcast**, but the LLVM lowering (`ConvertBitcast`) forwarded the input descriptor through a bare `unrealized_conversion_cast`:

```cpp
rewriter.replaceOpWithNewOp<UnrealizedConversionCastOp>(op, convertedOutputType, adaptor.getInput());
```

Equal-rank memref descriptors share one LLVM struct type, so the cast is a structural no-op: an `affine[4] → field[8]` reinterpret kept the input's `sizes=[4]` and input-element strides. A later dealloc/copy then computed the wrong byte count and corrupted the heap.

This surfaced downstream in fractalyze/zkx#773 (affine EC point ↔ base-field `bitcast_convert`, for Fiat-Shamir-over-points provers): an `affine[N] ↔ field[N*2]` round-trip crashed at runtime with `munmap_chunk(): invalid pointer`.

The sibling `field::ConvertBitcast` already hit and fixed this exact bug — its `convertMemRefBitcast` comment explicitly warns against the `unrealized_conversion_cast` approach this lowering still used.

## Fix

Port `field::ConvertBitcast::convertMemRefBitcast` into the EC lowering: for a memref bitcast, rebuild the descriptor instead of forwarding it —

- share the allocated/aligned pointers (same buffer),
- scale the offset by the coordinate-count ratio (`getNumCoords`: affine 2, jacobian 3, xyzz 4),
- reset sizes from the static output shape and strides to 1 (contiguous).

Value-level bitcasts keep the `unrealized_conversion_cast` path.

## Test

`tests/Dialect/EllipticCurve/elliptic_curve_to_llvm.mlir` gains descriptor-rebuild cases (pack `memref<8x!PF>→memref<4x!affine>`, unpack, and a 3-coord jacobian), mirroring the existing `ext_field_to_llvm.mlir` guards.

Verified end-to-end in the zkx consumer: the affine↔coordinate round-trip unit test (`cpu_kernel_emitter_g1_unittest` `GroupBitcastConvertTest`, pallas + vesta) went from `munmap_chunk(): invalid pointer` to passing with correct values, with no regression in the rest of that suite.

Authored with assistance from Claude Code.