### PR TITLE
feat(dialect/field): add opt-in Fermat prime-field inverse

### DIFF
--- a/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/EllipticCurveToField.cpp
+++ b/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/EllipticCurveToField.cpp
@@ -836,7 +836,14 @@ void EllipticCurveToField::runOnOperation() {
   ModuleOp module = getOperation();
 
   // Parse lowering mode option
-  LoweringMode mode = mlir::prime_ir::parseLoweringMode(loweringMode);
+  std::optional<LoweringMode> parsedMode =
+      mlir::prime_ir::parseLoweringMode(loweringMode);
+  if (!parsedMode) {
+    module.emitError() << "invalid lowering-mode option: '" << loweringMode
+                       << "' (expected 'inline', 'auto', or 'aot_runtime')";
+    return signalPassFailure();
+  }
+  LoweringMode mode = *parsedMode;
 
   ConversionTarget target(*context);
   target.addIllegalOp<

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/BUILD.bazel
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/BUILD.bazel
@@ -62,6 +62,7 @@ prime_ir_cc_library(
         ":PrimeFieldCodeGen",
         "//prime_ir/Dialect/Field/IR:Field",
         "//prime_ir/Utils:BuilderContext",
+        "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:TransformUtils",
     ],

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldCodeGen.cpp
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldCodeGen.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldCodeGen.h"
 
+#include "llvm/ADT/APInt.h"
 #include "prime_ir/Dialect/Field/IR/FieldTypes.h"
 #include "prime_ir/Utils/BuilderContext.h"
 
@@ -167,6 +168,21 @@ FieldCodeGen FieldCodeGen::square() const {
 
 FieldCodeGen FieldCodeGen::inverse() const {
   return applyUnaryOp(codeGen, [](const auto &v) { return v.Inverse(); });
+}
+
+FieldCodeGen FieldCodeGen::pow(const APInt &exp) const {
+  assert(!exp.isZero() && "pow() exponent must be non-zero");
+  // MSB-first square-and-multiply, seeded with the base so no multiplicative
+  // identity constant is needed. With `exp` known at build time the loop is
+  // fully unrolled into straight-line IR. Walk the bits below the MSB, high to
+  // low.
+  FieldCodeGen result = *this;
+  for (unsigned i = exp.getActiveBits() - 1; i-- > 0;) {
+    result = result.square();
+    if (exp[i])
+      result = result * (*this);
+  }
+  return result;
 }
 
 } // namespace mlir::prime_ir::field

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldCodeGen.h
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldCodeGen.h
@@ -49,6 +49,13 @@ public:
   FieldCodeGen dbl() const;
   FieldCodeGen square() const;
   FieldCodeGen inverse() const;
+  // Exponentiation by a compile-time constant via MSB-first
+  // square-and-multiply. The exponent bits are known at build time, so this
+  // emits a fully unrolled, branch-free chain of squarings and multiplications
+  // (no data-dependent control flow). `exp` must be non-zero. Used to realize
+  // the Fermat's-little-theorem inverse (x^(p-2)), which is divergence-free on
+  // GPU unlike the Bernstein-Yang safegcd loop.
+  FieldCodeGen pow(const APInt &exp) const;
 
 private:
   CodeGenType codeGen;

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
@@ -978,7 +978,14 @@ void FieldToModArith::runOnOperation() {
   ModuleOp module = getOperation();
   FieldToModArithTypeConverter typeConverter(context);
 
-  LoweringMode mode = mlir::prime_ir::parseLoweringMode(loweringMode);
+  std::optional<LoweringMode> parsedMode =
+      mlir::prime_ir::parseLoweringMode(loweringMode);
+  if (!parsedMode) {
+    module.emitError() << "invalid lowering-mode option: '" << loweringMode
+                       << "' (expected 'inline', 'auto', or 'aot_runtime')";
+    return signalPassFailure();
+  }
+  LoweringMode mode = *parsedMode;
 
   std::optional<InverseAlgorithm> inverseAlgo =
       parseInverseAlgorithm(inverseAlgorithm);

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
@@ -61,6 +61,22 @@ namespace mlir::prime_ir::field {
 
 namespace {
 
+// Algorithm for a prime-field scalar inverse. Mirrors the `loweringMode`
+// string-option-to-enum idiom (see Utils/LoweringMode.h).
+enum class InverseAlgorithm { BernsteinYang, Fermat, Auto };
+
+// Returns std::nullopt for unrecognized values so the caller can fail fast
+// instead of silently selecting a default.
+std::optional<InverseAlgorithm> parseInverseAlgorithm(StringRef algorithm) {
+  if (algorithm == "bernstein-yang")
+    return InverseAlgorithm::BernsteinYang;
+  if (algorithm == "fermat")
+    return InverseAlgorithm::Fermat;
+  if (algorithm == "auto")
+    return InverseAlgorithm::Auto;
+  return std::nullopt;
+}
+
 // ---- AOT Runtime helpers ----
 
 // Check if AOTRuntime should be used for this extension field operation.
@@ -446,17 +462,43 @@ struct ConvertInverse : ConvertFieldOpBase<InverseOp, ConvertInverse> {
   using Base = ConvertFieldOpBase<InverseOp, ConvertInverse>;
 
   ConvertInverse(const TypeConverter &converter, MLIRContext *context,
-                 AOTConfig aotConfig, bool useElementwiseInverse)
+                 AOTConfig aotConfig, bool useElementwiseInverse,
+                 InverseAlgorithm inverseAlgorithm)
       : Base(converter, context, aotConfig),
-        useElementwiseInverse(useElementwiseInverse) {}
+        useElementwiseInverse(useElementwiseInverse),
+        inverseAlgorithm(inverseAlgorithm) {}
 
   std::optional<std::string> getAOTFuncName(Type fieldType) const {
     return getFieldAOTFuncName("inverse", fieldType);
   }
   Value emitInlineCodeGen(InverseOp op, OpAdaptor adaptor) const {
     Type fieldType = getElementTypeOrSelf(op.getOutput());
-    return FieldCodeGen(fieldType, adaptor.getInput(), this->typeConverter)
-        .inverse();
+    return emitScalarInverse(fieldType, adaptor.getInput());
+  }
+
+  // Fermat's-little-theorem inverse (x^(p-2)) emits a fully unrolled,
+  // branch-free square-and-multiply chain, which is divergence-free on GPU but
+  // grows ~p_bits multiplications of p_bits/64-limb operands. It beats the
+  // Bernstein-Yang safegcd loop for small fields and loses for wide ones, so
+  // `auto` gates on modulus width. Fermat is implemented for prime fields
+  // only; extension fields always use Bernstein-Yang.
+  static constexpr unsigned kFermatMaxModulusBits = 64;
+
+  Value emitScalarInverse(Type fieldType, Value value) const {
+    FieldCodeGen cg(fieldType, value, this->typeConverter);
+    if (auto pf = dyn_cast<PrimeFieldType>(fieldType)) {
+      APInt modulus = pf.getModulus().getValue();
+      bool useFermat = inverseAlgorithm == InverseAlgorithm::Fermat ||
+                       (inverseAlgorithm == InverseAlgorithm::Auto &&
+                        modulus.getActiveBits() <= kFermatMaxModulusBits);
+      if (useFermat) {
+        // PrimeFieldType rejects power-of-2 moduli, so p >= 3 and the Fermat
+        // exponent p - 2 >= 1 — never zero, as pow() requires.
+        APInt exp = modulus - 2;
+        return cg.pow(exp);
+      }
+    }
+    return cg.inverse();
   }
 
   LogicalResult
@@ -599,7 +641,7 @@ private:
     if (rank == 0) {
       Value elem = tensor::ExtractOp::create(b, input, ValueRange{});
       ScopedBuilderContext scopedCtx(&b);
-      Value inv = FieldCodeGen(fieldType, elem, this->typeConverter).inverse();
+      Value inv = emitScalarInverse(fieldType, elem);
       Value result =
           tensor::FromElementsOp::create(b, convertedTensorType, inv);
       rewriter.replaceOp(op, result);
@@ -623,8 +665,7 @@ private:
         [&](OpBuilder &nestedBuilder, Location nestedLoc, ValueRange args) {
           ImplicitLocOpBuilder lb(nestedLoc, nestedBuilder);
           ScopedBuilderContext scopedCtx(&lb);
-          Value inv =
-              FieldCodeGen(fieldType, args[0], this->typeConverter).inverse();
+          Value inv = emitScalarInverse(fieldType, args[0]);
           linalg::YieldOp::create(lb, ValueRange{inv});
         });
     rewriter.replaceOp(op, genericOp.getResults());
@@ -632,6 +673,7 @@ private:
   }
 
   bool useElementwiseInverse;
+  InverseAlgorithm inverseAlgorithm;
 };
 
 struct ConvertNegate : ConvertFieldOpBase<NegateOp, ConvertNegate> {
@@ -938,6 +980,15 @@ void FieldToModArith::runOnOperation() {
 
   LoweringMode mode = mlir::prime_ir::parseLoweringMode(loweringMode);
 
+  std::optional<InverseAlgorithm> inverseAlgo =
+      parseInverseAlgorithm(inverseAlgorithm);
+  if (!inverseAlgo) {
+    module.emitError() << "invalid inverse-algorithm option: '"
+                       << inverseAlgorithm
+                       << "' (expected 'bernstein-yang', 'fermat', or 'auto')";
+    return signalPassFailure();
+  }
+
   ConversionTarget target(*context);
 
   // Mark field operations as dynamically legal if they contain BinaryFieldType
@@ -983,7 +1034,7 @@ void FieldToModArith::runOnOperation() {
       // clang-format on
       >(typeConverter, context, aotConfig);
   patterns.add<ConvertInverse>(typeConverter, context, aotConfig,
-                               useElementwiseInverse);
+                               useElementwiseInverse, *inverseAlgo);
 
   patterns.add<
       // clang-format off

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.td
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.td
@@ -56,6 +56,20 @@ def FieldToModArith : Pass<"field-to-mod-arith", "ModuleOp"> {
            "scalar inverse instead of Montgomery batch inverse. "
            "Preferred for GPU targets where parallel per-element inverse "
            "is faster than sequential batch inverse.">,
+    Option<"inverseAlgorithm", "inverse-algorithm", "std::string",
+           /*default=*/"\"bernstein-yang\"",
+           "Algorithm for prime-field scalar inverse:\n"
+           "  'bernstein-yang' (default) - safegcd loop (data-dependent "
+           "control flow), the device-neutral choice;\n"
+           "  'fermat'         - x^(p-2) as a fully unrolled, branch-free "
+           "square-and-multiply chain (divergence-free, but its cost grows "
+           "with field width);\n"
+           "  'auto'           - Fermat for small prime fields (modulus "
+           "<= 64 bits), Bernstein-Yang otherwise. The crossover is "
+           "GPU-specific (Fermat avoids warp divergence for small fields but "
+           "overtakes Bernstein-Yang's cost for wide ones), so a target that "
+           "benefits (e.g. the GPU backend) opts in rather than this being the "
+           "default. Extension-field inverse always uses Bernstein-Yang.">,
   ];
 }
 

--- a/prime_ir/Utils/LoweringMode.h
+++ b/prime_ir/Utils/LoweringMode.h
@@ -16,6 +16,8 @@ limitations under the License.
 #ifndef PRIME_IR_UTILS_LOWERINGMODE_H_
 #define PRIME_IR_UTILS_LOWERINGMODE_H_
 
+#include <optional>
+
 #include "llvm/ADT/StringRef.h"
 
 namespace mlir::prime_ir {
@@ -38,13 +40,16 @@ enum class LoweringMode {
 };
 
 /// Parse the lowering mode from a string.
-/// Returns LoweringMode::Inline for unrecognized values.
-inline LoweringMode parseLoweringMode(llvm::StringRef mode) {
+/// Returns std::nullopt for unrecognized values so the caller can fail fast
+/// instead of silently selecting a default.
+inline std::optional<LoweringMode> parseLoweringMode(llvm::StringRef mode) {
+  if (mode == "inline")
+    return LoweringMode::Inline;
   if (mode == "auto")
     return LoweringMode::Auto;
   if (mode == "aot_runtime")
     return LoweringMode::AOTRuntime;
-  return LoweringMode::Inline;
+  return std::nullopt;
 }
 
 /// Convert lowering mode to string for debugging/logging.

--- a/tests/Dialect/Field/fermat_inverse.mlir
+++ b/tests/Dialect/Field/fermat_inverse.mlir
@@ -1,0 +1,70 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// `inverse-algorithm` selects the prime-field scalar-inverse lowering. Fermat
+// (x^(p-2)) emits a fully unrolled, branch-free square-and-multiply chain
+// (mod_arith.mul / mod_arith.square, no mod_arith.inverse and no scf.while);
+// Bernstein-Yang emits mod_arith.inverse (a safegcd loop). `auto` picks Fermat
+// for prime fields whose modulus is <= 64 bits, Bernstein-Yang otherwise. The
+// default is bernstein-yang; `auto` is opt-in (see FieldToModArith.td).
+
+// RUN: prime-ir-opt -field-to-mod-arith="use-elementwise-inverse=true inverse-algorithm=auto" -split-input-file %s | FileCheck %s --check-prefix=AUTO
+// RUN: prime-ir-opt -field-to-mod-arith="use-elementwise-inverse=true inverse-algorithm=bernstein-yang" -split-input-file %s | FileCheck %s --check-prefix=FORCEBY
+// RUN: prime-ir-opt -field-to-mod-arith="use-elementwise-inverse=true inverse-algorithm=fermat" -split-input-file %s | FileCheck %s --check-prefix=FORCEFERMAT
+
+// Small prime field (modulus 97, 7 bits): auto -> Fermat.
+!PF = !field.pf<97:i32, true>
+
+// AUTO-LABEL: @small_field
+// AUTO: linalg.generic
+// AUTO: mod_arith.mul
+// AUTO-NOT: mod_arith.inverse
+// AUTO-NOT: scf.while
+
+// Forcing bernstein-yang overrides auto's Fermat choice.
+// FORCEBY-LABEL: @small_field
+// FORCEBY: mod_arith.inverse
+
+// Forcing fermat matches auto here (small field).
+// FORCEFERMAT-LABEL: @small_field
+// FORCEFERMAT: mod_arith.mul
+// FORCEFERMAT-NOT: mod_arith.inverse
+func.func @small_field(%arg0: tensor<4x!PF>) -> tensor<4x!PF> {
+  %inv = field.inverse %arg0 : tensor<4x!PF>
+  return %inv : tensor<4x!PF>
+}
+
+// -----
+
+// Large prime field (bn254 scalar, 254 bits): auto -> Bernstein-Yang, because
+// the unrolled Fermat chain (~p_bits wide multiplications) is more expensive
+// than safegcd for wide fields.
+!PF = !field.pf<21888242871839275222246405745257275088548364400416034343698204186575808495617:i256, true>
+
+// AUTO-LABEL: @large_field
+// AUTO: mod_arith.inverse
+
+// FORCEBY-LABEL: @large_field
+// FORCEBY: mod_arith.inverse
+
+// Forcing fermat overrides auto's width gate: even the 254-bit field lowers to
+// the unrolled square-and-multiply chain, never mod_arith.inverse.
+// FORCEFERMAT-LABEL: @large_field
+// FORCEFERMAT: mod_arith.mul
+// FORCEFERMAT-NOT: mod_arith.inverse
+func.func @large_field(%arg0: tensor<4x!PF>) -> tensor<4x!PF> {
+  %inv = field.inverse %arg0 : tensor<4x!PF>
+  return %inv : tensor<4x!PF>
+}

--- a/tests/Dialect/Field/inverse_algorithm_invalid.mlir
+++ b/tests/Dialect/Field/inverse_algorithm_invalid.mlir
@@ -1,0 +1,26 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// An unrecognized inverse-algorithm value fails the pass rather than silently
+// falling back to a default.
+// RUN: not prime-ir-opt -field-to-mod-arith="inverse-algorithm=fermt" %s 2>&1 | FileCheck %s --check-prefix=BADINV
+// BADINV: invalid inverse-algorithm option: 'fermt'
+
+!PF = !field.pf<97:i32, true>
+
+func.func @inv(%arg0: !PF) -> !PF {
+  %inv = field.inverse %arg0 : !PF
+  return %inv : !PF
+}

--- a/tests/Dialect/Field/inverse_algorithm_invalid.mlir
+++ b/tests/Dialect/Field/inverse_algorithm_invalid.mlir
@@ -18,6 +18,10 @@
 // RUN: not prime-ir-opt -field-to-mod-arith="inverse-algorithm=fermt" %s 2>&1 | FileCheck %s --check-prefix=BADINV
 // BADINV: invalid inverse-algorithm option: 'fermt'
 
+// Likewise for an unrecognized lowering-mode value.
+// RUN: not prime-ir-opt -field-to-mod-arith="lowering-mode=bogus" %s 2>&1 | FileCheck %s --check-prefix=BADMODE
+// BADMODE: invalid lowering-mode option: 'bogus'
+
 !PF = !field.pf<97:i32, true>
 
 func.func @inv(%arg0: !PF) -> !PF {


### PR DESCRIPTION
## What

Adds an `inverse-algorithm` option to `FieldToModArith` selecting how a
prime-field scalar inverse lowers:

- **`bernstein-yang`** (default) — the current behavior: `mod_arith.inverse`,
  a data-dependent safegcd `scf.while` loop. The device-neutral choice.
- **`fermat`** — `x^(p-2)` emitted as a fully unrolled, branch-free
  square-and-multiply chain (new `FieldCodeGen::pow`; a compile-time-constant
  exponent unrolls into straight-line IR, no control flow).
- **`auto`** — Fermat for prime fields with modulus ≤ 64 bits, Bernstein-Yang
  otherwise.

## Why mechanism-here, policy-in-the-backend

On the GPU elementwise inverse path the safegcd loop's data-dependent trip
count diverges across warp lanes; Fermat's unrolled chain is divergence-free
and far faster for small fields. But Fermat's cost grows with field width
(~`p_bits` multiplications of `p_bits/64`-limb operands) and overtakes safegcd
for wide fields, so the choice is field-size-dependent.

Measured on an RTX 5090 (elementwise GPU inverse, random full-width inputs):

| field (bits)    | Bernstein-Yang | Fermat   | winner       |
|-----------------|---------------:|---------:|--------------|
| koalabear (31)  | 7.6k M-inv/s   | 64.5k    | Fermat ~8.5× |
| babybear (31)   | 7.6k           | 64.3k    | Fermat ~8.5× |
| goldilocks (64) | 5.3k           | 11.4k    | Fermat ~2.1× |
| bn254_sf (254)  | 1.2k           | ~0.11k   | BY ~11×      |

At 254 bits the unrolled Fermat chain (~380 wide ops) is also impractically
slow to compile, so `auto` gates at single-limb width. This matches the
hand-written CUDA result in riscv-witness #2185 (Fermat ~4.8× for the koalabear
septic `LiftX` pure-inverse).

**Crucially, this crossover is GPU-specific** (no warp divergence on CPU), and
prime-ir is device-agnostic — `FieldToModArith` is shared by both the CPU and
GPU backends. So this PR keeps the **mechanism** here (the three algorithms +
the `auto` width heuristic) but defaults to the device-neutral
`bernstein-yang`; the **policy** of enabling `auto` lives in the consumer that
knows it targets GPU (a follow-up sets `inverse-algorithm=auto` in the zkx GPU
emitter). The CPU path is unchanged.

## Scope

- Fermat is prime-field only; extension-field inverse always uses
  Bernstein-Yang (its Fermat exponent is `p^d − 2`, out of scope).
- The option parses to an `InverseAlgorithm` enum mirroring the existing
  `loweringMode` string-option idiom; unrecognized values fall back to
  `bernstein-yang`.

## Testing

- `tests/Dialect/Field/fermat_inverse.mlir` (new): `auto` picks Fermat for a
  small field and Bernstein-Yang for a 254-bit field; `fermat` /
  `bernstein-yang` force the choice.
- Default behavior is unchanged, so existing inverse tests are untouched. Full
  Field suite passes (53/53).
- Correctness spot-checked by constant-folding (Fermat and BY both fold
  `2⁻¹ mod 97 = 49`, Montgomery and standard form) and on-GPU (`x·x⁻¹ = 1` for
  both algorithms across koalabear/babybear/goldilocks/bn254).
