### PR TITLE
feat: expose BinaryFieldType to the C API and Python bindings

### DIFF
--- a/prime_ir/Dialect/Field/C/FieldTypes.cpp
+++ b/prime_ir/Dialect/Field/C/FieldTypes.cpp
@@ -49,6 +49,31 @@ bool primeIRPrimeFieldTypeIsMontgomery(MlirType type) {
 }
 
 //===----------------------------------------------------------------------===//
+// BinaryField types.
+//===----------------------------------------------------------------------===//
+
+MlirTypeID primeIRBinaryFieldTypeGetTypeID() {
+  return wrap(BinaryFieldType::getTypeID());
+}
+
+bool primeIRTypeIsABinaryField(MlirType type) {
+  return llvm::isa<BinaryFieldType>(unwrap(type));
+}
+
+MlirType primeIRBinaryFieldTypeGet(MlirContext ctx, unsigned towerLevel,
+                                   bool isGhash) {
+  return wrap(BinaryFieldType::get(unwrap(ctx), towerLevel, isGhash));
+}
+
+unsigned primeIRBinaryFieldTypeGetTowerLevel(MlirType type) {
+  return llvm::cast<BinaryFieldType>(unwrap(type)).getTowerLevel();
+}
+
+bool primeIRBinaryFieldTypeIsGhash(MlirType type) {
+  return llvm::cast<BinaryFieldType>(unwrap(type)).isGhash();
+}
+
+//===----------------------------------------------------------------------===//
 // ExtensionField types.
 // ===----------------------------------------------------------------------===//
 

--- a/prime_ir/Dialect/Field/C/FieldTypes.h
+++ b/prime_ir/Dialect/Field/C/FieldTypes.h
@@ -45,6 +45,29 @@ MLIR_CAPI_EXPORTED MlirAttribute primeIRPrimeFieldTypeGetModulus(MlirType type);
 MLIR_CAPI_EXPORTED bool primeIRPrimeFieldTypeIsMontgomery(MlirType type);
 
 //===----------------------------------------------------------------------===//
+// BinaryField types.
+//===----------------------------------------------------------------------===//
+
+// Returns the typeID of a binary field type.
+MLIR_CAPI_EXPORTED MlirTypeID primeIRBinaryFieldTypeGetTypeID(void);
+
+// Checks whether the given type is a binary field type.
+MLIR_CAPI_EXPORTED bool primeIRTypeIsABinaryField(MlirType type);
+
+// Creates a binary field type GF(2^(2^towerLevel)) in the context. When isGhash
+// is true (valid only at towerLevel 7) the type selects the flat GHASH/POLYVAL
+// basis instead of the recursive tower basis. The type is owned by the context.
+MLIR_CAPI_EXPORTED MlirType primeIRBinaryFieldTypeGet(MlirContext ctx,
+                                                      unsigned towerLevel,
+                                                      bool isGhash);
+
+// Returns the tower level of the given binary field type.
+MLIR_CAPI_EXPORTED unsigned primeIRBinaryFieldTypeGetTowerLevel(MlirType type);
+
+// Checks whether the given binary field type uses the flat GHASH basis.
+MLIR_CAPI_EXPORTED bool primeIRBinaryFieldTypeIsGhash(MlirType type);
+
+//===----------------------------------------------------------------------===//
 // ExtensionField types.
 // ===----------------------------------------------------------------------===//
 

--- a/prime_ir/Dialect/Field/Python/FieldTypes.cpp
+++ b/prime_ir/Dialect/Field/Python/FieldTypes.cpp
@@ -48,6 +48,34 @@ void PyPrimeFieldType::bindDerived(ClassTy &c) {
 }
 
 // static
