### PR TITLE
fix(dialect/ec): lower multi-element tensor point conversions element-wise

### DIFF
--- a/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/EllipticCurveToField.cpp
+++ b/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/EllipticCurveToField.cpp
@@ -341,7 +341,7 @@ struct ConvertConvertPointType
     // The batch inverse avoids per-element scalar inverse, enabling
     // Montgomery's trick (3(N-1) muls + 1 inverse instead of N inverses).
     if (auto tensorType = dyn_cast<RankedTensorType>(inputType);
-        tensorType && tensorType.getRank() > 0) {
+        tensorType && tensorType.getRank() == 1) {
       auto inputPti = cast<PointTypeInterface>(tensorType.getElementType());
       auto outputPti = cast<PointTypeInterface>(outputType);
       if (outputPti.getPointKind() == PointKind::kAffine &&
@@ -351,9 +351,41 @@ struct ConvertConvertPointType
       }
     }
 
-    // AOT runtime path for point type conversions.
-    // Use getElementTypeOrSelf for inputType: multi-element tensors that the
-    // batch path doesn't cover (e.g. affine input) can still reach here.
+    // Any remaining tensor form converts element-wise with the inline
+    // scalar codegen regardless of mode: unlike the ->affine batch above
+    // these directions share no work across elements (no inverse to
+    // amortize), so a per-point AOT call would be pure overhead — and
+    // jacobian<->xyzz have no runtime symbol to call anyway.
+    if (auto tensorType = dyn_cast<RankedTensorType>(inputType)) {
+      ImplicitLocOpBuilder b(loc, rewriter);
+      SmallVector<Value> dynExtents;
+      for (int64_t i = 0; i < tensorType.getRank(); ++i) {
+        if (tensorType.isDynamicDim(i)) {
+          Value idx = arith::ConstantIndexOp::create(b, i);
+          dynExtents.push_back(
+              tensor::DimOp::create(b, adaptor.getInput(), idx));
+        }
+      }
+      auto outputTensorType =
+          RankedTensorType::get(tensorType.getShape(), outputType);
+      PointKind outKind = cast<PointTypeInterface>(outputType).getPointKind();
+      Value result =
+          tensor::GenerateOp::create(
+              b, outputTensorType, dynExtents,
+              [&](OpBuilder &nb, Location nloc, ValueRange ivs) {
+                ImplicitLocOpBuilder lb(nloc, nb);
+                ScopedBuilderContext scopedBuilderContext(&lb);
+                Value pt =
+                    tensor::ExtractOp::create(lb, adaptor.getInput(), ivs);
+                PointCodeGen codeGen(tensorType.getElementType(), pt);
+                tensor::YieldOp::create(lb, codeGen.convert(outKind));
+              })
+              .getResult();
+      rewriter.replaceOp(op, result);
+      return success();
+    }
+
+    // AOT runtime path for scalar point type conversions.
     if (shouldUseAOTRuntime(op, outputType, aotConfig.mode,
                             aotConfig.inlineConstOps)) {
       auto inputPti = cast<PointTypeInterface>(getElementTypeOrSelf(inputType));

--- a/tests/Dialect/EllipticCurve/elliptic_curve_to_field.mlir
+++ b/tests/Dialect/EllipticCurve/elliptic_curve_to_field.mlir
@@ -252,3 +252,16 @@ func.func @test_1x1_jacobian_to_affine_inline(%arg0: tensor<1x1x!jacobianm>) -> 
   %result = elliptic_curve.convert_point_type %arg0 : tensor<1x1x!jacobianm> -> tensor<1x1x!affinem>
   return %result : tensor<1x1x!affinem>
 }
+
+// Multi-element tensors with no batch lowering (affine input) convert
+// element-wise inside tensor.generate (fractalyze/xla#165).
+// CHECK-LABEL: @test_4elem_affine_to_jacobian_inline
+func.func @test_4elem_affine_to_jacobian_inline(%arg0: tensor<4x!affinem>) -> tensor<4x!jacobianm> {
+  // CHECK-NOT: elliptic_curve.convert_point_type
+  // CHECK: tensor.generate
+  // CHECK: tensor.extract
+  // CHECK: elliptic_curve.from_coords
+  // CHECK: tensor.yield
+  %result = elliptic_curve.convert_point_type %arg0 : tensor<4x!affinem> -> tensor<4x!jacobianm>
+  return %result : tensor<4x!jacobianm>
+}

