### PR TITLE
fix: lower multi-element EC-convert and from_mont on the CPU hero path

### DIFF
--- a/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/EllipticCurveToField.cpp
+++ b/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/EllipticCurveToField.cpp
@@ -349,6 +349,34 @@ struct ConvertConvertPointType
         return rewriteTensorToAffine(op, adaptor, rewriter, tensorType,
                                      inputPti, outputPti);
       }
+      // Any other multi-element convert (e.g. affine→jacobian) under the AOT
+      // runtime: the ec_* symbols are scalar, so the AOT path below would emit
+      // an unresolvable tensor-signature call. Scalarize via tensor.generate —
+      // a scalar convert_point_type per element re-enters this pattern and
+      // takes the scalar AOT path, lowering to an scf loop the CPU hero-emitter
+      // pipeline can legalize (the single-element path above handles N = 1).
+      if (shouldUseAOTRuntime(op, outputType, aotConfig.mode,
+                              aotConfig.inlineConstOps)) {
+        ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+        SmallVector<Value> dynExtents;
+        for (int64_t d = 0, rank = tensorType.getRank(); d < rank; ++d)
+          if (tensorType.isDynamicDim(d))
+            dynExtents.push_back(tensor::DimOp::create(
+                b, adaptor.getInput(), arith::ConstantIndexOp::create(b, d)));
+        Value result =
+            tensor::GenerateOp::create(
+                b, cast<RankedTensorType>(op.getType()), ValueRange(dynExtents),
+                [&](OpBuilder &nb, Location loc, ValueRange ivs) {
+                  ImplicitLocOpBuilder lb(loc, nb);
+                  Value pt =
+                      tensor::ExtractOp::create(lb, adaptor.getInput(), ivs);
+                  Value cvt = ConvertPointTypeOp::create(lb, outputType, pt);
+                  tensor::YieldOp::create(lb, cvt);
+                })
+                .getResult();
+        rewriter.replaceOp(op, result);
+        return success();
+      }
     }
 
     // AOT runtime path for point type conversions.

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
@@ -360,10 +360,10 @@ struct ConvertToMont : public OpConversionPattern<ToMontOp> {
 };
 
 struct ConvertFromMont : public OpConversionPattern<FromMontOp> {
-  explicit ConvertFromMont(MLIRContext *context)
-      : OpConversionPattern<FromMontOp>(context) {}
-
-  using OpConversionPattern::OpConversionPattern;
+  explicit ConvertFromMont(const TypeConverter &converter, MLIRContext *context,
+                           AOTConfig aotConfig)
+      : OpConversionPattern<FromMontOp>(converter, context),
+        aotConfig(aotConfig) {}
 
   LogicalResult
   matchAndRewrite(FromMontOp op, OpAdaptor adaptor,
@@ -371,6 +371,41 @@ struct ConvertFromMont : public OpConversionPattern<FromMontOp> {
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
 
     Type fieldType = getElementTypeOrSelf(op.getOutput());
+
+    // Multi-element prime-field tensor under the AOT runtime (CPU): a
+    // whole-tensor mod_arith.from_mont lowers to whole-tensor i256 arith the
+    // CPU hero-emitter pipeline (LowerTensors, not bufferization) cannot
+    // scalarize. Scalarize via tensor.generate — a scalar from_mont per element
+    // — which lowers to an scf loop. GPU (Inline mode) keeps the vectorized
+    // whole-tensor reduction. (The scalar path below handles rank-0 / non-CPU.)
+    if (auto tensorType = dyn_cast<RankedTensorType>(op.getType());
+        tensorType && tensorType.getRank() >= 1 &&
+        isa<PrimeFieldType>(fieldType) &&
+        aotConfig.mode == LoweringMode::Auto) {
+      Type resultTensorType = typeConverter->convertType(op.getType());
+      Type elemResultType = getElementTypeOrSelf(resultTensorType);
+      SmallVector<Value> dynExtents;
+      for (int64_t d = 0, rank = tensorType.getRank(); d < rank; ++d)
+        if (tensorType.isDynamicDim(d))
+          dynExtents.push_back(tensor::DimOp::create(
+              b, adaptor.getInput(), arith::ConstantIndexOp::create(b, d)));
+      Value result =
+          tensor::GenerateOp::create(
+              b, cast<RankedTensorType>(resultTensorType),
+              ValueRange(dynExtents),
+              [&](OpBuilder &nb, Location loc, ValueRange ivs) {
+                ImplicitLocOpBuilder lb(loc, nb);
+                Value elem =
+                    tensor::ExtractOp::create(lb, adaptor.getInput(), ivs);
+                Value red =
+                    mod_arith::FromMontOp::create(lb, elemResultType, elem);
+                tensor::YieldOp::create(lb, red);
+              })
+              .getResult();
+      rewriter.replaceOp(op, result);
+      return success();
+    }
+
     if (isa<PrimeFieldType>(fieldType)) {
       Type resultType = typeConverter->convertType(op.getType());
       auto extracted =
@@ -394,6 +429,8 @@ struct ConvertFromMont : public OpConversionPattern<FromMontOp> {
     }
     return failure();
   }
+
+  AOTConfig aotConfig;
 };
 
 template <typename OpT, typename Derived>
@@ -1049,11 +1086,11 @@ void FieldToModArith::runOnOperation() {
       ConvertBitcast,
       ConvertConstant,
       ConvertCmp,
-      ConvertFromMont,
       ConvertPowUI,
       ConvertToMont
       // clang-format on
       >(typeConverter, context);
+  patterns.add<ConvertFromMont>(typeConverter, context, aotConfig);
 
   // Catch-all: converts any op whose operands/results carry field types.
   // Op-specific patterns above have root-op-name priority in the applicator.

--- a/tests/Dialect/EllipticCurve/elliptic_curve_to_field_aot.mlir
+++ b/tests/Dialect/EllipticCurve/elliptic_curve_to_field_aot.mlir
@@ -60,3 +60,17 @@ func.func @test_1x1_affine_to_jacobian_aot(%arg0: tensor<1x1x!affinem>) -> tenso
   %result = elliptic_curve.convert_point_type %arg0 : tensor<1x1x!affinem> -> tensor<1x1x!jacobianm>
   return %result : tensor<1x1x!jacobianm>
 }
+
+// A multi-element affine->jacobian convert has no batch (->affine only) or
+// single-element path, so it scalarizes via tensor.generate -- a scalar
+// convert per element takes the AOT path -- instead of emitting an
+// unresolvable tensor-signature ec_affine_to_jacobian call.
+// CHECK-LABEL: @test_batch_affine_to_jacobian_aot
+func.func @test_batch_affine_to_jacobian_aot(
+    %arg0: tensor<4x!affinem>) -> tensor<4x!jacobianm> {
+  // CHECK: tensor.generate
+  // CHECK: call @ec_affine_to_jacobian_bn254_g1_mont
+  %result = elliptic_curve.convert_point_type %arg0
+      : tensor<4x!affinem> -> tensor<4x!jacobianm>
+  return %result : tensor<4x!jacobianm>
+}

--- a/tests/Dialect/Field/prime_field_from_mont_auto.mlir
+++ b/tests/Dialect/Field/prime_field_from_mont_auto.mlir
@@ -1,0 +1,19 @@
+// RUN: prime-ir-opt -field-to-mod-arith='lowering-mode=auto' %s \
+// RUN:   | FileCheck %s -enable-var-scope
+
+!PF1 = !field.pf<97:i32>
+!PF1m = !field.pf<97:i32, true>
+!PFmv = tensor<4x!PF1m>
+!PFv = tensor<4x!PF1>
+
+// Under 'auto' (the CPU trio's lowering mode) a multi-element prime-field
+// from_mont scalarizes via tensor.generate -- a scalar mod_arith.from_mont per
+// element -- so the CPU hero-emitter pipeline can lower it. A whole-tensor
+// mod_arith.from_mont would become whole-tensor i256 arith it cannot scalarize.
+// CHECK-LABEL: @test_from_mont_batch_auto
+func.func @test_from_mont_batch_auto(%arg0: !PFmv) -> !PFv {
+  // CHECK: tensor.generate
+  // CHECK: mod_arith.from_mont
+  %res = field.from_mont %arg0 : !PFv
+  return %res : !PFv
+}


### PR DESCRIPTION
Two CPU-lowering gap-fills so multi-element EC/field tensor ops legalize on
XLA's CPU **hero-emitter** pipeline (which uses `LowerTensors`, not one-shot
bufferization, and so cannot scalarize whole-tensor `i256` arith or call a
scalar `ec_*` symbol on a whole tensor). Both are prime_ir-side; no consumer
(zorch IPA prover, the Pippenger MSM) changes.

## Fix A — `ConvertConvertPointType` (`dialect/ec`)
A multi-element **non-→affine** convert (e.g. `affine→jacobian` on a length-N
Pedersen-basis half) matched neither the `→affine` batch path nor the
single-element path, so under the AOT runtime it emitted a tensor-signature
call to the scalar `ec_affine_to_jacobian_*` symbol → failed to legalize. Now
it scalarizes via `tensor.generate` (a scalar convert per element re-enters the
pattern → the scalar AOT path). Gated to the AOT runtime so GPU (inline) is
untouched.

## Fix B — `ConvertFromMont` (`dialect/field`)
A prime-field `from_mont` lowered to one `mod_arith.from_mont` over the whole
tensor → whole-tensor `arith.andi (tensor<Nxi256>)` that the hero path can't
scalarize (blocks an affine-base Montgomery-scalar MSM, where the Pippenger
reduces the scalar tensor). Now, under the CPU trio's `Auto` mode, a
multi-element prime-field `from_mont` scalarizes via `tensor.generate`. GPU
keeps the vectorized whole-tensor reduction (default `inline` mode); the
Pippenger is CPU-only anyway (GPU MSM uses the ICICLE thunk).

## Tests
- Lit: `elliptic_curve_to_field_aot.mlir` `@test_batch_affine_to_jacobian_aot`
  (Fix A) and `prime_field_from_mont_auto.mlir` `@test_from_mont_batch_auto`
  (Fix B) — both check the `tensor.generate` scalarization.
- End-to-end byte-correctness in XLA's `xla/backends/cpu/tests/ec_test.cc`
  (`Bn254G1AffineToJacobianBatchConvert`, `Bn254G1AffineMontMsmStage1`) — those
  land with the XLA prime_ir pin bump.

## Context
These make the natural zorch IPA prover code (an `affine→jacobian` basis fold +
Montgomery-scalar Pedersen commit) compile on CPU with no zorch/Pippenger
change. A separate, deeper XLA CPU EC-codegen miscompile in modules with many
EC ops (fractalyze/xla#155) still blocks full byte-match end-to-end.