### PR TITLE
feat(dialect/field): enable binary field arithmetic + bump zk_dtypes

### DIFF
--- a/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BUILD.bazel
+++ b/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BUILD.bazel
@@ -54,6 +54,10 @@ prime_ir_cc_library(
 prime_ir_cc_library(
     name = "BinaryFieldTables",
     hdrs = ["BinaryFieldTables.h"],
+    deps = [
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+    ],
 )
 
 prime_ir_cc_library(

--- a/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldCodeGen.cpp
+++ b/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldCodeGen.cpp
@@ -162,12 +162,35 @@ BinaryFieldCodeGen BinaryFieldCodeGen::one(BinaryFieldType bfType,
   return constant(bfType, 1, builder);
 }
 
-uint64_t BinaryFieldCodeGen::getTowerAlpha(unsigned towerLevel) const {
-  // Tower α constants are defined in BinaryFieldTables.h
-  // These are the elements satisfying x² + x + α = 0
-  // at each tower level. Level 0 has no α (it's GF(2)).
-  assert(towerLevel >= 1 && towerLevel <= 7 && "Tower level must be 1-7 for α");
-  return kTowerAlphas[towerLevel];
+Value BinaryFieldCodeGen::mulXTower(Value a, unsigned towerLevel) const {
+  // Multiply by the generator Xₖ of GF(2^(2ᵏ)) = subfield[X]/(X² + βₖ₋₁·X + 1):
+  //   (a₀ + a₁·X)·X = a₁ + (a₀ + βₖ₋₁·a₁)·X
+  // where βₖ₋₁·(·) recurses as mulXTower one level down. Base: the generator of
+  // GF(2) is 1, so multiply-by-generator is the identity.
+  if (towerLevel == 0) {
+    return a;
+  }
+
+  unsigned halfBits = 1u << (towerLevel - 1);
+  IntegerType halfType = IntegerType::get(builder_.getContext(), halfBits);
+  IntegerType fullType = IntegerType::get(builder_.getContext(), halfBits * 2);
+
+  Value a0 = arith::TruncIOp::create(builder_, halfType, a);
+  Value halfBitsConst = arith::ConstantIntOp::create(
+      builder_, static_cast<int64_t>(halfBits), fullType.getWidth());
+  Value a1 = arith::TruncIOp::create(
+      builder_, halfType, arith::ShRUIOp::create(builder_, a, halfBitsConst));
+
+  // lo = a₁,  hi = a₀ + βₖ₋₁·a₁
+  Value resultLo = a1;
+  Value resultHi =
+      arith::XOrIOp::create(builder_, a0, mulXTower(a1, towerLevel - 1));
+
+  Value resultLoExt = arith::ExtUIOp::create(builder_, fullType, resultLo);
+  Value resultHiExt = arith::ExtUIOp::create(builder_, fullType, resultHi);
+  Value resultHiShifted =
+      arith::ShLIOp::create(builder_, resultHiExt, halfBitsConst);
+  return arith::OrIOp::create(builder_, resultLoExt, resultHiShifted);
 }
 
 Value BinaryFieldCodeGen::mulTower(Value a, Value b,
@@ -177,20 +200,14 @@ Value BinaryFieldCodeGen::mulTower(Value a, Value b,
     return arith::AndIOp::create(builder_, a, b);
   }
 
-  // Recursive case: use Karatsuba-style multiplication
-  // For GF(2^(2^k)), we have elements a = a₀ + a₁*x and b = b₀ + b₁*x
-  // where x² + x + α = ₀
+  // Recursive case: Karatsuba over the Fan-Paar tower. For GF(2^(2ᵏ)) with
+  // a = a₀ + a₁*x, b = b₀ + b₁*x and reduction x² = βₖ₋₁*x + 1:
   //
-  // Product: a*b = (a₀*b₀ + a₁*b₁*α) + (a₀*b₁ + a₁*b₀ + a₁*b₁)*x
+  //   a*b = (a₀*b₀ + a₁*b₁) + (a₀*b₁ + a₁*b₀ + βₖ₋₁*a₁*b₁)*x
   //
-  // Using Karatsuba:
-  // m₀ = a₀*b₀
-  // m₁ = a₁*b₁
-  // m₂ = (a₀+a₁)*(b₀+b₁)
-  // result_lo = m₀ + m₁*α
-  // result_hi = m₂ + m₀     (= a₀*b₁ + a₁*b₀ + a₁*b₁)
-  // Note m₂ + m₀ = a₀b₁ + a₁b₀ + a₁b₁, NOT m₂ + m₀ + m₁ (that cancels the
-  // a₁b₁ the x² = x + α fold contributes to the high term).
+  // Using Karatsuba products m₀ = a₀*b₀, m₁ = a₁*b₁, m₂ = (a₀+a₁)*(b₀+b₁):
+  // result_lo = m₀ + m₁                    (constant term 1)
+  // result_hi = (m₂ + m₀ + m₁) + βₖ₋₁*m₁   (m₂+m₀+m₁ = a₀b₁+a₁b₀; βₖ₋₁* = mulX)
 
   unsigned halfBits = 1u << (towerLevel - 1);
   IntegerType halfType = IntegerType::get(builder_.getContext(), halfBits);
@@ -214,18 +231,14 @@ Value BinaryFieldCodeGen::mulTower(Value a, Value b,
   Value b0Xb1 = arith::XOrIOp::create(builder_, b0, b1);
   Value m2 = mulTower(a0Xa1, b0Xb1, towerLevel - 1);
 
-  // Get α for this tower level
-  // TowerAlpha<k> is the α used in GF(2^(2ᵏ))
-  uint64_t alpha = getTowerAlpha(towerLevel);
-  Value alphaConst = arith::ConstantIntOp::create(
-      builder_, static_cast<int64_t>(alpha), halfType.getWidth());
+  // result_lo = m₀ + m₁
+  Value resultLo = arith::XOrIOp::create(builder_, m0, m1);
 
-  // result_lo = m₀ + m₁*α
-  Value m1Alpha = mulTower(m1, alphaConst, towerLevel - 1);
-  Value resultLo = arith::XOrIOp::create(builder_, m0, m1Alpha);
-
-  // result_hi = m₂ + m₀
-  Value resultHi = arith::XOrIOp::create(builder_, m2, m0);
+  // result_hi = (m₂ + m₀ + m₁) + βₖ₋₁·m₁
+  Value m2Xm0 = arith::XOrIOp::create(builder_, m2, m0);
+  Value crossTerm = arith::XOrIOp::create(builder_, m2Xm0, m1);
+  Value resultHi =
+      arith::XOrIOp::create(builder_, crossTerm, mulXTower(m1, towerLevel - 1));
 
   // Combine: result = result_lo | (result_hi << halfBits)
   Value resultLoExt = arith::ExtUIOp::create(builder_, fullType, resultLo);
@@ -241,9 +254,9 @@ Value BinaryFieldCodeGen::squareTower(Value a, unsigned towerLevel) const {
     return a;
   }
 
-  // For GF(2^(2ᵏ)), element a = a₀ + a1*x where x² + x + α = 0
-  // a² = a₀² + a₁²*x² = a₀² + a₁²*(x + α)
-  //     = (a₀² + a₁²*α) + a₁²*x
+  // For GF(2^(2ᵏ)), element a = a₀ + a1*x where x² = βₖ₋₁*x + 1
+  // a² = a₀² + a₁²*x² = a₀² + a₁²*(βₖ₋₁*x + 1)
+  //     = (a₀² + a₁²) + βₖ₋₁*a₁²*x
 
   unsigned halfBits = 1u << (towerLevel - 1);
   IntegerType halfType = IntegerType::get(builder_.getContext(), halfBits);
@@ -260,18 +273,11 @@ Value BinaryFieldCodeGen::squareTower(Value a, unsigned towerLevel) const {
   Value a0Sq = squareTower(a0, towerLevel - 1);
   Value a1Sq = squareTower(a1, towerLevel - 1);
 
-  // Get α for this tower level
-  // TowerAlpha<k> is the α used in GF(2^(2ᵏ))
-  uint64_t alpha = getTowerAlpha(towerLevel);
-  Value alphaConst = arith::ConstantIntOp::create(
-      builder_, static_cast<int64_t>(alpha), halfType.getWidth());
+  // result_lo = a₀² + a₁²          (constant term 1)
+  Value resultLo = arith::XOrIOp::create(builder_, a0Sq, a1Sq);
 
-  // result_lo = a₀² + a1²*α
-  Value a1SqAlpha = mulTower(a1Sq, alphaConst, towerLevel - 1);
-  Value resultLo = arith::XOrIOp::create(builder_, a0Sq, a1SqAlpha);
-
-  // result_hi = a1²
-  Value resultHi = a1Sq;
+  // result_hi = βₖ₋₁·a₁²
+  Value resultHi = mulXTower(a1Sq, towerLevel - 1);
 
   // Combine: result = result_lo | (result_hi << halfBits)
   Value resultLoExt = arith::ExtUIOp::create(builder_, fullType, resultLo);

--- a/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldCodeGen.h
+++ b/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldCodeGen.h
@@ -92,9 +92,12 @@ private:
   // Recursive squaring for tower level k
   Value squareTower(Value a, unsigned towerLevel) const;
 
-  // Get the α constant for tower level k
-  // Alpha is the element satisfying x² + x + α = 0
-  uint64_t getTowerAlpha(unsigned towerLevel) const;
+  // Multiply a tower-level-k element by that level's generator βₖ (the root X
+  // of the level-k defining polynomial). This is the Fan-Paar tower's
+  // "multiply by βₖ₋₁" one level up: the linear coefficient of the reduction
+  // X² + βₖ₋₁·X + 1 is a subfield element, not a stored constant, so it is
+  // realized recursively rather than as a multiply by an α table entry.
+  Value mulXTower(Value a, unsigned towerLevel) const;
 
   // Lookup table-based inverse for bf<8> (tower level 3)
   // Uses O(1) table lookup instead of O(n) Fermat computation

--- a/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldTables.h
+++ b/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldTables.h
@@ -26,33 +26,19 @@ limitations under the License.
 namespace mlir::prime_ir::field {
 
 //===----------------------------------------------------------------------===//
-// Tower Alpha Constants
-//===----------------------------------------------------------------------===//
-//
-// Tower alpha constants from zk_dtypes.
-// These are the elements satisfying x² + x + α = 0 at each tower level.
-// Level 0 (GF(2)) has no α.
-
-constexpr uint64_t kTowerAlphas[8] = {
-    0,                      // Level 0: GF(2), no extension
-    1,                      // Level 1: x² + x + 1
-    2,                      // Level 2: x² + x + 2
-    8,                      // Level 3: x² + x + 8
-    128,                    // Level 4: x² + x + 128
-    32768,                  // Level 5: x² + x + 32768
-    2147483648ULL,          // Level 6: x² + x + 2³¹
-    9223372036854775808ULL, // Level 7: x² + x + 2⁶³
-};
-
-//===----------------------------------------------------------------------===//
 // Tower <-> AES Field Isomorphism Tables
 //===----------------------------------------------------------------------===//
 //
-// The AES field uses the irreducible polynomial x⁸ + x⁴ + x³ + x + 1 (0x11B)
-// Our binary tower field at level 3 uses recursive extension polynomials:
-//   Level 1: X² + X + 1 (α = 1)
-//   Level 2: X² + X + 2 (α = 2)
-//   Level 3: X² + X + 8 (α = 8)
+// The F₂-linear isomorphism between the Fan-Paar/Binius canonical GF(2^8) tower
+// (level k: subfield[X]/(X² + βₖ₋₁·X + 1)) and the standard AES field
+// (x⁸+x⁴+x³+x+1, 0x11B) — the field vgf2p8mulb multiplies in. These are lifted
+// from Binius, which uses this same canonical tower, so they already match the
+// generic BinaryFieldToArith lowering.
+//
+// Independently regenerated and verified against this tower: the full GFNI path
+// affine(gf2p8mul(affine(a), affine(b)), a2t) equals the tower product for all
+// 65536 (a,b) pairs on GFNI hardware; the matrices are byte-identical to these
+// Binius-sourced values.
 //
 // Source: Binius project
 // - binius/crates/field/src/arch/x86_64/gfni/gfni_arithmetics.rs

--- a/prime_ir/Dialect/Field/IR/FieldTypes.cpp
+++ b/prime_ir/Dialect/Field/IR/FieldTypes.cpp
@@ -248,6 +248,19 @@ void BinaryFieldType::print(AsmPrinter &printer) const {
   printer << ">";
 }
 
+// FieldTypeInterface. A binary field is a leaf in prime-ir's field-type
+// algebra: its GF(2^(2^level)) tower is internal to BinaryFieldToArith, not a
+// prime-field coefficient decomposition. So, like a prime field, attr-shape is
+// empty and degree over the prime field is 1 (keeping the invariant
+// getDegreeOverPrime == product(getAttrShape)). Declaring the interface is what
+// lets passes gated on it (e.g. stablehlo's ConvertFieldMul) treat a binary
+// multiply as a field op instead of skipping it.
+bool BinaryFieldType::isMontgomery() const { return false; }
+
+SmallVector<int64_t> BinaryFieldType::getAttrShape() const { return {}; }
+
+unsigned BinaryFieldType::getDegreeOverPrime() const { return 1; }
+
 llvm::TypeSize BinaryFieldType::getTypeSizeInBits(
     DataLayout const &, llvm::ArrayRef<DataLayoutEntryInterface>) const {
   return llvm::TypeSize::getFixed(getTypeSizeInBits());

--- a/prime_ir/Dialect/Field/IR/FieldTypes.td
+++ b/prime_ir/Dialect/Field/IR/FieldTypes.td
@@ -108,6 +108,7 @@ def Field_PrimeFieldType : Field_Type<"PrimeField", "pf", [
 def Field_BinaryFieldType : Field_Type<"BinaryField", "bf", [
   MemRefElementTypeInterface,
   VectorElementTypeInterface,
+  DeclareTypeInterfaceMethods<FieldTypeInterface>,
   DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
   DeclareTypeInterfaceMethods<ConstantLikeInterface>
   ]> {

--- a/tests/Dialect/Field/BUILD.bazel
+++ b/tests/Dialect/Field/BUILD.bazel
@@ -37,6 +37,17 @@ prime_ir_cc_test(
 )
 
 prime_ir_cc_test(
+    name = "BinaryFieldAesTablesTest",
+    srcs = ["BinaryFieldAesTablesTest.cpp"],
+    deps = [
+        "//prime_ir/Dialect/Field/Conversions/BinaryFieldToArith:BinaryFieldTables",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "@zk_dtypes//zk_dtypes:binary_field",
+    ],
+)
+
+prime_ir_cc_test(
     name = "PrimeFieldOperationTest",
     srcs = ["PrimeFieldOperationTest.cpp"],
     deps = [

--- a/tests/Dialect/Field/BinaryFieldAesTablesTest.cpp
+++ b/tests/Dialect/Field/BinaryFieldAesTablesTest.cpp
@@ -1,0 +1,96 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// Guards the Tower<->AES isomorphism tables used by the GFNI (x86) and PMULL
+// (ARM) binary-field specializations. The GFNI/ARM multiply computes
+//   from_aes( aes_mul( to_aes(a), to_aes(b) ) )
+// so the tables MUST implement a field isomorphism between the Fan-Paar
+// canonical GF(2^8) tower (the field zk_dtypes multiplies in) and the AES field
+// (x^8+x^4+x^3+x+1, 0x11B — what vgf2p8mulb uses). Otherwise the specialized
+// paths silently disagree with the portable BinaryFieldToArith lowering. This
+// runs pure host arithmetic, so it validates the tables without GFNI hardware.
+
+#include <cstdint>
+
+#include "gtest/gtest.h"
+#include "prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldTables.h"
+#include "zk_dtypes/include/field/binary_field.h"
+
+namespace mlir::prime_ir::field {
+namespace {
+
+// GF(2^8) tower multiply — the field the codegen targets.
+uint8_t towerMul(uint8_t a, uint8_t b) {
+  return (zk_dtypes::BinaryFieldT3::FromUnchecked(a) *
+          zk_dtypes::BinaryFieldT3::FromUnchecked(b))
+      .value();
+}
+
+// AES field multiply mod x^8+x^4+x^3+x+1 (0x11B), the vgf2p8mulb field.
+uint8_t aesMul(uint8_t a, uint8_t b) {
+  uint8_t p = 0;
+  for (int i = 0; i < 8; ++i) {
+    if (b & 1)
+      p ^= a;
+    bool hi = a & 0x80;
+    a <<= 1;
+    if (hi)
+      a ^= 0x1b;
+    b >>= 1;
+  }
+  return p;
+}
+
+// vgf2p8affineqb semantics with imm8=0: output bit i is the parity of
+// (matrix qword byte [7 - i]) AND the input byte. Mirrors the hardware op the
+// packed matrix is consumed by.
+uint8_t affine(const uint8_t (&m)[8], uint8_t x) {
+  uint8_t out = 0;
+  for (int i = 0; i < 8; ++i)
+    out |= static_cast<uint8_t>(__builtin_parity(m[7 - i] & x) << i);
+  return out;
+}
+
+// The scalar lookup table must be a field isomorphism tower -> AES.
+TEST(BinaryFieldAesTables, LookupIsFieldIsomorphism) {
+  bool seen[256] = {false};
+  for (int x = 0; x < 256; ++x) {
+    ASSERT_FALSE(seen[kTowerToAesLookupTable[x]]) << "not a bijection at " << x;
+    seen[kTowerToAesLookupTable[x]] = true;
+  }
+  ASSERT_EQ(kTowerToAesLookupTable[0], 0);
+  ASSERT_EQ(kTowerToAesLookupTable[1], 1);
+  for (int a = 0; a < 256; ++a)
+    for (int b = 0; b < 256; ++b)
+      ASSERT_EQ(kTowerToAesLookupTable[towerMul(a, b)],
+                aesMul(kTowerToAesLookupTable[a], kTowerToAesLookupTable[b]))
+          << "homomorphism fails at a=" << a << " b=" << b;
+}
+
+// The GFNI affine matrices must realize the same map as the lookup table (and
+// invert each other), under the vgf2p8affineqb bit convention.
+TEST(BinaryFieldAesTables, MatricesMatchLookupUnderGfniConvention) {
+  for (int x = 0; x < 256; ++x) {
+    EXPECT_EQ(affine(kTowerToAesMatrix, static_cast<uint8_t>(x)),
+              kTowerToAesLookupTable[x])
+        << "tower->aes matrix disagrees with lookup at " << x;
+    EXPECT_EQ(affine(kAesToTowerMatrix, kTowerToAesLookupTable[x]),
+              static_cast<uint8_t>(x))
+        << "aes->tower matrix is not the inverse at " << x;
+  }
+}
+
+} // namespace
+} // namespace mlir::prime_ir::field

--- a/tests/Dialect/Field/binary_field_runner.mlir
+++ b/tests/Dialect/Field/binary_field_runner.mlir
@@ -41,16 +41,13 @@ func.func @test_bf8_add() {
   func.call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
   return
 }
-// CHECK: [6]
+// CHECK: {{^}}[6]
 
-// Test: BF8 multiplication using tower field arithmetic
-// In tower field GF(2^8) with tower construction:
-//   Level 1: X² + X + 1 (α = 1), field GF(4)
-//   Level 2: X² + X + 2 (α = 2), field GF(16)
-//   Level 3: X² + X + 8 (α = 8), field GF(256)
-// In GF(4): 2 represents ω, 3 represents ω+1
-//   ω * (ω+1) = ω² + ω = (ω+1) + ω = 1
-// Since 2 and 3 embed in lower half of GF(256): 2 * 3 = 1
+// Test: BF8 multiplication using tower field arithmetic.
+// Fan-Paar/Binius canonical tower GF(2^8): each level GF(2^(2ᵏ)) =
+// subfield[X]/(X² + βₖ₋₁·X + 1), βₖ₋₁ the subfield generator.
+// 2 and 3 live in the GF(4) subfield (β₀ = 1 ⇒ X² + X + 1, unchanged across
+// towers): 2 = ω, 3 = ω+1, ω·(ω+1) = ω²+ω = (ω+1)+ω = 1. So 2 * 3 = 1.
 func.func @test_bf8_mul() {
   %a = field.constant 2 : !BF8
   %b = field.constant 3 : !BF8
@@ -64,7 +61,7 @@ func.func @test_bf8_mul() {
   func.call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
   return
 }
-// CHECK: [1]
+// CHECK: {{^}}[1]
 
 // Test: BF8 squaring
 // In GF(4): 3 = ω+1, and (ω+1)² = ω² + 1 = (ω+1) + 1 = ω = 2
@@ -81,7 +78,7 @@ func.func @test_bf8_square() {
   func.call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
   return
 }
-// CHECK: [2]
+// CHECK: {{^}}[2]
 
 // Test: BF8 double (should be 0 in characteristic 2)
 // 2 * x = x + x = 0 for all x in GF(2ⁿ)
@@ -97,12 +94,10 @@ func.func @test_bf8_double() {
   func.call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
   return
 }
-// CHECK: [0]
+// CHECK: {{^}}[0]
 
-// Test: BF8 self-multiply exercises the x² = x + α high-term fold.
-// 3 = ω+1 in the GF(4) subfield, so 3*3 = (ω+1)² = ω = 2 (= square(3)).
-// A wrong Karatsuba high term (m₂+m₀+m₁ instead of m₂+m₀) drops the a₁b₁
-// the fold contributes, making 3 a zero-divisor (3*3 = 0).
+// Test: BF8 self-multiply. 3 = ω+1 in the GF(4) subfield, so 3*3 = (ω+1)² =
+// ω = 2 (= square(3)). Subfield-only, so tower-independent.
 func.func @test_bf8_mul_self() {
   %a = field.constant 3 : !BF8
   %c = field.mul %a, %a : !BF8
@@ -115,7 +110,42 @@ func.func @test_bf8_mul_self() {
   func.call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
   return
 }
-// CHECK: [2]
+// CHECK: {{^}}[2]
+
+// Test: BF8 multiply where operands span tower level ≥ 2, so the result
+// distinguishes the Fan-Paar tower from the previous x²+x+α tower. 5 spans
+// GF(16); 5 * 3 = 15 (0x0f) in the canonical tower (the old tower gave 6).
+// This is the case that a bare zk_dtypes bump silently broke — every other
+// case here is subfield-only and agrees across towers.
+func.func @test_bf8_mul_cross() {
+  %a = field.constant 5 : !BF8
+  %b = field.constant 3 : !BF8
+  %c = field.mul %a, %b : !BF8
+
+  %result_i8 = field.bitcast %c : !BF8 -> i8
+  %result = arith.extui %result_i8 : i8 to i32
+  %tensor = tensor.from_elements %result : tensor<1xi32>
+  %buffer = bufferization.to_buffer %tensor : tensor<1xi32> to memref<1xi32>
+  %cast = memref.cast %buffer : memref<1xi32> to memref<*xi32>
+  func.call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
+  return
+}
+// CHECK: {{^}}[15]
+
+// Test: BF8 square spanning level ≥ 2. 5² = 8 in the canonical tower.
+func.func @test_bf8_square_cross() {
+  %a = field.constant 5 : !BF8
+  %c = field.square %a : !BF8
+
+  %result_i8 = field.bitcast %c : !BF8 -> i8
+  %result = arith.extui %result_i8 : i8 to i32
+  %tensor = tensor.from_elements %result : tensor<1xi32>
+  %buffer = bufferization.to_buffer %tensor : tensor<1xi32> to memref<1xi32>
+  %cast = memref.cast %buffer : memref<1xi32> to memref<*xi32>
+  func.call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
+  return
+}
+// CHECK: {{^}}[8]
 
 // Test: BF128 (GF(2^128)) multiplication on the portable tower path.
 // 2 and 3 embed in the GF(4) subfield, so 2 * 3 = 1 at every tower level.
@@ -132,7 +162,7 @@ func.func @test_bf128_mul() {
   func.call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
   return
 }
-// CHECK: [1]
+// CHECK: {{^}}[1]
 
 // Test: BF128 self-multiply — 3 * 3 = 2 (zero-divisor guard at the top level).
 func.func @test_bf128_mul_self() {
@@ -147,7 +177,24 @@ func.func @test_bf128_mul_self() {
   func.call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
   return
 }
-// CHECK: [2]
+// CHECK: {{^}}[2]
+
+// Test: BF128 multiply spanning level ≥ 2 (5 and 3 embed in GF(16) ⊂ GF(2^128),
+// so 5 * 3 = 15 at the top level too — guards the full recursive tower).
+func.func @test_bf128_mul_cross() {
+  %a = field.constant 5 : !BF128
+  %b = field.constant 3 : !BF128
+  %c = field.mul %a, %b : !BF128
+
+  %result_i128 = field.bitcast %c : !BF128 -> i128
+  %result = arith.trunci %result_i128 : i128 to i32
+  %tensor = tensor.from_elements %result : tensor<1xi32>
+  %buffer = bufferization.to_buffer %tensor : tensor<1xi32> to memref<1xi32>
+  %cast = memref.cast %buffer : memref<1xi32> to memref<*xi32>
+  func.call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
+  return
+}
+// CHECK: {{^}}[15]
 
 func.func @main() {
   func.call @test_bf8_add() : () -> ()
@@ -155,7 +202,10 @@ func.func @main() {
   func.call @test_bf8_square() : () -> ()
   func.call @test_bf8_double() : () -> ()
   func.call @test_bf8_mul_self() : () -> ()
+  func.call @test_bf8_mul_cross() : () -> ()
+  func.call @test_bf8_square_cross() : () -> ()
   func.call @test_bf128_mul() : () -> ()
   func.call @test_bf128_mul_self() : () -> ()
+  func.call @test_bf128_mul_cross() : () -> ()
   return
 }

--- a/third_party/zk_dtypes/workspace.bzl
+++ b/third_party/zk_dtypes/workspace.bzl
@@ -17,8 +17,8 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def repo():
-    ZK_DTYPES_COMMIT = "760107d1e95f0af3eb1242d4f19f2d731e9e011b"
-    ZK_DTYPES_SHA256 = "c80156921eca72225667ceddf985f93640da36a487b213acd8b4a404c3617fd4"
+    ZK_DTYPES_COMMIT = "2a13226c78ba10ce94e3e380ee81c5be17fac9a7"
+    ZK_DTYPES_SHA256 = "5be5c2f424171f52192ca41a5e0cbfcf541649b2d6e992b113d856b523ed8519"
     http_archive(
         name = "zk_dtypes",
         sha256 = ZK_DTYPES_SHA256,


### PR DESCRIPTION
Closes two gaps that blocked binary-field arithmetic (ghash and every
`bf<k>`) from executing, and bumps zk_dtypes to the Fan-Paar/Binius
canonical tower (`2a13226`, zk_dtypes#148). Supersedes #382 (pin-only)
and folds in #385 (the interface half).

## 1. `BinaryFieldType` didn't implement `FieldTypeInterface`

Only prime/extension fields declared it, so passes gated on
`isa<FieldTypeInterface>` — notably stablehlo's `ConvertFieldMul` —
**skipped binary**: a binary `stablehlo.multiply` never became
`field.mul` and died at bufferization. Declare the interface with
**leaf-field** semantics (like prime fields): `isMontgomery()=false`,
`getAttrShape()={}`, `getDegreeOverPrime()=1`. A binary field's
GF(2^(2^k)) tower is internal to `BinaryFieldToArith`, not a prime-field
coefficient decomposition, so the invariant
`getDegreeOverPrime == product(getAttrShape)` holds at 1. The
interface-gated folders already guard on concrete
`PrimeFieldType`/`ExtensionFieldType`, so binary stays out of them —
full regression sweep green (108/110, 2 skipped).

## 2. Generic codegen was on the old tower

Once the op is `field.mul`, the generic `BinaryFieldToArith` lowering
computed the previous `x²+x+α` tower (hardcoded `kTowerAlphas`), while
constant-folding and the Binius-sourced GFNI/ARM AES tables already used
the canonical tower — so a pin-only bump leaves the generic path
computing a different field:

```
field.mul 5, 3 : !field.bf<3>   →  6   (should be 15)
```

Rewrite `mulTower`/`squareTower` for the Fan-Paar reduction
`X² = βₖ₋₁·X + 1` (linear coefficient = subfield generator, a recursive
`mulXTower`; constant term 1); drop `kTowerAlphas`. **AES tables
unchanged** — an independent regeneration reproduces them byte-for-byte
and a full **65536-pair GFNI hardware check** passes; only the stale
`α=1,2,8` comment is fixed, now guarded by a host field-iso test
(`BinaryFieldAesTablesTest`).

## Testing

- Full `//tests/Dialect/Field:*` + `//prime_ir/...` green.
- New `binary_field_runner` level-≥2 cases (`5·3=15`, `5²=8`) — the gap
  that let a subfield-only test pass a wrong tower.
- New `BinaryFieldAesTablesTest` — GFNI/ARM tables are a valid tower→AES
  field isomorphism (CI-safe, no GFNI hardware).

Behavioral e2e (ghash `a*b`) lands once this bumps into xla + a jaxlib
rebuild; the stablehlo-side `ConvertFieldMul` binary test is a follow-up
in that repo.

https://claude.ai/code/session_0111aA8ZkJoaHtVL6aBidtpN