### PR TITLE
perf(mod_arith): gl64-lazy Goldilocks reduction + cheaper canonicalize

### DIFF
--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -263,17 +263,30 @@ bool canAcceptLazy(Operation *user, Value val, const APInt &valUmax,
   // Goldilocks gl64: a multiply/square consumer reduces via Solinas, which is
   // correct for any product < 2¹²⁸. A [0, 2⁶⁴) operand (the squared umax is
   // < 2¹²⁸) needs no pre-reduction, so the lazy value is absorbed directly.
-  if (isGoldilocksModulus(p) && isa<MulOp, SquareOp>(user))
+  if (isGoldilocksModulus(p) && isa<SquareOp>(user))
     return true;
+  if (auto mulOp = dyn_cast<MulOp>(user)) {
+    if (isGoldilocksModulus(p)) {
+      // ConvertMul's RHS-constant shortcuts (inverse-of-two-power halving and
+      // the shift/mask degree paths) run before the Solinas branch and assume a
+      // canonical lhs in [0, p): the halve does `lhs + p` (overflows i64 for a
+      // gl64 lhs such as p) and the degree path does `lhs >> d` / `lhs & mask`
+      // (wrong once lhs >= p). Keep the producer canonical for those; the plain
+      // Solinas mul path absorbs a gl64 operand directly.
+      if (mulOp.getRhs().getDefiningOp<ConstantOp>())
+        return false;
+      return true;
+    }
+  }
 
   if (auto addOp = dyn_cast<AddOp>(user)) {
     Value other = (addOp.getLhs() == val) ? addOp.getRhs() : addOp.getLhs();
     APInt total = valUmax + getUmax(other);
     // Goldilocks full-width add carry-folds the result into [0, 2⁶⁴) instead of
     // canonicalizing (2⁶⁴ ≡ ε mod p). That single fold is exact as long as the
-    // sum cannot double-overflow, i.e. total < 2⁶⁴ + p — which holds whenever at
-    // least one operand is canonical. So a gl64 value can stay lazy through an
-    // add with a canonical partner (but not through one with another gl64).
+    // sum cannot double-overflow, i.e. total < 2⁶⁴ + p — which holds whenever
+    // at least one operand is canonical. So a gl64 value can stay lazy through
+    // an add with a canonical partner (but not through one with another gl64).
     if (isGoldilocksModulus(p))
       return total.ult(APInt::getOneBitSet(dw, w) + p);
     return total.ule(wMax);
@@ -363,8 +376,8 @@ void buildBoundMap(func::FuncOp funcOp, BoundMap &boundMap) {
         // Lazy sub computes lhs - rhs + rhsKp·p (a non-negative representative
         // without a conditional subtract). That only fits in w bits when
         // lhsUmax + rhsKp·p <= 2^w - 1. For full-width moduli (Goldilocks)
-        // lhs + p already overflows i64, so the result cannot stay lazy — record
-        // the canonical bound and let ConvertSub emit getCanonicalDiff.
+        // lhs + p already overflows i64, so the result cannot stay lazy —
+        // record the canonical bound and let ConvertSub emit getCanonicalDiff.
         uint64_t rhsKp = kpFromUmax(getOpUmax(subOp.getRhs()), p);
         APInt lazyUmax = getOpUmax(subOp.getLhs()) + p * APInt(dw, rhsKp);
         umax = lazyUmax.ule(APInt::getMaxValue(w).zext(dw)) ? lazyUmax
@@ -399,48 +412,53 @@ void buildBoundMap(func::FuncOp funcOp, BoundMap &boundMap) {
   // When two lazy values block each other (a value and its add partner are both
   // gl64, so neither add can absorb the other), canonicalizing ONE unblocks the
   // rest. The Goldilocks diffusion is the motivating case: one column-sum is
-  // shared by 16 adds, each pairing it with a distinct gl64 product. Erasing the
-  // single high-fanout sum (1 reduction) lets all 16 low-fanout products stay
-  // lazy; erasing the products instead would cost 16. So visit candidates by
-  // descending fanout and erase immediately: a widely-shared value is reduced
-  // first, and its now-canonical value lets its many partners pass their check.
+  // shared by 16 adds, each pairing it with a distinct gl64 product. Erasing
+  // the single high-fanout sum (1 reduction) lets all 16 low-fanout products
+  // stay lazy; erasing the products instead would cost 16. So visit candidates
+  // by descending fanout and erase immediately: a widely-shared value is
+  // reduced first, and its now-canonical value lets its many partners pass
+  // their check. Collect candidates in IR walk order — not DenseMap iteration
+  // order, which is nondeterministic — so equal-fanout ties in the stable_sort
+  // below break the same way across runs and builds (otherwise equal-fanout
+  // lazy cycles could lower differently).
   SmallVector<Value> candidates;
-  for (auto &[val, umax] : boundMap)
-    if (val.getDefiningOp())
-      candidates.push_back(val);
+  funcOp.walk([&](Operation *op) {
+    for (Value val : op->getResults())
+      if (boundMap.find(val) != boundMap.end())
+        candidates.push_back(val);
+  });
   llvm::stable_sort(candidates, [](Value a, Value b) {
     return std::distance(a.user_begin(), a.user_end()) >
            std::distance(b.user_begin(), b.user_end());
   });
 
-  bool changed = true;
-  while (changed) {
-    changed = false;
-    for (Value val : candidates) {
-      auto it = boundMap.find(val);
-      if (it == boundMap.end())
-        continue; // already forced canonical
-      auto modType =
-          dyn_cast<ModArithType>(getElementTypeOrSelf(val.getType()));
-      if (!modType)
-        continue;
-      unsigned w = modType.getTypeSizeInBits();
-      unsigned dw = 2 * w;
-      APInt p = modType.getModulus().getValue().zext(dw);
-      if (kpFromUmax(it->second, p) <= 1)
-        continue;
-      bool allBenefit = true;
-      for (Operation *user : val.getUsers()) {
-        if (!canAcceptLazy(user, val, it->second, boundMap, p, w)) {
-          allBenefit = false;
-          break;
-        }
-      }
-      if (!allBenefit) {
-        boundMap.erase(val);
-        changed = true;
+  // A single descending-fanout pass suffices. Erasing a value only lowers its
+  // reported bound to p-1, which can only relax a partner's canAcceptLazy check
+  // (false -> true), never tighten it (canAcceptLazy is monotone in the operand
+  // bounds across every consumer kind). So a candidate that passes on this pass
+  // stays passing after later erasures, and one that fails is erased here — a
+  // second pass could never erase anything more.
+  for (Value val : candidates) {
+    auto it = boundMap.find(val);
+    if (it == boundMap.end())
+      continue; // already forced canonical
+    auto modType = dyn_cast<ModArithType>(getElementTypeOrSelf(val.getType()));
+    if (!modType)
+      continue;
+    unsigned w = modType.getTypeSizeInBits();
+    unsigned dw = 2 * w;
+    APInt p = modType.getModulus().getValue().zext(dw);
+    if (kpFromUmax(it->second, p) <= 1)
+      continue;
+    bool allBenefit = true;
+    for (Operation *user : val.getUsers()) {
+      if (!canAcceptLazy(user, val, it->second, boundMap, p, w)) {
+        allBenefit = false;
+        break;
       }
     }
+    if (!allBenefit)
+      boundMap.erase(val);
   }
 }
 
@@ -769,8 +787,8 @@ struct ConvertAdd : public BoundMapPattern<AddOp> {
     APInt sumMax = lhsUmax + rhsUmax;
 
     // Goldilocks full-width add can carry-fold its result into [0, 2⁶⁴)
-    // (gl64-lazy) when a consumer accepts a non-canonical operand (resBound > 1),
-    // skipping the canonicalizing subtract. 2⁶⁴ ≡ ε (mod p), so a single
+    // (gl64-lazy) when a consumer accepts a non-canonical operand (resBound >
+    // 1), skipping the canonicalizing subtract. 2⁶⁴ ≡ ε (mod p), so a single
     // conditional +ε on the carry suffices — but only if the operands cannot
     // double-overflow (total < 2⁶⁴ + p), i.e. at most one is gl64.
     bool wantLazyGl64 =
@@ -812,14 +830,14 @@ struct ConvertAdd : public BoundMapPattern<AddOp> {
     if (modWidth == storageWidth) {
       auto add = arith::AddUIExtendedOp::create(b, lhs, rhs);
       if (wantLazyGl64) {
-        // gl64-lazy: fold the carry as +ε (2⁶⁴ ≡ ε mod p), leaving the result in
-        // [0, 2⁶⁴). No compare-vs-p — a multiply or canonical-add consumer
+        // gl64-lazy: fold the carry as +ε (2⁶⁴ ≡ ε mod p), leaving the result
+        // in [0, 2⁶⁴). No compare-vs-p — a multiply or canonical-add consumer
         // absorbs it. Pre-reduction above guarantees at most one gl64 operand,
         // so the +ε never double-overflows.
         APInt epsilon = APInt::getOneBitSet(storageWidth, storageWidth / 2) -
                         APInt(storageWidth, 1); // 2³² - 1
-        Value eps = createScalarOrSplatConstant(b, b.getLoc(), lhs.getType(),
-                                                epsilon);
+        Value eps =
+            createScalarOrSplatConstant(b, b.getLoc(), lhs.getType(), epsilon);
         Value zero =
             createScalarOrSplatConstant(b, b.getLoc(), lhs.getType(), 0);
         Value corr = arith::SelectOp::create(b, add.getOverflow(), eps, zero);

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -268,7 +268,15 @@ bool canAcceptLazy(Operation *user, Value val, const APInt &valUmax,
 
   if (auto addOp = dyn_cast<AddOp>(user)) {
     Value other = (addOp.getLhs() == val) ? addOp.getRhs() : addOp.getLhs();
-    return (valUmax + getUmax(other)).ule(wMax);
+    APInt total = valUmax + getUmax(other);
+    // Goldilocks full-width add carry-folds the result into [0, 2⁶⁴) instead of
+    // canonicalizing (2⁶⁴ ≡ ε mod p). That single fold is exact as long as the
+    // sum cannot double-overflow, i.e. total < 2⁶⁴ + p — which holds whenever at
+    // least one operand is canonical. So a gl64 value can stay lazy through an
+    // add with a canonical partner (but not through one with another gl64).
+    if (isGoldilocksModulus(p))
+      return total.ult(APInt::getOneBitSet(dw, w) + p);
+    return total.ule(wMax);
   }
   if (auto subOp = dyn_cast<SubOp>(user)) {
     if (subOp.getLhs() == val) {
@@ -345,10 +353,22 @@ void buildBoundMap(func::FuncOp funcOp, BoundMap &boundMap) {
 
       APInt umax = defaultUmax;
       if (auto addOp = dyn_cast<AddOp>(op)) {
-        umax = getOpUmax(addOp.getLhs()) + getOpUmax(addOp.getRhs());
+        // Goldilocks full-width add carry-folds into [0, 2⁶⁴) (gl64-lazy), like
+        // the mul case; non-Goldilocks adds keep the raw lhs+rhs bound.
+        if (isGoldilocksModulus(p))
+          umax = APInt::getMaxValue(w).zext(dw);
+        else
+          umax = getOpUmax(addOp.getLhs()) + getOpUmax(addOp.getRhs());
       } else if (auto subOp = dyn_cast<SubOp>(op)) {
+        // Lazy sub computes lhs - rhs + rhsKp·p (a non-negative representative
+        // without a conditional subtract). That only fits in w bits when
+        // lhsUmax + rhsKp·p <= 2^w - 1. For full-width moduli (Goldilocks)
+        // lhs + p already overflows i64, so the result cannot stay lazy — record
+        // the canonical bound and let ConvertSub emit getCanonicalDiff.
         uint64_t rhsKp = kpFromUmax(getOpUmax(subOp.getRhs()), p);
-        umax = getOpUmax(subOp.getLhs()) + p * APInt(dw, rhsKp);
+        APInt lazyUmax = getOpUmax(subOp.getLhs()) + p * APInt(dw, rhsKp);
+        umax = lazyUmax.ule(APInt::getMaxValue(w).zext(dw)) ? lazyUmax
+                                                            : defaultUmax;
       } else if (isa<DoubleOp>(op)) {
         auto doubleOp = cast<DoubleOp>(op);
         umax = getOpUmax(doubleOp.getInput()) * APInt(dw, 2);
@@ -375,31 +395,53 @@ void buildBoundMap(func::FuncOp funcOp, BoundMap &boundMap) {
   // field.ext_from_coeffs, func.return, mod_arith.inverse), the value must be
   // reduced — a lazy value would propagate unreduced through ext_from_coeffs →
   // ext_to_coeffs round-trips where the bound information is lost.
-  SmallVector<Value> toErase;
-  for (auto &[val, umax] : boundMap) {
-    Operation *defOp = val.getDefiningOp();
-    if (!defOp)
-      continue;
-    auto modType = dyn_cast<ModArithType>(getElementTypeOrSelf(val.getType()));
-    if (!modType)
-      continue;
-    unsigned w = modType.getTypeSizeInBits();
-    unsigned dw = 2 * w;
-    APInt p = modType.getModulus().getValue().zext(dw);
-    if (kpFromUmax(umax, p) <= 1)
-      continue;
-    bool allBenefit = true;
-    for (Operation *user : val.getUsers()) {
-      if (!canAcceptLazy(user, val, umax, boundMap, p, w)) {
-        allBenefit = false;
-        break;
+  //
+  // When two lazy values block each other (a value and its add partner are both
+  // gl64, so neither add can absorb the other), canonicalizing ONE unblocks the
+  // rest. The Goldilocks diffusion is the motivating case: one column-sum is
+  // shared by 16 adds, each pairing it with a distinct gl64 product. Erasing the
+  // single high-fanout sum (1 reduction) lets all 16 low-fanout products stay
+  // lazy; erasing the products instead would cost 16. So visit candidates by
+  // descending fanout and erase immediately: a widely-shared value is reduced
+  // first, and its now-canonical value lets its many partners pass their check.
+  SmallVector<Value> candidates;
+  for (auto &[val, umax] : boundMap)
+    if (val.getDefiningOp())
+      candidates.push_back(val);
+  llvm::stable_sort(candidates, [](Value a, Value b) {
+    return std::distance(a.user_begin(), a.user_end()) >
+           std::distance(b.user_begin(), b.user_end());
+  });
+
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    for (Value val : candidates) {
+      auto it = boundMap.find(val);
+      if (it == boundMap.end())
+        continue; // already forced canonical
+      auto modType =
+          dyn_cast<ModArithType>(getElementTypeOrSelf(val.getType()));
+      if (!modType)
+        continue;
+      unsigned w = modType.getTypeSizeInBits();
+      unsigned dw = 2 * w;
+      APInt p = modType.getModulus().getValue().zext(dw);
+      if (kpFromUmax(it->second, p) <= 1)
+        continue;
+      bool allBenefit = true;
+      for (Operation *user : val.getUsers()) {
+        if (!canAcceptLazy(user, val, it->second, boundMap, p, w)) {
+          allBenefit = false;
+          break;
+        }
+      }
+      if (!allBenefit) {
+        boundMap.erase(val);
+        changed = true;
       }
     }
-    if (!allBenefit)
-      toErase.push_back(val);
   }
-  for (Value v : toErase)
-    boundMap.erase(v);
 }
 
 } // namespace
@@ -725,7 +767,29 @@ struct ConvertAdd : public BoundMapPattern<AddOp> {
     APInt wMax = APInt::getMaxValue(storageWidth).zext(dw);
     APInt p = modArithType.getModulus().getValue().zext(dw);
     APInt sumMax = lhsUmax + rhsUmax;
-    if (sumMax.ugt(wMax)) {
+
+    // Goldilocks full-width add can carry-fold its result into [0, 2⁶⁴)
+    // (gl64-lazy) when a consumer accepts a non-canonical operand (resBound > 1),
+    // skipping the canonicalizing subtract. 2⁶⁴ ≡ ε (mod p), so a single
+    // conditional +ε on the carry suffices — but only if the operands cannot
+    // double-overflow (total < 2⁶⁴ + p), i.e. at most one is gl64.
+    bool wantLazyGl64 =
+        modWidth == storageWidth && resBound > 1 && isGoldilocksModulus(p);
+
+    if (wantLazyGl64) {
+      // Pre-reduce ONLY to prevent double-overflow: if both operands are
+      // non-canonical, reduce one so the sum stays < 2⁶⁴ + p.
+      APInt dblOverflow = APInt::getOneBitSet(dw, storageWidth) + p; // 2⁶⁴ + p
+      if (sumMax.uge(dblOverflow)) {
+        uint64_t lhsKp = kpFromUmax(lhsUmax, p);
+        uint64_t rhsKp = kpFromUmax(rhsUmax, p);
+        if (rhsKp > 1)
+          rhs = montReducer.getCanonicalFromExtended(rhs, rhsKp);
+        else if (lhsKp > 1)
+          lhs = montReducer.getCanonicalFromExtended(lhs, lhsKp);
+      }
+    } else if (sumMax.ugt(wMax)) {
+      // Canonical path: pre-reduce lazy inputs whose umax sum overflows w bits.
       // Try reducing only one operand when that alone avoids overflow.
       uint64_t lhsKp = kpFromUmax(lhsUmax, p);
       uint64_t rhsKp = kpFromUmax(rhsUmax, p);
@@ -747,11 +811,25 @@ struct ConvertAdd : public BoundMapPattern<AddOp> {
     Value result;
     if (modWidth == storageWidth) {
       auto add = arith::AddUIExtendedOp::create(b, lhs, rhs);
-      // In the full-width case (modWidth == storageWidth), A + B can exceed the
-      // storage type range, producing an overflow bit, so lazy reduction is not
-      // possible.
-      result =
-          montReducer.getCanonicalFromExtended(add.getSum(), add.getOverflow());
+      if (wantLazyGl64) {
+        // gl64-lazy: fold the carry as +ε (2⁶⁴ ≡ ε mod p), leaving the result in
+        // [0, 2⁶⁴). No compare-vs-p — a multiply or canonical-add consumer
+        // absorbs it. Pre-reduction above guarantees at most one gl64 operand,
+        // so the +ε never double-overflows.
+        APInt epsilon = APInt::getOneBitSet(storageWidth, storageWidth / 2) -
+                        APInt(storageWidth, 1); // 2³² - 1
+        Value eps = createScalarOrSplatConstant(b, b.getLoc(), lhs.getType(),
+                                                epsilon);
+        Value zero =
+            createScalarOrSplatConstant(b, b.getLoc(), lhs.getType(), 0);
+        Value corr = arith::SelectOp::create(b, add.getOverflow(), eps, zero);
+        result = arith::AddIOp::create(b, add.getSum(), corr);
+      } else {
+        // Full-width canonical: A + B can exceed the storage range, so fold the
+        // overflow bit into a canonical [0, p) result.
+        result = montReducer.getCanonicalFromExtended(add.getSum(),
+                                                      add.getOverflow());
+      }
     } else {
       // nuw (no unsigned wrap) is safe when storageWidth - modWidth >= 1.
       // nsw (no signed wrap) is only safe when storageWidth - modWidth >= 2,
@@ -862,6 +940,9 @@ struct ConvertSub : public BoundMapPattern<SubOp> {
     unsigned dw = 2 * w;
     APInt wMax = APInt::getMaxValue(w).zext(dw);
     APInt p = modType.getModulus().getValue().zext(dw);
+    // For a full-width modulus (e.g. Goldilocks) the lazy sub's lhs + rhsKp·p
+    // already overflows w bits, so it cannot stay lazy — always canonicalize.
+    bool fullWidth = modType.getModulus().getValue().getActiveBits() == w;
     uint64_t lhsKp = kpFromUmax(lhsUmax, p);
     uint64_t rhsKp = kpFromUmax(rhsUmax, p);
     APInt resultMax = lhsUmax + p * APInt(dw, rhsKp);
@@ -884,7 +965,7 @@ struct ConvertSub : public BoundMapPattern<SubOp> {
       }
     }
 
-    if (resBound > 1) {
+    if (resBound > 1 && !fullWidth) {
       // Lazy sub: (lhs - rhs + correction) without final conditional sub.
       // correction = rhsKp * p ensures lhs + correction - rhs >= 0.
       APInt modulus = modType.getModulus().getValue();

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -420,16 +420,17 @@ void buildBoundMap(func::FuncOp funcOp, BoundMap &boundMap) {
   // their check. Collect candidates in IR walk order — not DenseMap iteration
   // order, which is nondeterministic — so equal-fanout ties in the stable_sort
   // below break the same way across runs and builds (otherwise equal-fanout
-  // lazy cycles could lower differently).
-  SmallVector<Value> candidates;
+  // lazy cycles could lower differently). Cache each fanout once — the use-list
+  // walk (std::distance) is O(fanout), so precomputing keeps the comparator O(1).
+  SmallVector<std::pair<Value, size_t>> candidates;
   funcOp.walk([&](Operation *op) {
     for (Value val : op->getResults())
       if (boundMap.find(val) != boundMap.end())
-        candidates.push_back(val);
+        candidates.emplace_back(
+            val, std::distance(val.user_begin(), val.user_end()));
   });
-  llvm::stable_sort(candidates, [](Value a, Value b) {
-    return std::distance(a.user_begin(), a.user_end()) >
-           std::distance(b.user_begin(), b.user_end());
+  llvm::stable_sort(candidates, [](const auto &a, const auto &b) {
+    return a.second > b.second;
   });
 
   // A single descending-fanout pass suffices. Erasing a value only lowers its
@@ -438,7 +439,7 @@ void buildBoundMap(func::FuncOp funcOp, BoundMap &boundMap) {
   // bounds across every consumer kind). So a candidate that passes on this pass
   // stays passing after later erasures, and one that fails is erased here — a
   // second pass could never erase anything more.
-  for (Value val : candidates) {
+  for (auto &[val, fanout] : candidates) {
     auto it = boundMap.find(val);
     if (it == boundMap.end())
       continue; // already forced canonical

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -267,12 +267,10 @@ bool canAcceptLazy(Operation *user, Value val, const APInt &valUmax,
     return true;
   if (auto mulOp = dyn_cast<MulOp>(user)) {
     if (isGoldilocksModulus(p)) {
-      // ConvertMul's RHS-constant shortcuts (inverse-of-two-power halving and
-      // the shift/mask degree paths) run before the Solinas branch and assume a
-      // canonical lhs in [0, p): the halve does `lhs + p` (overflows i64 for a
-      // gl64 lhs such as p) and the degree path does `lhs >> d` / `lhs & mask`
-      // (wrong once lhs >= p). Keep the producer canonical for those; the plain
-      // Solinas mul path absorbs a gl64 operand directly.
+      // ConvertMul's RHS-constant shortcuts (halving, shift/mask degree paths)
+      // run before Solinas and assume a canonical lhs in [0, p), so a gl64 lhs
+      // breaks them. Keep the producer canonical for those; the plain Solinas
+      // mul path absorbs a gl64 operand directly.
       if (mulOp.getRhs().getDefiningOp<ConstantOp>())
         return false;
       return true;
@@ -282,11 +280,10 @@ bool canAcceptLazy(Operation *user, Value val, const APInt &valUmax,
   if (auto addOp = dyn_cast<AddOp>(user)) {
     Value other = (addOp.getLhs() == val) ? addOp.getRhs() : addOp.getLhs();
     APInt total = valUmax + getUmax(other);
-    // Goldilocks full-width add carry-folds the result into [0, 2⁶⁴) instead of
-    // canonicalizing (2⁶⁴ ≡ ε mod p). That single fold is exact as long as the
-    // sum cannot double-overflow, i.e. total < 2⁶⁴ + p — which holds whenever
-    // at least one operand is canonical. So a gl64 value can stay lazy through
-    // an add with a canonical partner (but not through one with another gl64).
+    // Goldilocks add carry-folds into [0, 2⁶⁴) (2⁶⁴ ≡ ε mod p) instead of
+    // canonicalizing. That fold is exact only if the sum can't double-overflow
+    // (total < 2⁶⁴ + p), i.e. at most one operand is gl64 — so a gl64 value
+    // stays lazy through an add with a canonical partner, but not another gl64.
     if (isGoldilocksModulus(p))
       return total.ult(APInt::getOneBitSet(dw, w) + p);
     return total.ule(wMax);
@@ -373,11 +370,10 @@ void buildBoundMap(func::FuncOp funcOp, BoundMap &boundMap) {
         else
           umax = getOpUmax(addOp.getLhs()) + getOpUmax(addOp.getRhs());
       } else if (auto subOp = dyn_cast<SubOp>(op)) {
-        // Lazy sub computes lhs - rhs + rhsKp·p (a non-negative representative
-        // without a conditional subtract). That only fits in w bits when
-        // lhsUmax + rhsKp·p <= 2^w - 1. For full-width moduli (Goldilocks)
-        // lhs + p already overflows i64, so the result cannot stay lazy —
-        // record the canonical bound and let ConvertSub emit getCanonicalDiff.
+        // Lazy sub computes lhs - rhs + rhsKp·p, which fits in w bits only when
+        // lhsUmax + rhsKp·p <= 2^w - 1. For Goldilocks lhs + p already
+        // overflows i64, so it can't stay lazy — record the canonical bound
+        // and let ConvertSub emit getCanonicalDiff.
         uint64_t rhsKp = kpFromUmax(getOpUmax(subOp.getRhs()), p);
         APInt lazyUmax = getOpUmax(subOp.getLhs()) + p * APInt(dw, rhsKp);
         umax = lazyUmax.ule(APInt::getMaxValue(w).zext(dw)) ? lazyUmax
@@ -409,19 +405,15 @@ void buildBoundMap(func::FuncOp funcOp, BoundMap &boundMap) {
   // reduced — a lazy value would propagate unreduced through ext_from_coeffs →
   // ext_to_coeffs round-trips where the bound information is lost.
   //
-  // When two lazy values block each other (a value and its add partner are both
-  // gl64, so neither add can absorb the other), canonicalizing ONE unblocks the
-  // rest. The Goldilocks diffusion is the motivating case: one column-sum is
-  // shared by 16 adds, each pairing it with a distinct gl64 product. Erasing
-  // the single high-fanout sum (1 reduction) lets all 16 low-fanout products
-  // stay lazy; erasing the products instead would cost 16. So visit candidates
-  // by descending fanout and erase immediately: a widely-shared value is
-  // reduced first, and its now-canonical value lets its many partners pass
-  // their check. Collect candidates in IR walk order — not DenseMap iteration
-  // order, which is nondeterministic — so equal-fanout ties in the stable_sort
-  // below break the same way across runs and builds (otherwise equal-fanout
-  // lazy cycles could lower differently). Cache each fanout once — the use-list
-  // walk (std::distance) is O(fanout), so precomputing keeps the comparator O(1).
+  // When two lazy gl64 values block each other (add partners, neither add can
+  // absorb the other), canonicalizing ONE unblocks the rest. Motivating case:
+  // Goldilocks diffusion shares one column-sum across 16 adds — erasing that
+  // high-fanout sum (1 reduction) keeps all 16 low-fanout products lazy, vs 16
+  // if we erased the products. So visit high-fanout-first and erase in place:
+  // the shared value reduces first, letting its partners pass. Collect in IR
+  // walk order (DenseMap order is nondeterministic) so equal-fanout ties in the
+  // stable_sort break identically across builds. Cache each fanout once — the
+  // use-list walk (std::distance) is O(fanout), so keeps the comparator O(1).
   SmallVector<std::pair<Value, size_t>> candidates;
   funcOp.walk([&](Operation *op) {
     for (Value val : op->getResults())
@@ -433,12 +425,10 @@ void buildBoundMap(func::FuncOp funcOp, BoundMap &boundMap) {
     return a.second > b.second;
   });
 
-  // A single descending-fanout pass suffices. Erasing a value only lowers its
-  // reported bound to p-1, which can only relax a partner's canAcceptLazy check
-  // (false -> true), never tighten it (canAcceptLazy is monotone in the operand
-  // bounds across every consumer kind). So a candidate that passes on this pass
-  // stays passing after later erasures, and one that fails is erased here — a
-  // second pass could never erase anything more.
+  // One pass suffices: erasing a value only drops its bound to p-1, which can
+  // only relax a partner's canAcceptLazy check, never tighten it (the check is
+  // monotone in operand bounds). So a passing candidate keeps passing after
+  // later erasures — a second pass could erase nothing more.
   for (auto &[val, fanout] : candidates) {
     auto it = boundMap.find(val);
     if (it == boundMap.end())
@@ -787,11 +777,10 @@ struct ConvertAdd : public BoundMapPattern<AddOp> {
     APInt p = modArithType.getModulus().getValue().zext(dw);
     APInt sumMax = lhsUmax + rhsUmax;
 
-    // Goldilocks full-width add can carry-fold its result into [0, 2⁶⁴)
-    // (gl64-lazy) when a consumer accepts a non-canonical operand (resBound >
-    // 1), skipping the canonicalizing subtract. 2⁶⁴ ≡ ε (mod p), so a single
-    // conditional +ε on the carry suffices — but only if the operands cannot
-    // double-overflow (total < 2⁶⁴ + p), i.e. at most one is gl64.
+    // Goldilocks add can carry-fold into [0, 2⁶⁴) (gl64-lazy) when the consumer
+    // accepts a non-canonical operand (resBound > 1): 2⁶⁴ ≡ ε mod p, so one
+    // conditional +ε on the carry replaces the canonicalizing subtract — valid
+    // only when operands can't double-overflow (total < 2⁶⁴ + p, ≤1 gl64).
     bool wantLazyGl64 =
         modWidth == storageWidth && resBound > 1 && isGoldilocksModulus(p);
 
@@ -832,9 +821,8 @@ struct ConvertAdd : public BoundMapPattern<AddOp> {
       auto add = arith::AddUIExtendedOp::create(b, lhs, rhs);
       if (wantLazyGl64) {
         // gl64-lazy: fold the carry as +ε (2⁶⁴ ≡ ε mod p), leaving the result
-        // in [0, 2⁶⁴). No compare-vs-p — a multiply or canonical-add consumer
-        // absorbs it. Pre-reduction above guarantees at most one gl64 operand,
-        // so the +ε never double-overflows.
+        // in [0, 2⁶⁴) with no compare-vs-p. Pre-reduction above bounds this to
+        // one gl64 operand, so the +ε never double-overflows.
         APInt epsilon = APInt::getOneBitSet(storageWidth, storageWidth / 2) -
                         APInt(storageWidth, 1); // 2³² - 1
         Value eps =

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -103,6 +103,16 @@ namespace {
 // kp = ceil((umax + 1) / p) is derived on-the-fly when needed.
 using BoundMap = DenseMap<Value, APInt>;
 
+// True for the Goldilocks prime p = 2⁶⁴ - 2³² + 1. Its Solinas reduce is
+// correct for any product < 2¹²⁸ and yields a result in [0, 2⁶⁴) (kp = 2,
+// since p < 2⁶⁴ < 2p) before the canonicalizing subtract — so a Goldilocks
+// value can stay "gl64-lazy" in [0, 2⁶⁴) and a multiply/square consumer
+// absorbs it directly.
+bool isGoldilocksModulus(const APInt &modulus) {
+  return modulus.getActiveBits() <= 64 &&
+         modulus.getZExtValue() == zk_dtypes::Goldilocks::Config::kModulus;
+}
+
 // Derive kp from umax: kp = ceil((umax + 1) / p).
 uint64_t kpFromUmax(const APInt &umax, const APInt &p) {
   APInt umaxP1 = umax + 1;
@@ -250,6 +260,12 @@ bool canAcceptLazy(Operation *user, Value val, const APInt &valUmax,
     return it != boundMap.end() ? it->second : p - 1;
   };
 
+  // Goldilocks gl64: a multiply/square consumer reduces via Solinas, which is
+  // correct for any product < 2¹²⁸. A [0, 2⁶⁴) operand (the squared umax is
+  // < 2¹²⁸) needs no pre-reduction, so the lazy value is absorbed directly.
+  if (isGoldilocksModulus(p) && isa<MulOp, SquareOp>(user))
+    return true;
+
   if (auto addOp = dyn_cast<AddOp>(user)) {
     Value other = (addOp.getLhs() == val) ? addOp.getRhs() : addOp.getLhs();
     return (valUmax + getUmax(other)).ule(wMax);
@@ -338,6 +354,10 @@ void buildBoundMap(func::FuncOp funcOp, BoundMap &boundMap) {
         umax = getOpUmax(doubleOp.getInput()) * APInt(dw, 2);
       } else if (isa<MontMulOp, MontSquareOp, MontReduceOp>(op)) {
         umax = p * APInt(dw, 2) - 1;
+      } else if (isa<MulOp, SquareOp>(op) && isGoldilocksModulus(p)) {
+        // gl64-lazy: the Solinas reduce yields a value in [0, 2⁶⁴) before its
+        // canonicalizing subtract; skipping that leaves the result here.
+        umax = APInt::getMaxValue(w).zext(dw);
       } else if (isa<ConstantOp>(op)) {
         auto *lattice =
             solver.lookupState<dataflow::IntegerValueRangeLattice>(result);
@@ -888,11 +908,8 @@ struct ConvertSub : public BoundMapPattern<SubOp> {
   }
 };
 
-struct ConvertMul : public OpConversionPattern<MulOp> {
-  explicit ConvertMul(MLIRContext *context)
-      : OpConversionPattern<MulOp>(context) {}
-
-  using OpConversionPattern::OpConversionPattern;
+struct ConvertMul : public BoundMapPattern<MulOp> {
+  using BoundMapPattern::BoundMapPattern;
 
   LogicalResult
   matchAndRewrite(MulOp op, OpAdaptor adaptor,
@@ -1051,8 +1068,12 @@ struct ConvertMul : public OpConversionPattern<MulOp> {
     if (isGoldilocks) {
       auto prod =
           arith::MulUIExtendedOp::create(b, adaptor.getLhs(), adaptor.getRhs());
-      rewriter.replaceOp(
-          op, SolinasReducer(b, modType).reduce(prod.getLow(), prod.getHigh()));
+      // gl64-lazy: when every consumer accepts a [0, 2⁶⁴) operand, skip the
+      // canonicalizing subtract (kp of the result is >= 2).
+      uint64_t resBound = lookupKp(op.getResult());
+      rewriter.replaceOp(op, SolinasReducer(b, modType)
+                                 .reduce(prod.getLow(), prod.getHigh(),
+                                         /*lazy=*/resBound >= 2));
       return success();
     }
 
@@ -1351,11 +1372,8 @@ MulExtendedResult squareExtended(ImplicitLocOpBuilder &b, Op op, Value input) {
 
 } // namespace
 
-struct ConvertSquare : public OpConversionPattern<SquareOp> {
-  explicit ConvertSquare(MLIRContext *context)
-      : OpConversionPattern<SquareOp>(context) {}
-
-  using OpConversionPattern::OpConversionPattern;
+struct ConvertSquare : public BoundMapPattern<SquareOp> {
+  using BoundMapPattern::BoundMapPattern;
 
   LogicalResult
   matchAndRewrite(SquareOp op, OpAdaptor adaptor,
@@ -1380,8 +1398,10 @@ struct ConvertSquare : public OpConversionPattern<SquareOp> {
         modulus.getBitWidth() == 64 &&
         modulus == APInt(64, zk_dtypes::Goldilocks::Config::kModulus);
     if (isGoldilocks) {
+      uint64_t resBound = lookupKp(op.getResult());
       rewriter.replaceOp(
-          op, SolinasReducer(b, modType).reduce(result.lo, result.hi));
+          op, SolinasReducer(b, modType)
+                  .reduce(result.lo, result.hi, /*lazy=*/resBound >= 2));
       return success();
     }
 
@@ -1563,7 +1583,9 @@ void ModArithToArith::runOnOperation() {
       ConvertMontMul,
       ConvertMontReduce,
       ConvertMontSquare,
+      ConvertMul,
       ConvertNegate,
+      ConvertSquare,
       ConvertSub
       // clang-format on
       >(typeConverter, context, bm);
@@ -1574,8 +1596,6 @@ void ModArithToArith::runOnOperation() {
       ConvertBitcast,
       ConvertConstant,
       ConvertFromMont,
-      ConvertMul,
-      ConvertSquare,
       ConvertToMont
       // clang-format on
       >(typeConverter, context);

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/MontReducer.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/MontReducer.cpp
@@ -96,18 +96,12 @@ Value MontReducer::getCanonicalFromExtended(Value input, uint64_t bound) {
 
 Value MontReducer::getCanonicalFromExtended(Value input, Value overflow) {
   auto cmod = createModulusConst(input.getType(), input);
-  // Canonicalize the value `overflow·2^w + input` (input ∈ [0, 2p), so one
-  // subtract of p suffices) in 3 ALU ops instead of 4.
-  //
-  // `min(input - p, input)` folds the `input ≥ p` case without a compare: when
-  // input < p, `input - p` wraps to `input + (2^w - p) > input` (and < 2^w, no
-  // double wrap), so min keeps input; when input ≥ p, `input - p < input`, so
-  // min picks it. A carry into bit w (overflow) always means subtract p, so the
-  // select forces that branch. Byte-identical to the prior
-  // `(input >= p || overflow) ? input - p : input` for every input and any
-  // modulus: overflow ⟹ both yield `input - p`; otherwise min reproduces the
-  // compare. Drops the `cmpi` + `ori` for a single `minui`. The subtract form
-  // is what makes min safe here — getCanonicalDiff adds p and so cannot.
+  // Canonicalize `overflow·2^w + input` (input ∈ [0, 2p)) in 3 ALU ops, not 4.
+  // `min(input - p, input)` picks input when input < p (the subtract wraps up)
+  // and input - p when input ≥ p — folding the compare into a minui; overflow
+  // forces the subtract branch. Byte-identical to the old
+  // `(input >= p || overflow) ? input - p : input`, minus the cmpi+ori. Uses
+  // subtract-of-p, not getCanonicalDiff's add-of-p, so min stays safe.
   auto sub = arith::SubIOp::create(b, input, cmod);
   auto min = arith::MinUIOp::create(b, sub, input);
   auto select = arith::SelectOp::create(b, overflow, sub, min);

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/MontReducer.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/MontReducer.cpp
@@ -96,15 +96,21 @@ Value MontReducer::getCanonicalFromExtended(Value input, uint64_t bound) {
 
 Value MontReducer::getCanonicalFromExtended(Value input, Value overflow) {
   auto cmod = createModulusConst(input.getType(), input);
-  // NOTE(chokobole): 'ult' is generally preferred over 'uge' for
-  // better performance. However, using 'ult' would require inverting the
-  // overflow check logic. Currently, 'uge' is used for clearer logic, but
-  // this choice should be re-evaluated after benchmarking. See
-  // https://github.com/fractalyze/prime-ir/pull/86/commits/10d3807
-  auto ifge = arith::CmpIOp::create(b, arith::CmpIPredicate::uge, input, cmod);
-  auto or_ = arith::OrIOp::create(b, ifge, overflow);
+  // Canonicalize the value `overflow·2^w + input` (input ∈ [0, 2p), so one
+  // subtract of p suffices) in 3 ALU ops instead of 4.
+  //
+  // `min(input - p, input)` folds the `input ≥ p` case without a compare: when
+  // input < p, `input - p` wraps to `input + (2^w - p) > input` (and < 2^w, no
+  // double wrap), so min keeps input; when input ≥ p, `input - p < input`, so
+  // min picks it. A carry into bit w (overflow) always means subtract p, so the
+  // select forces that branch. Byte-identical to the prior
+  // `(input >= p || overflow) ? input - p : input` for every input and any
+  // modulus: overflow ⟹ both yield `input - p`; otherwise min reproduces the
+  // compare. Drops the `cmpi` + `ori` for a single `minui`. The subtract form
+  // is what makes min safe here — getCanonicalDiff adds p and so cannot.
   auto sub = arith::SubIOp::create(b, input, cmod);
-  auto select = arith::SelectOp::create(b, or_, sub, input);
+  auto min = arith::MinUIOp::create(b, sub, input);
+  auto select = arith::SelectOp::create(b, overflow, sub, min);
   return select.getResult();
 }
 

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/SolinasReducer.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/SolinasReducer.cpp
@@ -35,7 +35,7 @@ SolinasReducer::SolinasReducer(ImplicitLocOpBuilder &b,
          "p = 2^64 - 2^32 + 1");
 }
 
-Value SolinasReducer::reduce(Value lo, Value hi) {
+Value SolinasReducer::reduce(Value lo, Value hi, bool lazy) {
   Type t = lo.getType();
   auto konst = [&](uint64_t v) {
     return arith::ConstantOp::create(b, t, b.getIntegerAttr(t, v));
@@ -69,6 +69,9 @@ Value SolinasReducer::reduce(Value lo, Value hi) {
       arith::SelectOp::create(b, add.getOverflow(), t2Corr, add.getSum());
 
   // t2 < 2^64 < 2p, but may be ≥ p; one conditional subtract canonicalizes.
+  // In lazy (gl64) mode we keep t2 in [0, 2^64) and let the consumer reduce.
+  if (lazy)
+    return t2;
   Value p = konst(modAttr.getValue().getZExtValue());
   Value ge = arith::CmpIOp::create(b, arith::CmpIPredicate::uge, t2, p);
   Value sub = arith::SubIOp::create(b, t2, p);

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/SolinasReducer.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/SolinasReducer.cpp
@@ -73,9 +73,14 @@ Value SolinasReducer::reduce(Value lo, Value hi, bool lazy) {
   if (lazy)
     return t2;
   Value p = konst(modAttr.getValue().getZExtValue());
-  Value ge = arith::CmpIOp::create(b, arith::CmpIPredicate::uge, t2, p);
+  // Canonicalize with min instead of cmpi+select (2 ALU ops vs 3). Valid
+  // because t2 ∈ [0, 2^64) and 2^64 - p = ε: when t2 < p, `t2 - p` wraps to
+  // t2 + ε > t2 (no wrap of the sum since t2 + ε < 2^64), so min picks t2;
+  // when t2 ≥ p, `t2 - p` ∈ [0, ε) < t2, so min picks t2 - p. Matches the
+  // trick in MontReducer::getCanonicalFromExtended. (The subtract-of-p form
+  // is what makes min safe here; getCanonicalDiff adds p and so cannot.)
   Value sub = arith::SubIOp::create(b, t2, p);
-  return arith::SelectOp::create(b, ge, sub, t2);
+  return arith::MinUIOp::create(b, sub, t2);
 }
 
 } // namespace mlir::prime_ir::mod_arith

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/SolinasReducer.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/SolinasReducer.cpp
@@ -73,12 +73,9 @@ Value SolinasReducer::reduce(Value lo, Value hi, bool lazy) {
   if (lazy)
     return t2;
   Value p = konst(modAttr.getValue().getZExtValue());
-  // Canonicalize with min instead of cmpi+select (2 ALU ops vs 3). Valid
-  // because t2 ∈ [0, 2^64) and 2^64 - p = ε: when t2 < p, `t2 - p` wraps to
-  // t2 + ε > t2 (no wrap of the sum since t2 + ε < 2^64), so min picks t2;
-  // when t2 ≥ p, `t2 - p` ∈ [0, ε) < t2, so min picks t2 - p. Matches the
-  // trick in MontReducer::getCanonicalFromExtended. (The subtract-of-p form
-  // is what makes min safe here; getCanonicalDiff adds p and so cannot.)
+  // Canonicalize with min, not cmpi+select (2 ALU ops vs 3). t2 ∈ [0, 2^64),
+  // 2^64 - p = ε: `min(t2 - p, t2)` picks t2 when t2 < p (the subtract wraps
+  // up), else t2 - p. Same min trick as MontReducer::getCanonicalFromExtended.
   Value sub = arith::SubIOp::create(b, t2, p);
   return arith::MinUIOp::create(b, sub, t2);
 }

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/SolinasReducer.h
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/SolinasReducer.h
@@ -46,7 +46,9 @@ public:
 
   // Reduces the 128-bit product `hi·2^64 + lo` (each half a canonical-width
   // `k`-bit integer, e.g. from `arith.mului_extended`) to a `k`-bit residue.
-  // Precondition: `hi·2^64 + lo < p²`.
+  // Precondition: `hi·2^64 + lo < 2^128`; canonical callers naturally satisfy
+  // the tighter `< p²` bound, while gl64-lazy callers may use the full 64-bit
+  // operand range.
   //
   // When `lazy` is false, returns the canonical residue in `[0, p)`.
   // When `lazy` is true, skips the final conditional subtract of `p` and

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/SolinasReducer.h
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/SolinasReducer.h
@@ -45,9 +45,16 @@ public:
   explicit SolinasReducer(ImplicitLocOpBuilder &b, ModArithType modArithType);
 
   // Reduces the 128-bit product `hi·2^64 + lo` (each half a canonical-width
-  // `k`-bit integer, e.g. from `arith.mului_extended`) to the canonical
-  // `k`-bit residue in `[0, p)`. Precondition: `hi·2^64 + lo < p²`.
-  Value reduce(Value lo, Value hi);
+  // `k`-bit integer, e.g. from `arith.mului_extended`) to a `k`-bit residue.
+  // Precondition: `hi·2^64 + lo < p²`.
+  //
+  // When `lazy` is false, returns the canonical residue in `[0, p)`.
+  // When `lazy` is true, skips the final conditional subtract of `p` and
+  // returns the reduced-but-not-canonical value in `[0, 2^64)` (the gl64
+  // representation: still one ε wider than `[0, p)`, congruent mod p). A
+  // consumer that needs canonical form must reduce once — kp for such a value
+  // is 2 (since `p < 2^64 < 2p`), so a single conditional subtract suffices.
+  Value reduce(Value lo, Value hi, bool lazy = false);
 
 private:
   ImplicitLocOpBuilder &b;

--- a/tests/Dialect/ModArith/lazy_reduction.mlir
+++ b/tests/Dialect/ModArith/lazy_reduction.mlir
@@ -554,6 +554,34 @@ func.func @test_lazy_mul_chain_goldilocks(%a : !Glz, %b : !Glz) -> !Glz {
 
 // -----
 
+// A mul whose RHS is a constant takes ConvertMul's RHS-constant shortcuts, which
+// assume a canonical lhs in [0, p). So the producer feeding it must NOT stay
+// gl64: unlike @test_lazy_mul_chain_goldilocks (mul->mul stays lazy), the first
+// mul here canonicalizes (minui tail) because its only consumer is a mul-by-
+// constant. Guards against feeding a gl64 value (e.g. p) into the halve/degree
+// shortcuts, which would `lhs + p` overflow or `lhs >> d` a non-canonical lhs.
+!Glc = !mod_arith.int<18446744069414584321 : i64>
+
+// LAZY-LABEL:     @test_lazy_mul_const_rhs_forces_canonical
+// LAZY:           arith.mului_extended
+// LAZY:           arith.minui
+// LAZY:           arith.mului_extended
+// LAZY:           return
+
+// EAGER-LABEL:    @test_lazy_mul_const_rhs_forces_canonical
+// EAGER:          arith.mului_extended
+// EAGER:          arith.minui
+// EAGER:          arith.mului_extended
+// EAGER:          return
+func.func @test_lazy_mul_const_rhs_forces_canonical(%a : !Glc, %b : !Glc) -> !Glc {
+  %c = mod_arith.constant 3 : !Glc
+  %p1 = mod_arith.mul %a, %b : !Glc
+  %p2 = mod_arith.mul %p1, %c : !Glc
+  return %p2 : !Glc
+}
+
+// -----
+
 // Goldilocks gl64 lazy ADD: a full-width add (modWidth == storageWidth == 64)
 // can carry-fold its result into [0, 2^64) instead of canonicalizing, since
 // 2^64 ≡ ε (mod p). Valid when at most one operand is gl64 (so the +ε can't
@@ -564,8 +592,13 @@ func.func @test_lazy_mul_chain_goldilocks(%a : !Glz, %b : !Glz) -> !Glz {
 
 // LAZY-LABEL:     @test_lazy_add_goldilocks
 // LAZY:           arith.addui_extended
+// The eager canonicalize (subi + minui + select) must not appear in the add
+// slice — prove the whole add-to-mul handoff stays gl64 lazy.
+// LAZY-NOT:       arith.subi
+// LAZY-NOT:       arith.minui
 // LAZY:           arith.select
 // LAZY:           arith.addi
+// LAZY-NOT:       arith.subi
 // LAZY-NOT:       arith.minui
 // LAZY:           arith.mului_extended
 // LAZY:           return

--- a/tests/Dialect/ModArith/lazy_reduction.mlir
+++ b/tests/Dialect/ModArith/lazy_reduction.mlir
@@ -520,31 +520,63 @@ func.func @test_consumer_aware_add_mont_square(%a : !Zp, %b : !Zp) -> !Zp {
 // output `t2` is already in [0, 2⁶⁴) before the final canonicalizing subtract.
 // Because the reduction is correct for any product < 2¹²⁸ (not just < p²), a
 // mul result feeding only another mul/square can stay in [0, 2⁶⁴): the
-// consuming multiply absorbs it directly, so the trailing `cmpi uge`/subtract
-// is dropped. Reduction is mod-p preserving, so the result is byte-identical.
+// consuming multiply absorbs it directly, so the trailing canonicalizing
+// subtract (`subi` + `minui`) is dropped. Reduction is mod-p preserving, so the
+// result is byte-identical.
 !Glz = !mod_arith.int<18446744069414584321 : i64>
 
-// First mul feeds only the second mul → lazy (no canonicalizing `cmpi uge`
+// First mul feeds only the second mul → lazy (no canonicalizing `minui`
 // between the two `mului_extended`s). Second mul feeds `return` → canonical.
+// The Solinas tail canonicalizes via `subi` + `minui` (the `cmpi`+`select`
+// form costs one extra ALU op); the only `cmpi` inside the reduce body is the
+// `ult` borrow check, so `minui` uniquely marks canonicalization.
 // LAZY-LABEL:     @test_lazy_mul_chain_goldilocks
 // LAZY:           arith.mului_extended
 // LAZY:           arith.addui_extended
 // LAZY:           arith.select
-// LAZY-NOT:       arith.cmpi uge
+// LAZY-NOT:       arith.minui
 // LAZY:           arith.mului_extended
-// LAZY:           arith.cmpi uge
-// LAZY:           arith.select
+// LAZY:           arith.minui
 // LAZY:           return
 
-// Eager: both muls canonicalize (a `cmpi uge` after each `mului_extended`).
+// Eager: both muls canonicalize (a `minui` after each `mului_extended`).
 // EAGER-LABEL:    @test_lazy_mul_chain_goldilocks
 // EAGER:          arith.mului_extended
-// EAGER:          arith.cmpi uge
+// EAGER:          arith.minui
 // EAGER:          arith.mului_extended
-// EAGER:          arith.cmpi uge
+// EAGER:          arith.minui
 // EAGER:          return
 func.func @test_lazy_mul_chain_goldilocks(%a : !Glz, %b : !Glz) -> !Glz {
   %p1 = mod_arith.mul %a, %b : !Glz
   %p2 = mod_arith.mul %p1, %b : !Glz
   return %p2 : !Glz
+}
+
+// -----
+
+// Goldilocks gl64 lazy ADD: a full-width add (modWidth == storageWidth == 64)
+// can carry-fold its result into [0, 2^64) instead of canonicalizing, since
+// 2^64 ≡ ε (mod p). Valid when at most one operand is gl64 (so the +ε can't
+// double-overflow) and the consumer accepts a non-canonical operand. An add
+// feeding a multiply is lazy (carry-fold: addui_extended + select + addi, no
+// minui); an add feeding `return` stays canonical (subi + minui + select).
+!Gla = !mod_arith.int<18446744069414584321 : i64>
+
+// LAZY-LABEL:     @test_lazy_add_goldilocks
+// LAZY:           arith.addui_extended
+// LAZY:           arith.select
+// LAZY:           arith.addi
+// LAZY-NOT:       arith.minui
+// LAZY:           arith.mului_extended
+// LAZY:           return
+
+// EAGER-LABEL:    @test_lazy_add_goldilocks
+// EAGER:          arith.addui_extended
+// EAGER:          arith.subi
+// EAGER:          arith.minui
+// EAGER:          return
+func.func @test_lazy_add_goldilocks(%a : !Gla, %b : !Gla, %c : !Gla) -> !Gla {
+  %s = mod_arith.add %a, %b : !Gla
+  %r = mod_arith.mul %s, %c : !Gla
+  return %r : !Gla
 }

--- a/tests/Dialect/ModArith/lazy_reduction.mlir
+++ b/tests/Dialect/ModArith/lazy_reduction.mlir
@@ -513,3 +513,38 @@ func.func @test_consumer_aware_add_mont_square(%a : !Zp, %b : !Zp) -> !Zp {
   %r = mod_arith.mont_square %sum : !Zp
   return %r : !Zp
 }
+
+// -----
+
+// Goldilocks gl64 lazy: p = 2⁶⁴ - 2³² + 1 uses the Solinas reducer, whose
+// output `t2` is already in [0, 2⁶⁴) before the final canonicalizing subtract.
+// Because the reduction is correct for any product < 2¹²⁸ (not just < p²), a
+// mul result feeding only another mul/square can stay in [0, 2⁶⁴): the
+// consuming multiply absorbs it directly, so the trailing `cmpi uge`/subtract
+// is dropped. Reduction is mod-p preserving, so the result is byte-identical.
+!Glz = !mod_arith.int<18446744069414584321 : i64>
+
+// First mul feeds only the second mul → lazy (no canonicalizing `cmpi uge`
+// between the two `mului_extended`s). Second mul feeds `return` → canonical.
+// LAZY-LABEL:     @test_lazy_mul_chain_goldilocks
+// LAZY:           arith.mului_extended
+// LAZY:           arith.addui_extended
+// LAZY:           arith.select
+// LAZY-NOT:       arith.cmpi uge
+// LAZY:           arith.mului_extended
+// LAZY:           arith.cmpi uge
+// LAZY:           arith.select
+// LAZY:           return
+
+// Eager: both muls canonicalize (a `cmpi uge` after each `mului_extended`).
+// EAGER-LABEL:    @test_lazy_mul_chain_goldilocks
+// EAGER:          arith.mului_extended
+// EAGER:          arith.cmpi uge
+// EAGER:          arith.mului_extended
+// EAGER:          arith.cmpi uge
+// EAGER:          return
+func.func @test_lazy_mul_chain_goldilocks(%a : !Glz, %b : !Glz) -> !Glz {
+  %p1 = mod_arith.mul %a, %b : !Glz
+  %p2 = mod_arith.mul %p1, %b : !Glz
+  return %p2 : !Glz
+}

--- a/tests/Dialect/ModArith/mod_arith_to_arith.mlir
+++ b/tests/Dialect/ModArith/mod_arith_to_arith.mlir
@@ -307,6 +307,30 @@ func.func @test_lower_sub_goldilocks(%lhs : !Gp, %rhs : !Gp) -> !Gp {
 
 // -----
 
+// Goldilocks add is full-width (modWidth == storageWidth == 64), so it carries
+// into an addui_extended overflow bit and canonicalizes via the overflow form
+// of getCanonicalFromExtended. That folds the `>= p` case with `minui` (no
+// `cmpi`/`ori`): subi + minui + select = 3 ALU ops. Byte-identical to the prior
+// cmpi + ori + subi + select (4 ops). p = 0xffffffff00000001 prints as
+// -4294967295 in signed i64.
+!Gadd = !mod_arith.int<18446744069414584321 : i64>
+// CHECK-LABEL: @test_lower_add_goldilocks
+// CHECK-SAME: (%[[LHS:.*]]: [[T:.*]], %[[RHS:.*]]: [[T]]) -> [[T]] {
+func.func @test_lower_add_goldilocks(%lhs : !Gadd, %rhs : !Gadd) -> !Gadd {
+  // CHECK-NOT: mod_arith.add
+  // CHECK: %[[SUM:.*]], %[[OVF:.*]] = arith.addui_extended %[[LHS]], %[[RHS]] : [[T]], i1
+  // CHECK: %[[CMOD:.*]] = arith.constant -4294967295 : [[T]]
+  // CHECK: %[[SUB:.*]] = arith.subi %[[SUM]], %[[CMOD]] : [[T]]
+  // CHECK: %[[MIN:.*]] = arith.minui %[[SUB]], %[[SUM]] : [[T]]
+  // CHECK: %[[RES:.*]] = arith.select %[[OVF]], %[[SUB]], %[[MIN]] : [[T]]
+  // CHECK-NOT: arith.cmpi
+  // CHECK: return %[[RES]] : [[T]]
+  %res = mod_arith.add %lhs, %rhs : !Gadd
+  return %res : !Gadd
+}
+
+// -----
+
 // Goldilocks p = 2^64 - 2^32 + 1 takes a 64-bit Solinas reduction path so the
 // CPU JIT runtime doesn't need libgcc's `__umodti3` (the generic
 // `arith.remui i128, i128` fallback is unsupported on that runtime). The whole
@@ -334,9 +358,8 @@ func.func @test_lower_mul_goldilocks(%lhs : !Goldilocks, %rhs : !Goldilocks)
   // CHECK:      %[[SUM:.*]], %[[CARRY:.*]] = arith.addui_extended %[[T0]], %[[T1]] : i64, i1
   // CHECK:      %[[T2COR:.*]] = arith.addi %[[SUM]], %{{.*}} : i64
   // CHECK:      %[[T2:.*]] = arith.select %[[CARRY]], %[[T2COR]], %[[SUM]] : i64
-  // CHECK:      %[[GE:.*]] = arith.cmpi uge, %[[T2]], %{{.*}} : i64
   // CHECK:      %[[PSUB:.*]] = arith.subi %[[T2]], %{{.*}} : i64
-  // CHECK:      %[[RES:.*]] = arith.select %[[GE]], %[[PSUB]], %[[T2]] : i64
+  // CHECK:      %[[RES:.*]] = arith.minui %[[PSUB]], %[[T2]] : i64
   // CHECK:      return %[[RES]] : i64
   %res = mod_arith.mul %lhs, %rhs : !Goldilocks
   return %res : !Goldilocks
@@ -361,10 +384,28 @@ func.func @test_lower_square_goldilocks(%lhs : !Goldilocks) -> !Goldilocks {
   // CHECK:      %[[SUM:.*]], %[[CARRY:.*]] = arith.addui_extended %[[T0]], %[[T1]] : i64, i1
   // CHECK:      %[[T2COR:.*]] = arith.addi %[[SUM]], %{{.*}} : i64
   // CHECK:      %[[T2:.*]] = arith.select %[[CARRY]], %[[T2COR]], %[[SUM]] : i64
-  // CHECK:      %[[GE:.*]] = arith.cmpi uge, %[[T2]], %{{.*}} : i64
   // CHECK:      %[[PSUB:.*]] = arith.subi %[[T2]], %{{.*}} : i64
-  // CHECK:      %[[RES:.*]] = arith.select %[[GE]], %[[PSUB]], %[[T2]] : i64
+  // CHECK:      %[[RES:.*]] = arith.minui %[[PSUB]], %[[T2]] : i64
   // CHECK:      return %[[RES]] : i64
   %res = mod_arith.square %lhs : !Goldilocks
   return %res : !Goldilocks
+}
+
+// -----
+
+// Regression: a Goldilocks (full-width) sub must never take the lazy
+// `lhs + p - rhs` path — lhs + p overflows i64, corrupting the residue. Even
+// when the result feeds a multiply (a lazy-accepting consumer), the sub must
+// canonicalize via getCanonicalDiff (subi + addi + cmpi + select).
+!Gsub = !mod_arith.int<18446744069414584321 : i64>
+// CHECK-LABEL: @test_lower_sub_goldilocks_feeds_mul
+func.func @test_lower_sub_goldilocks_feeds_mul(%a: !Gsub, %b: !Gsub, %c: !Gsub) -> !Gsub {
+  // CHECK:      %[[SUB:.*]] = arith.subi %[[A:.*]], %[[B:.*]] : i64
+  // CHECK:      %[[ADD:.*]] = arith.addi %[[SUB]], %{{.*}} : i64
+  // CHECK:      %[[CMP:.*]] = arith.cmpi ult, %[[A]], %[[B]] : i64
+  // CHECK:      %[[DIFF:.*]] = arith.select %[[CMP]], %[[ADD]], %[[SUB]] : i64
+  // CHECK:      arith.mului_extended %[[DIFF]], %{{.*}}
+  %s = mod_arith.sub %a, %b : !Gsub
+  %r = mod_arith.mul %s, %c : !Gsub
+  return %r : !Gsub
 }

--- a/tests/Dialect/ModArith/mod_arith_to_arith.mlir
+++ b/tests/Dialect/ModArith/mod_arith_to_arith.mlir
@@ -319,11 +319,15 @@ func.func @test_lower_sub_goldilocks(%lhs : !Gp, %rhs : !Gp) -> !Gp {
 func.func @test_lower_add_goldilocks(%lhs : !Gadd, %rhs : !Gadd) -> !Gadd {
   // CHECK-NOT: mod_arith.add
   // CHECK: %[[SUM:.*]], %[[OVF:.*]] = arith.addui_extended %[[LHS]], %[[RHS]] : [[T]], i1
+  // The old cmpi + ori canonicalize must not appear anywhere in the add slice.
+  // CHECK-NOT: arith.cmpi
+  // CHECK-NOT: arith.ori
   // CHECK: %[[CMOD:.*]] = arith.constant -4294967295 : [[T]]
   // CHECK: %[[SUB:.*]] = arith.subi %[[SUM]], %[[CMOD]] : [[T]]
   // CHECK: %[[MIN:.*]] = arith.minui %[[SUB]], %[[SUM]] : [[T]]
   // CHECK: %[[RES:.*]] = arith.select %[[OVF]], %[[SUB]], %[[MIN]] : [[T]]
   // CHECK-NOT: arith.cmpi
+  // CHECK-NOT: arith.ori
   // CHECK: return %[[RES]] : [[T]]
   %res = mod_arith.add %lhs, %rhs : !Gadd
   return %res : !Gadd


### PR DESCRIPTION
  ## Goal

  Cut ALU-op count on Goldilocks (p = 2⁶⁴−2³²+1) field arithmetic in the
  ModArithToArith lowering, on the chained-multiply critical paths that dominate
  Poseidon2 (the pow7 S-box, diffusion column sums). Refs fractalyze/zisk-zorch#49.

  ## What changed

  Two commits:

  **1. gl64-lazy mul/square reduction (`4aa9cd68`)**
  Under `-mod-arith-to-arith=lazy-reduction=true`, a Goldilocks multiply/square
  whose every consumer is itself a multiply/square skips the Solinas reducer's
  final canonicalizing subtract, leaving the result in the gl64 representation
  `[0, 2⁶⁴)` (kp = 2). The Solinas reduce is correct for any product < 2¹²⁸, so a
  consuming multiply absorbs a `[0, 2⁶⁴)` operand directly; the deferred subtract
  is mod-p preserving → **byte-identical** output.
  - `SolinasReducer::reduce` gains a `lazy` flag (skips the trailing cmp/sub/select).
  - `buildBoundMap` records mul/square results at `umax = 2⁶⁴−1`; consumer-aware
    clamp keeps them lazy only when all consumers are mul/square.
  - `ConvertMul`/`ConvertSquare` move to the BoundMap pattern set.

  **2. Cheaper canonicalize + lazy add + bound allocation (`3cc8631b`)**
  - **Min-canonicalize**: the Solinas mul/square tail (`cmpi uge + subi + select`)
    and `getCanonicalFromExtended` (`cmpi + ori + subi + select`) both collapse to
    `subi + minui[+ select]` — one fewer ALU op on every Goldilocks mul, square,
    and add. Byte-identical.
  - **Lazy Goldilocks add**: when a consumer accepts a non-canonical operand,
    carry-fold into `[0, 2⁶⁴)` instead of canonicalizing (valid because at most
    one operand is gl64).
  - **Bound allocation**: `buildBoundMap` phase 2 visits candidates by descending
    fanout and erases immediately, so canonicalizing a widely-shared value once
    lets its many low-fanout partners stay lazy — minimizing *total* reductions.
  - **Bug fix**: the gl64-lazy sub (`lhs + rhs·kp·p − rhs`) overflowed i64 for
    full-width moduli (`lhs + p > 2⁶⁴`), corrupting the residue. Now records the
    canonical bound and emits `getCanonicalDiff` for full-width subs; the lazy form
    stays for narrow fields where `lhs + correction` fits.

  ## Impact

  On a W16 Poseidon2 permutation, Goldilocks arithmetic drops **29046 → 22715 ALU
  ops (−22%)** (pil2's fully-lazy floor is ~20292).

  ## Testing

  - All ModArith + Field lit/runtime tests pass.
  - New tests pin: the Goldilocks lazy add, the min-canonicalize shapes, and the
    full-width sub regression (`tests/Dialect/ModArith/lazy_reduction.mlir` +67,
    `mod_arith_to_arith.mlir` +49).