--- a/tests/Dialect/EllipticCurve/elliptic_curve_to_field_aot.mlir
+++ b/tests/Dialect/EllipticCurve/elliptic_curve_to_field_aot.mlir
@@ -60,3 +60,38 @@ func.func @test_1x1_affine_to_jacobian_aot(%arg0: tensor<1x1x!affinem>) -> tenso
   %result = elliptic_curve.convert_point_type %arg0 : tensor<1x1x!affinem> -> tensor<1x1x!jacobianm>
   return %result : tensor<1x1x!jacobianm>
 }
+
+// Multi-element tensors with no batch lowering (affine input) convert
+// element-wise with the inline codegen even in AOT mode: the lift shares no
+// work across elements and the single-point runtime symbol must never see a
+// tensor operand (fractalyze/xla#165).
+// CHECK-LABEL: @test_4elem_affine_to_jacobian_aot
+func.func @test_4elem_affine_to_jacobian_aot(%arg0: tensor<4x!affinem>) -> tensor<4x!jacobianm> {
+  // CHECK-NOT: call @ec_affine_to_jacobian_bn254_g1_mont
+  // CHECK: tensor.generate
+  // CHECK: tensor.extract
+  // CHECK: elliptic_curve.from_coords
+  // CHECK: tensor.yield
+  %result = elliptic_curve.convert_point_type %arg0 : tensor<4x!affinem> -> tensor<4x!jacobianm>
+  return %result : tensor<4x!jacobianm>
+}
+
+// CHECK-LABEL: @test_4elem_affine_to_xyzz_aot
+func.func @test_4elem_affine_to_xyzz_aot(%arg0: tensor<4x!affinem>) -> tensor<4x!xyzzm> {
+  // CHECK-NOT: call @ec_affine_to_xyzz_bn254_g1_mont
+  // CHECK: tensor.generate
+  // CHECK: elliptic_curve.from_coords
+  // CHECK: tensor.yield
+  %result = elliptic_curve.convert_point_type %arg0 : tensor<4x!affinem> -> tensor<4x!xyzzm>
+  return %result : tensor<4x!xyzzm>
+}
+
+// Dynamic extents thread through tensor.dim into the generated loop nest.
+// CHECK-LABEL: @test_dyn_affine_to_jacobian_aot
+func.func @test_dyn_affine_to_jacobian_aot(%arg0: tensor<?x!affinem>) -> tensor<?x!jacobianm> {
+  // CHECK: tensor.dim
+  // CHECK: tensor.generate
+  // CHECK: elliptic_curve.from_coords
+  %result = elliptic_curve.convert_point_type %arg0 : tensor<?x!affinem> -> tensor<?x!jacobianm>
+  return %result : tensor<?x!jacobianm>
+}


### PR DESCRIPTION
## Description

`convert_point_type` on a multi-point tensor fell through to the scalar AOT/inline legs: AOT mode called the single-point runtime symbol with a tensor operand, leaving a `func.func` declaration with `elliptic_curve` tensor types that no later pass can legalize (inline mode would assert in `PointCodeGen`). Only jacobian/xyzz → affine had a tensor lowering (the batch-inverse path); the affine → jacobian/xyzz tiles produced by XLA's CPU tiled emitter hit the gap — G1 tiles at 2 points per tile and fails, while G2's wider element yields 1-point tiles that the wrapped-scalar normalization already handles, which is why only G1 broke.

Remaining tensor forms now lower to `tensor.generate` over the **inline** scalar codegen in every mode. Unlike the batch-inverse →affine direction there is no work to share across elements (affine→jacobian/xyzz is a mul-free coordinate lift, jacobian→xyzz is two independent muls), so per-point AOT calls would be pure call overhead — and jacobian↔xyzz have no AOT runtime symbols in the registry at all, so re-entering the AOT leg per element would produce unresolvable JIT symbols. The batch-inverse path is gated to rank-1 explicitly so higher ranks fall through to the element-wise form instead of failing to match.

## Related Issues/PRs

Fixes the legalization failure behind fractalyze/xla#165 (`ec_affine_to_jacobian_bn254_g1` marked illegal). Verified end-to-end against fractalyze/xla with `--override_repository`: the new batched convert tests there (including an identity point in the batch) fail on current main and pass byte-equal with this change.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline