### PR TITLE
feat(dialect/field): implement FieldTypeInterface on BinaryFieldType

### DIFF
--- a/prime_ir/Dialect/Field/IR/FieldTypes.cpp
+++ b/prime_ir/Dialect/Field/IR/FieldTypes.cpp
@@ -248,6 +248,20 @@ void BinaryFieldType::print(AsmPrinter &printer) const {
   printer << ">";
 }
 
+// FieldTypeInterface. A binary field is a leaf in prime-ir's field-type algebra:
+// its GF(2^(2^level)) tower structure is internal to BinaryFieldToArith and is
+// not exposed as a prime-field coefficient decomposition. So, like a prime
+// field, its attr-shape is empty and its degree over the prime field is 1
+// (the invariant getDegreeOverPrime == product(getAttrShape) is preserved).
+// Implementing the interface is what lets dtype-generic passes (e.g. stablehlo's
+// ConvertFieldMul, gated on FieldTypeInterface) treat binary multiply as a
+// field op instead of skipping it.
+bool BinaryFieldType::isMontgomery() const { return false; }
+
+SmallVector<int64_t> BinaryFieldType::getAttrShape() const { return {}; }
+
+unsigned BinaryFieldType::getDegreeOverPrime() const { return 1; }
+
 llvm::TypeSize BinaryFieldType::getTypeSizeInBits(
     DataLayout const &, llvm::ArrayRef<DataLayoutEntryInterface>) const {
   return llvm::TypeSize::getFixed(getTypeSizeInBits());

--- a/prime_ir/Dialect/Field/IR/FieldTypes.td
+++ b/prime_ir/Dialect/Field/IR/FieldTypes.td
@@ -108,6 +108,7 @@ def Field_PrimeFieldType : Field_Type<"PrimeField", "pf", [
 def Field_BinaryFieldType : Field_Type<"BinaryField", "bf", [
   MemRefElementTypeInterface,
   VectorElementTypeInterface,
+  DeclareTypeInterfaceMethods<FieldTypeInterface>,
   DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
   DeclareTypeInterfaceMethods<ConstantLikeInterface>
   ]> {


### PR DESCRIPTION
`BinaryFieldType` did not declare `FieldTypeInterface` (only prime and
extension fields did). dtype-generic passes gated on
`isa<FieldTypeInterface>` — notably stablehlo's `ConvertFieldMul` —
therefore **skipped binary fields entirely**: a binary `stablehlo.multiply`
never became `field.mul` and died at bufferization, blocking all
binary-field arithmetic (ghash and every `bf<k>`), not just one dtype.
Pinned via a `fusion_compiler=5` IR dump. Infrastructure gap that #374
(binary dtype end-to-end wiring) did not close.

## Change

Declare the interface and implement it with **leaf-field** semantics,
matching `PrimeFieldType`:

| method | value | why |
|---|---|---|
| `isMontgomery()` | `false` | characteristic 2, no Montgomery form |
| `getAttrShape()` | `{}` | leaf — no prime-extension tower shape |
| `getDegreeOverPrime()` | `1` | invariant `degree == product(attrShape)` |

A binary field's GF(2^(2^k)) tower is internal to `BinaryFieldToArith`,
not exposed as a prime-field coefficient decomposition — so it is a leaf
in the field-type algebra, exactly like a prime field (degree 1, empty
shape), **not** degree 2^k.

## Blast radius: safe

The ~8 `isa/dyn_cast<FieldTypeInterface>` sites now also match binary. The
coefficient-decomposition folders that could mishandle it already guard on
concrete types — `foldMixedBinaryOp` does `cast<ExtensionFieldType>` at
entry, and the splat fold does `isa<PrimeFieldType, ExtensionFieldType>`
(comment: *"BinaryField doesn't participate in mixed PF/EF DRR patterns"*).
`FieldToModArith` likewise dispatches on concrete `PrimeFieldType`.

## Testing

Full prime-ir regression sweep (`//prime_ir/... //tests/...`) green
(108 pass / 110, 2 skipped). No prime-ir test is added: this alters no
prime-ir behavior (binary field ops already lower via `BinaryFieldToArith`;
the interface-gated folders exclude binary). The behavioral change is
downstream — the test with teeth is a stablehlo `ConvertFieldMul` binary
case plus the ghash `a*b` e2e (needs the prime-ir pin bump + jaxlib rebuild).

Complements the Fan-Paar codegen fix (#384): that corrects the multiply
*once the op is* `field.mul`; this makes the op become `field.mul` in the
first place. Both are needed for working binary arithmetic.

https://claude.ai/code/session_0111aA8ZkJoaHtVL6aBidtpN