### PR TITLE
fix(dialect/field): lower value-path tensor reinterpret in ExtFieldToLLVM

### DIFF
--- a/prime_ir/Dialect/Field/Conversions/ExtFieldToLLVM/ExtFieldToLLVM.cpp
+++ b/prime_ir/Dialect/Field/Conversions/ExtFieldToLLVM/ExtFieldToLLVM.cpp
@@ -144,6 +144,29 @@ struct ConvertBitcast : public ConvertOpToLLVMPattern<BitcastOp> {
       rewriter.replaceOp(op, adaptor.getInput());
       return success();
     }
+
+    // Ranked-tensor reinterpret in a value path (e.g. the GPU MLIR emitter,
+    // which — unlike the CPU fusion compiler — has no bufferization stage that
+    // would turn this into a memref bitcast). LowerTensors has already backed
+    // the tensor by a raw !llvm.ptr through unrealized_conversion_cast on both
+    // ends, so a count-changing base<->EF bitcast is a pure buffer-identity
+    // reinterpret: the input holds N*degIn storage integers and the output the
+    // same N*degOut, sharing one base pointer. Forward the converted operand as
+    // an unrealized_conversion_cast to the converted output type; the
+    // reconcile-unrealized-casts finalization collapses the
+    //   ptr -> tensor<in> -> tensor<out> -> ptr
+    // chain back to the original pointer (same idiom as
+    // SpecializeBinaryFieldToX86). The memref path above is handled separately
+    // because it must rebuild the descriptor; a tensor in this value path
+    // carries no descriptor.
+    if (isa<RankedTensorType>(inputType)) {
+      Value cast = UnrealizedConversionCastOp::create(rewriter, op.getLoc(),
+                                                      convertedOutputType,
+                                                      adaptor.getInput())
+                       .getResult(0);
+      rewriter.replaceOp(op, cast);
+      return success();
+    }
     return failure();
   }
 