+void PyBinaryFieldType::bindDerived(ClassTy &c) {
+  c.def_static(
+      "get",
+      [](unsigned towerLevel, bool isGhash,
+         DefaultingPyMlirContext context) -> PyBinaryFieldType {
+        MlirType t =
+            primeIRBinaryFieldTypeGet(context->get(), towerLevel, isGhash);
+        return PyBinaryFieldType(context->getRef(), t);
+      },
+      nb::arg("tower_level"), nb::arg("is_ghash") = false,
+      nb::arg("context") = nb::none(),
+      "Create a binary field type GF(2^(2^tower_level)); is_ghash selects the "
+      "flat GHASH basis (valid at tower_level 7 only)");
+  c.def_prop_ro(
+      "tower_level",
+      [](PyBinaryFieldType &self) -> unsigned {
+        return primeIRBinaryFieldTypeGetTowerLevel(self);
+      },
+      "Returns the tower level of the binary field type");
+  c.def_prop_ro(
+      "is_ghash",
+      [](PyBinaryFieldType &self) -> bool {
+        return primeIRBinaryFieldTypeIsGhash(self);
+      },
+      "Returns whether this uses the flat GHASH basis");
+}
+
+// static
 void PyExtensionFieldType::bindDerived(ClassTy &c) {
   c.def_static(
       "get",
@@ -112,6 +140,7 @@ void PyExtensionFieldType::bindDerived(ClassTy &c) {
 
 void populateIRTypes(nb::module_ &m) {
   PyPrimeFieldType::bind(m);
+  PyBinaryFieldType::bind(m);
   PyExtensionFieldType::bind(m);
 }
 

--- a/prime_ir/Dialect/Field/Python/FieldTypes.h
+++ b/prime_ir/Dialect/Field/Python/FieldTypes.h
@@ -36,6 +36,19 @@ public:
   static void bindDerived(ClassTy &c);
 };
 
+class PyBinaryFieldType
+    : public mlir::python::MLIR_BINDINGS_PYTHON_DOMAIN::PyConcreteType<
+          PyBinaryFieldType> {
+public:
+  static constexpr IsAFunctionTy isaFunction = primeIRTypeIsABinaryField;
+  static constexpr GetTypeIDFunctionTy getTypeIdFunction =
+      primeIRBinaryFieldTypeGetTypeID;
+  static constexpr const char *pyClassName = "BinaryFieldType";
+  using PyConcreteType::PyConcreteType;
+
+  static void bindDerived(ClassTy &c);
+};
+
 class PyExtensionFieldType
     : public mlir::python::MLIR_BINDINGS_PYTHON_DOMAIN::PyConcreteType<
           PyExtensionFieldType> {

--- a/tests/python/field_test.py
+++ b/tests/python/field_test.py
@@ -29,6 +29,25 @@ class FieldTest(absltest.TestCase):
       self.assertEqual(int(pf.modulus), BABYBEAR_MODULUS)
       self.assertTrue(pf.is_montgomery)
 
+  def testBinaryFieldTypes(self):
+    with Context() as ctx, Location.unknown():
+      field.register_dialect(ctx)
+
+      bf8 = field.BinaryFieldType.get(3, context=ctx)
+      self.assertEqual(str(bf8), "!field.bf<3>")
+      self.assertEqual(bf8.tower_level, 3)
+      self.assertFalse(bf8.is_ghash)
+
+      # is_ghash selects the flat GHASH basis at level 7; the two level-7 types
+      # are distinct (tower 2*3 = 1 vs flat 2*3 = 6).
+      tower = field.BinaryFieldType.get(7, context=ctx)
+      ghash = field.BinaryFieldType.get(7, True, ctx)
+      self.assertEqual(str(tower), "!field.bf<7>")
+      self.assertEqual(str(ghash), "!field.bf<7, ghash>")
+      self.assertFalse(tower.is_ghash)
+      self.assertTrue(ghash.is_ghash)
+      self.assertNotEqual(tower, ghash)
+
   def testExtensionFieldTypes(self):
     with Context() as ctx, Location.unknown():
       field.register_dialect(ctx)


### PR DESCRIPTION
## What

`PrimeFieldType` and `ExtensionFieldType` are reachable from the MLIR C API
(`prime_ir/Dialect/Field/C`) and the nanobind Python bindings
(`prime_ir/Dialect/Field/Python`). `BinaryFieldType` was not — so a Python
frontend had no way to construct `!field.bf<n>` / `!field.bf<7, ghash>`.

This adds, mirroring the prime/extension-field bindings:
- **C API**: `primeIRBinaryFieldTypeGet(ctx, towerLevel, isGhash)`, `…GetTypeID`,
  `primeIRTypeIsABinaryField`, `…GetTowerLevel`, `…IsGhash`.
- **Python**: `field.BinaryFieldType.get(tower_level, is_ghash=False, context=None)`
  with `tower_level` / `is_ghash` properties.
- A `field_test.py` case covering the tower vs GHASH level-7 distinction.

## Why

The JAX frontend lowers the `binary_field_ghash` numpy dtype to
`!field.bf<7, ghash>` via `field_dialect.BinaryFieldType.get(...)`; without this
binding that lowering can't build the type. First in a bottom-up chain
(prime-ir → stablehlo VHLO → XLA → JAX) wiring the flat GHASH GF(2^128) field
end to end.

https://claude.ai/code/session_018MbPZe9hdFV1nEs3qzNipw