### PR TITLE
perf(dialect/ec): batch convert_point_type ->affine at any rank

### DIFF
--- a/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/EllipticCurveToField.cpp
+++ b/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/EllipticCurveToField.cpp
@@ -341,7 +341,7 @@ struct ConvertConvertPointType
     // The batch inverse avoids per-element scalar inverse, enabling
     // Montgomery's trick (3(N-1) muls + 1 inverse instead of N inverses).
     if (auto tensorType = dyn_cast<RankedTensorType>(inputType);
-        tensorType && tensorType.getRank() == 1) {
+        tensorType && tensorType.getRank() > 0) {
       auto inputPti = cast<PointTypeInterface>(tensorType.getElementType());
       auto outputPti = cast<PointTypeInterface>(outputType);
       if (outputPti.getPointKind() == PointKind::kAffine &&
@@ -428,26 +428,21 @@ private:
                                       RankedTensorType tensorType,
                                       PointTypeInterface inputPti,
                                       PointTypeInterface outputPti) const {
-    if (tensorType.getRank() != 1)
-      return rewriter.notifyMatchFailure(
-          op, "batch convert_point_type requires 1-D tensor");
-
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
     Type fieldType = inputPti.getBaseFieldType();
-    int64_t n = tensorType.getDimSize(0); // may be kDynamic
-    bool isDynamic = n == ShapedType::kDynamic;
-
-    // Get N as Value.
-    Value c0val = arith::ConstantIndexOp::create(b, 0);
-    Value dimNval =
-        isDynamic
-            ? tensor::DimOp::create(b, adaptor.getInput(), c0val).getResult()
-            : arith::ConstantIndexOp::create(b, n).getResult();
-    SmallVector<Value, 1> dynExtentsStorage;
-    if (isDynamic)
-      dynExtentsStorage.push_back(dimNval);
+    // Shape-generic: field.inverse collapses the multi-dim column to 1-D
+    // internally, so any rank keeps the single batched inverse.
+    ArrayRef<int64_t> shape = tensorType.getShape();
+    SmallVector<Value> dynExtentsStorage;
+    for (int64_t i = 0; i < tensorType.getRank(); ++i) {
+      if (tensorType.isDynamicDim(i)) {
+        Value idx = arith::ConstantIndexOp::create(b, i);
+        dynExtentsStorage.push_back(
+            tensor::DimOp::create(b, adaptor.getInput(), idx));
+      }
+    }
     ValueRange dynExtents = dynExtentsStorage;
-    auto colType = RankedTensorType::get({n}, fieldType);
+    auto colType = RankedTensorType::get(shape, fieldType);
 
     PointKind inKind = inputPti.getPointKind();
     if (inKind != PointKind::kJacobian && inKind != PointKind::kXYZZ) {
@@ -473,7 +468,7 @@ private:
 
     // Fused output: batch inverse → single tensor.generate that computes
     // affine coordinates and assembles the output point in one pass.
-    auto outputTensorType = RankedTensorType::get({n}, cast<Type>(outputPti));
+    auto outputTensorType = RankedTensorType::get(shape, cast<Type>(outputPti));
     Value result;
     if (inKind == PointKind::kJacobian) {
       Value colZ = makeCol(2);

--- a/tests/Dialect/EllipticCurve/elliptic_curve_to_field.mlir
+++ b/tests/Dialect/EllipticCurve/elliptic_curve_to_field.mlir
@@ -217,6 +217,22 @@ func.func @test_batch_xyzz_to_affine(%arg0: tensor<4x!xyzzm>) -> tensor<4x!affin
   return %result : tensor<4x!affinem>
 }
 
+// Rank-2 →affine keeps the single batch field.inverse: field.inverse
+// collapses the multi-dim column internally, so higher ranks don't degrade
+// to a per-element inverse.
+// CHECK-LABEL: @test_batch_rank2_jacobian_to_affine
+func.func @test_batch_rank2_jacobian_to_affine(%arg0: tensor<2x3x!jacobianm>) -> tensor<2x3x!affinem> {
+  // CHECK-NOT: elliptic_curve.convert_point_type
+  // CHECK: tensor.generate
+  // CHECK: elliptic_curve.to_coords
+  // CHECK: field.inverse
+  // CHECK-NOT: field.inverse
+  // CHECK: tensor.generate
+  // CHECK: elliptic_curve.from_coords
+  %result = elliptic_curve.convert_point_type %arg0 : tensor<2x3x!jacobianm> -> tensor<2x3x!affinem>
+  return %result : tensor<2x3x!affinem>
+}
+
 // Single-element tensor convert_point_type takes the scalar path in inline
 // mode too: extract, scalar conversion, wrap back. The batch field.inverse
 // path saves nothing at N = 1, and the inline scalar codegen cannot consume


### PR DESCRIPTION
## Description

Follow-up to #379. The jacobian/xyzz → affine tensor lowering there matched only rank-1 — `rewriteTensorToAffine` bailed on `rank != 1`, so a higher-rank →affine fell through to the element-wise path and did N scalar `field.inverse` calls instead of one batched inverse, losing Montgomery's trick (3(N-1) muls + 1 inverse vs N inverses).

Nothing about rank>1 is actually different: `field.inverse` already collapses a multi-dim column to 1-D internally for the batch loop, and the `tensor.generate` bodies index by the full `ivs` range. So the coordinate columns and the output just adopt the point tensor's shape, the internal `rank != 1` bailout goes away, and the batch gate widens from `== 1` to `> 0` (which is what it was before #379 narrowed it). No producer emits a rank>1 →affine today (XLA CPU tiling yields rank-1 tiles), so this is latent-path hardening plus the optimization if one appears.

## Related Issues/PRs

Follow-up to #379 (which was merged). Same file; this only touches the →affine batch path.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline