### PR TITLE
fix(dialect/ec): reduce Montgomery MSM scalars per-element

### DIFF
--- a/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/MSM/Pippengers/Generic.cpp
+++ b/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/MSM/Pippengers/Generic.cpp
@@ -104,7 +104,14 @@ void PippengersGeneric::scalarIsNotOneBranch(Value scalar, Value point,
 ValueRange PippengersGeneric::bucketSingleAcc(Value i, Value windowSum,
                                               Value buckets, Value windowOffset,
                                               ImplicitLocOpBuilder &b) {
-  auto scalar = tensor::ExtractOp::create(b, scalars, ValueRange{i});
+  Value scalarRaw = tensor::ExtractOp::create(b, scalars, ValueRange{i});
+  // Reduce this scalar to standard form per-element. The whole-tensor
+  // reduction is intentionally skipped in Pippengers so the CPU fusion
+  // pipeline can scalarize it; non-Montgomery scalars pass through unchanged.
+  Value scalar =
+      field::isMontgomery(scalarRaw.getType())
+          ? field::FromMontOp::create(b, scalarFieldType, scalarRaw).getResult()
+          : scalarRaw;
   auto point = tensor::ExtractOp::create(b, points, ValueRange{i});
 
   Value zeroSF = field::createFieldZero(scalarFieldType, b);

--- a/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/MSM/Pippengers/Pippengers.cpp
+++ b/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/MSM/Pippengers/Pippengers.cpp
@@ -70,11 +70,12 @@ Pippengers::Pippengers(Value scalarsIn, Value points, Type outputType,
 
   scalarFieldType = cast<field::PrimeFieldType>(
       field::getStandardFormType(scalarsType.getElementType()));
-  scalars = field::isMontgomery(scalarsType)
-                ? field::FromMontOp::create(
-                      b, field::getStandardFormType(scalarsType), scalarsIn)
-                      .getResult()
-                : scalarsIn;
+  // Keep the scalars in their incoming form (possibly Montgomery). Each is
+  // reduced to standard form per-element at extraction (Generic.cpp
+  // bucketSingleAcc), not here: a from_mont over the whole scalar tensor
+  // lowers to whole-tensor arith on tensor<Nxi256>, which the XLA CPU
+  // hero-emitter pipeline (LowerTensors, not bufferization) cannot scalarize.
+  scalars = scalarsIn;
 
   size_t scalarBitWidth = scalarFieldType.getTypeSizeInBits();
   bitsPerWindow =


### PR DESCRIPTION
## Problem
The Pippenger MSM lowering reduces Montgomery scalars to standard form with a
`from_mont` over the **whole** scalar tensor (`Pippengers.cpp`). On XLA's CPU
hero-emitter pipeline (which uses `LowerTensors`, not one-shot bufferization),
that whole-tensor `arith.andi` on `tensor<Nxi256>` is never scalarized and fails
to legalize:

```
failed to legalize operation 'arith.andi' ... (tensor<Nxi256>) loc("wrapped_msm")
```

So an **affine-base MSM with Montgomery scalars** (e.g. a Pedersen commitment) can't
compile on the CPU backend. The jacobian path avoids this only because it routes
through XLA's `MsmExpander` unroll; non-Montgomery affine scalars avoid it because
they never emit the reduction — so this gap was previously unexercised.

## Fix
Move the reduction to each **extracted** scalar in `bucketSingleAcc` (guarded by
`isMontgomery`; non-Montgomery scalars pass through unchanged). A per-element
`from_mont` lowers like the rest of the Pippenger's scalar field arithmetic, so no
whole-tensor `i256` arith survives.

## Validation
A new `Bn254G1AffineMontMsmStage1` case in XLA's `xla/backends/cpu/tests/ec_test.cc`
(Montgomery scalars + affine bases) passes and is byte-correct against the host
computation; the jacobian G1/G2 and non-Montgomery paths are unchanged (full
`ec_test` green). That XLA test lands alongside a prime_ir pin bump.

## Scope note
This unblocks affine-base Montgomery-scalar MSM on the CPU backend. The full
consumer path (a Bulletproofs/IPA prover) additionally hits a separate XLA CPU
EC-codegen miscompile in modules that compile many EC ops together; that is
tracked independently and is out of scope here.