### PR TITLE
fix(dialect/field): correct binary tower multiply high term

### DIFF
--- a/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldCodeGen.cpp
+++ b/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldCodeGen.cpp
@@ -188,7 +188,9 @@ Value BinaryFieldCodeGen::mulTower(Value a, Value b,
   // m₁ = a₁*b₁
   // m₂ = (a₀+a₁)*(b₀+b₁)
   // result_lo = m₀ + m₁*α
-  // result_hi = m₂ + m₀ + m₁  (= a₀*b₁ + a₁*b₀ + a₁*b₁)
+  // result_hi = m₂ + m₀     (= a₀*b₁ + a₁*b₀ + a₁*b₁)
+  // Note m₂ + m₀ = a₀b₁ + a₁b₀ + a₁b₁, NOT m₂ + m₀ + m₁ (that cancels the
+  // a₁b₁ the x² = x + α fold contributes to the high term).
 
   unsigned halfBits = 1u << (towerLevel - 1);
   IntegerType halfType = IntegerType::get(builder_.getContext(), halfBits);
@@ -222,9 +224,8 @@ Value BinaryFieldCodeGen::mulTower(Value a, Value b,
   Value m1Alpha = mulTower(m1, alphaConst, towerLevel - 1);
   Value resultLo = arith::XOrIOp::create(builder_, m0, m1Alpha);
 
-  // result_hi = m₂ + m₀ + m₁
-  Value m2Xm0 = arith::XOrIOp::create(builder_, m2, m0);
-  Value resultHi = arith::XOrIOp::create(builder_, m2Xm0, m1);
+  // result_hi = m₂ + m₀
+  Value resultHi = arith::XOrIOp::create(builder_, m2, m0);
 
   // Combine: result = result_lo | (result_hi << halfBits)
   Value resultLoExt = arith::ExtUIOp::create(builder_, fullType, resultLo);

--- a/tests/Dialect/Field/binary_field_runner.mlir
+++ b/tests/Dialect/Field/binary_field_runner.mlir
@@ -21,7 +21,8 @@
 // RUN:      --shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
 // RUN: FileCheck %s < %t
 
-!BF8 = !field.bf<3>  // GF(2^8) tower field
+!BF8 = !field.bf<3>     // GF(2^8) tower field
+!BF128 = !field.bf<7>   // GF(2^128) tower field
 
 func.func private @printMemrefI32(memref<*xi32>) attributes { llvm.emit_c_interface }
 
@@ -98,10 +99,63 @@ func.func @test_bf8_double() {
 }
 // CHECK: [0]
 
+// Test: BF8 self-multiply exercises the x² = x + α high-term fold.
+// 3 = ω+1 in the GF(4) subfield, so 3*3 = (ω+1)² = ω = 2 (= square(3)).
+// A wrong Karatsuba high term (m₂+m₀+m₁ instead of m₂+m₀) drops the a₁b₁
+// the fold contributes, making 3 a zero-divisor (3*3 = 0).
+func.func @test_bf8_mul_self() {
+  %a = field.constant 3 : !BF8
+  %c = field.mul %a, %a : !BF8
+
+  %result_i8 = field.bitcast %c : !BF8 -> i8
+  %result = arith.extui %result_i8 : i8 to i32
+  %tensor = tensor.from_elements %result : tensor<1xi32>
+  %buffer = bufferization.to_buffer %tensor : tensor<1xi32> to memref<1xi32>
+  %cast = memref.cast %buffer : memref<1xi32> to memref<*xi32>
+  func.call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
+  return
+}
+// CHECK: [2]
+
+// Test: BF128 (GF(2^128)) multiplication on the portable tower path.
+// 2 and 3 embed in the GF(4) subfield, so 2 * 3 = 1 at every tower level.
+func.func @test_bf128_mul() {
+  %a = field.constant 2 : !BF128
+  %b = field.constant 3 : !BF128
+  %c = field.mul %a, %b : !BF128
+
+  %result_i128 = field.bitcast %c : !BF128 -> i128
+  %result = arith.trunci %result_i128 : i128 to i32
+  %tensor = tensor.from_elements %result : tensor<1xi32>
+  %buffer = bufferization.to_buffer %tensor : tensor<1xi32> to memref<1xi32>
+  %cast = memref.cast %buffer : memref<1xi32> to memref<*xi32>
+  func.call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
+  return
+}
+// CHECK: [1]
+
+// Test: BF128 self-multiply — 3 * 3 = 2 (zero-divisor guard at the top level).
+func.func @test_bf128_mul_self() {
+  %a = field.constant 3 : !BF128
+  %c = field.mul %a, %a : !BF128
+
+  %result_i128 = field.bitcast %c : !BF128 -> i128
+  %result = arith.trunci %result_i128 : i128 to i32
+  %tensor = tensor.from_elements %result : tensor<1xi32>
+  %buffer = bufferization.to_buffer %tensor : tensor<1xi32> to memref<1xi32>
+  %cast = memref.cast %buffer : memref<1xi32> to memref<*xi32>
+  func.call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
+  return
+}
+// CHECK: [2]
+
 func.func @main() {
   func.call @test_bf8_add() : () -> ()
   func.call @test_bf8_mul() : () -> ()
   func.call @test_bf8_square() : () -> ()
   func.call @test_bf8_double() : () -> ()
+  func.call @test_bf8_mul_self() : () -> ()
+  func.call @test_bf128_mul() : () -> ()
+  func.call @test_bf128_mul_self() : () -> ()
   return
 }


### PR DESCRIPTION
## What

`BinaryFieldCodeGen::mulTower` (the runtime lowering of `field.mul` for binary
tower fields) computed the Karatsuba high term as `result_hi = m₂ ^ m₀ ^ m₁`.
For the tower extension `x² + x + α` (so `x² = x + α`), the high coefficient is
`a₀b₁ + a₁b₀ + a₁b₁ = m₂ ^ m₀`; the extra `^ m₁` cancels the `a₁b₁` the `x²`
fold contributes. As written the lowering was not a field — at `bf<3>`,
`3·3 = 0` (3 a zero-divisor) and `mul(a,a) ≠ square(a)` even though `squareTower`
is correct.

Fix: `result_hi = m₂ ^ m₀`.

## Why it was latent

The `Mul` gtest checks `BinaryFieldOperation::operator*`, which constant-folds via
`zk_dtypes::BinaryMul` — it never reaches the codegen `mulTower`. Only the
`*_runner.mlir` lit tests execute the lowering, and they need `mlir-runner`.

## Test

Extends `binary_field_runner.mlir` (portable `--field-to-llvm` path) with bf<3>
and bf<7> self-multiply (`3·3 = 2`) — the zero-divisor case the bug produced — plus
bf<7> `2·3 = 1`. The existing bf<3> `2·3 = 1` already encoded the correct value.
`bazel test //tests/Dialect/Field:binary_field_runner` green.

## Scope

Fixes Finding A of #372 (portable `mulTower`). Finding B — the bf<6>/bf<7>
x86/ARM PCLMULQDQ specializers compute flat GHASH rather than the tower
(`2·3 = 6`, not `1`) — is a separate design decision (make them tower-correct, or
expose a distinct flat-GHASH dtype for consumers like flock that want GHASH) and
stays open. See fractalyze/flock-zorch#15.