@@ -286,11 +309,21 @@ void populateExtFieldToLLVMTypeConversion(LLVMTypeConverter &typeConverter) {
   // ConvertBitcast rebuilds the descriptor with correct sizes/strides/offset.
   typeConverter.addConversion(
       [](RankedTensorType tensorType) -> std::optional<Type> {
-        auto efType = dyn_cast<ExtensionFieldType>(tensorType.getElementType());
-        if (!efType)
-          return std::nullopt;
-        return RankedTensorType::get(tensorType.getShape(),
-                                     convertExtFieldType(efType));
+        if (auto efType =
+                dyn_cast<ExtensionFieldType>(tensorType.getElementType()))
+          return RankedTensorType::get(tensorType.getShape(),
+                                       convertExtFieldType(efType));
+        // Integer-element tensors are the non-EF side of a count-changing
+        // reinterpret bitcast in the GPU value path (the packed constant pool:
+        // tensor<N*deg x iK> <-> tensor<N x !EF>). They carry no EF element to
+        // lower, but ConvertBitcast still needs its adaptor built, so map them
+        // to themselves. Without an identity conversion here the base
+        // ConvertOpToLLVMPattern bails ("failed to legalize") before the
+        // pattern runs. These tensors are backed by a raw pointer and are
+        // removed by reconcile-unrealized-casts after lowering (xla#163).
+        if (isa<IntegerType>(tensorType.getElementType()))
+          return tensorType;
+        return std::nullopt;
       });
   typeConverter.addConversion(
       [](UnrankedTensorType tensorType) -> std::optional<Type> {

--- a/tests/Dialect/Field/ext_field_to_llvm_tensor_reinterpret.mlir
+++ b/tests/Dialect/Field/ext_field_to_llvm_tensor_reinterpret.mlir
@@ -1,0 +1,60 @@
+// Copyright 2025 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// RUN: prime-ir-opt --convert-ext-field-to-llvm -reconcile-unrealized-casts \
+// RUN:   -split-input-file %s | FileCheck %s
+
+// Value-path (no bufferization) tensor reinterpret bitcast — regression guard
+// for xla#163.  The GPU MLIR emitter lowers tensors to raw !llvm.ptr loads
+// (LowerTensors) with no bufferization stage, so a count-changing base<->EF
+// reinterpret survives as `field.bitcast` on a pointer-backed tensor rather than
+// as a memref bitcast.  ConvertBitcast forwards it as an unrealized cast to the
+// converted element type, and reconcile-unrealized-casts collapses the
+//   ptr -> tensor<in> -> tensor<out> -> ptr
+// chain back to the original pointer — the reinterpret is a pure buffer
+// identity (input and output hold the same total storage integers).
+
+!PF  = !field.pf<7:i32>
+!EF2 = !field.ef<2x!PF, 6:i32>
+
+// int -> EF: the packed EF constant-pool direction that fails on GPU without
+// the fix (tensor<4xi32> is 2 EF elements of degree 2).
+// CHECK-LABEL: @bitcast_tensor_i32_to_ef2
+//  CHECK-SAME: (%[[PTR:.+]]: !llvm.ptr)
+//   CHECK-NOT:   field.bitcast
+//       CHECK:   return %[[PTR]] : !llvm.ptr
+func.func @bitcast_tensor_i32_to_ef2(%ptr: !llvm.ptr) -> !llvm.ptr {
+  %t = builtin.unrealized_conversion_cast %ptr : !llvm.ptr to tensor<4xi32>
+  %b = field.bitcast %t : tensor<4xi32> -> tensor<2x!EF2>
+  %r = builtin.unrealized_conversion_cast %b : tensor<2x!EF2> to !llvm.ptr
+  return %r : !llvm.ptr
+}
+
+// -----
+
+!PF  = !field.pf<7:i32>
+!EF2 = !field.ef<2x!PF, 6:i32>
+
+// EF -> int: the reverse direction.
+// CHECK-LABEL: @bitcast_tensor_ef2_to_i32
+//  CHECK-SAME: (%[[PTR:.+]]: !llvm.ptr)
+//   CHECK-NOT:   field.bitcast
+//       CHECK:   return %[[PTR]] : !llvm.ptr
+func.func @bitcast_tensor_ef2_to_i32(%ptr: !llvm.ptr) -> !llvm.ptr {
+  %t = builtin.unrealized_conversion_cast %ptr : !llvm.ptr to tensor<2x!EF2>
+  %b = field.bitcast %t : tensor<2x!EF2> -> tensor<4xi32>
+  %r = builtin.unrealized_conversion_cast %b : tensor<4xi32> to !llvm.ptr
+  return %r : !llvm.ptr
+}


### PR DESCRIPTION
## What

`ExtFieldToLLVM::ConvertBitcast` gains a ranked-tensor (value-path) case for
count-changing base↔extension-field `field.bitcast`, so the packed EF constant
pool lowers on the XLA GPU MLIR emitter, which has no bufferization stage.

## Why

A count-changing whole-tensor `field.bitcast` (`tensor<N*deg x iK>` ↔
`tensor<N x EF>`) is a pure buffer-identity reinterpret — input and output hold
the same total storage integers. prime_ir lowers it zero-copy by deferring the
reinterpret to a **memref bitcast** produced by bufferization. That only lands
on the **CPU** fusion compiler, which runs `OneShotBufferize` and registers the
field `BufferizableOpInterface`. The **XLA GPU** MLIR emitter lowers tensors
straight to `!llvm.ptr` loads via `LowerTensors` and runs **no** bufferization,
so the bitcast reaches `ExtFieldToLLVM` as a pointer-backed tensor.
`ConvertBitcast` handled only the scalar and memref cases, so the tensor form
was left unlegalized and died at `LowerToLLVMGPU` ("failed to legalize
operation 'field.bitcast'").

## How

Two changes make the value path a pure buffer-identity reinterpret:

1. **Identity type-conversion for integer-element ranked tensors** in
   `populateExtFieldToLLVMTypeConversion`. This is the real unlock: without a
   type-converter entry for the `tensor<N*deg x iK>` operand, the
   dialect-conversion framework cannot build `ConvertBitcast`'s adaptor, so the
   pattern never runs and the op is left untouched (not "matched and failed").
2. **Ranked-tensor case in `ConvertBitcast`** — forward the converted operand
   as an `unrealized_conversion_cast` to the converted output type.
   `reconcile-unrealized-casts` collapses `ptr → tensor<in> → tensor<out> →
   ptr` back to the base pointer (same idiom as `SpecializeBinaryFieldToX86`).
   `addIllegalOp<BitcastOp>` is not needed — natural result-type illegality
   suffices once the operand converts.

## Test

`tests/Dialect/Field/ext_field_to_llvm_tensor_reinterpret.mlir` — a lit
regression guard covering both reinterpret directions (int→EF, EF→int),
asserting the `field.bitcast` is gone and the pointer flows through. It runs
under `--convert-ext-field-to-llvm -reconcile-unrealized-casts` (the standalone
pass the GPU pipeline uses; the generic `-convert-to-llvm` does not force the
tensor legalization). Also verified on the real shard17 `ExtFieldToLLVM`-input
IR: 0 `field.bitcast` remaining, consumers GEP directly on the base pointer.

## Context

Unblocks the `field.bitcast` legalization portion of fractalyze/xla#163. The
remaining A/B blocker there is a separate HLO layout-assignment desync tracked
as #117/#150 work — not this change. A pin bump into xla follows once this
merges.
