### PR TITLE
fix(dialect/field): convert arith.select carrying binary field types

### DIFF
--- a/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldToArith.cpp
+++ b/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldToArith.cpp
@@ -477,8 +477,9 @@ struct BinaryFieldToArith : impl::BinaryFieldToArithBase<BinaryFieldToArith> {
              !isa<BinaryFieldType>(outputElemType);
     });
 
-    // Arith dialect is legal
-    target.addLegalDialect<arith::ArithDialect>();
+    // scf is blanket-legal: the structural patterns only carve in the scf
+    // ops they retype; region ops outside that set (scf.parallel, scf.forall)
+    // are not converted here.
     target.addLegalDialect<scf::SCFDialect>();
 
     // Unrealized casts involving binary field types need to be converted.

--- a/tests/Dialect/Field/binary_field_to_arith.mlir
+++ b/tests/Dialect/Field/binary_field_to_arith.mlir
@@ -18,6 +18,7 @@
 // Test binary field to arith lowering
 
 !BF8 = !field.bf<3>  // GF(2^8)
+!GHASH = !field.bf<7, ghash>  // GF(2^128), flat GHASH basis
 
 // CHECK-LABEL: @test_bf_constant
 // CHECK-SAME: () -> i8
@@ -79,4 +80,23 @@ func.func @test_bf_square(%a: !BF8) -> !BF8 {
   // CHECK: arith.ori
   %c = field.square %a : !BF8
   return %c : !BF8
+}
+
+// arith.select can carry binary-field types (e.g. from a fused HLO select);
+// it must be retyped onto the storage int.
+// CHECK-LABEL: @test_bf_select
+// CHECK-SAME: (%arg0: i1, %arg1: i8, %arg2: i8) -> i8
+func.func @test_bf_select(%c: i1, %a: !BF8, %b: !BF8) -> !BF8 {
+  // CHECK: arith.select %arg0, %arg1, %arg2 : i8
+  %s = arith.select %c, %a, %b : !BF8
+  return %s : !BF8
+}
+
+// Same, on the flat GHASH basis — i128 storage.
+// CHECK-LABEL: @test_bf_ghash_select
+// CHECK-SAME: (%arg0: i1, %arg1: i128, %arg2: i128) -> i128
+func.func @test_bf_ghash_select(%c: i1, %a: !GHASH, %b: !GHASH) -> !GHASH {
+  // CHECK: arith.select %arg0, %arg1, %arg2 : i128
+  %s = arith.select %c, %a, %b : !GHASH
+  return %s : !GHASH
 }


### PR DESCRIPTION
## What

`BinaryFieldToArith` marks the whole arith dialect statically legal, so the
type-polymorphic `arith.select` is never rewritten even when its operands
carry binary field types (`arith.select i1, !field.bf<3>, !field.bf<3>`).
The operands *do* get converted, and the framework's compensating
`unrealized_conversion_cast` (storage int ↔ `!field.bf`) survives to the end
of the conversion:

```
error: failed to legalize unresolved materialization from ('i8') to ('!field.bf<3>')
       that remained live after conversion
```

This is exactly the carve-out `ModArithToArith` already has for the same
reason — mirror it:

```cpp
target.addDynamicallyLegalOp<arith::SelectOp>(
    [&](auto op) { return typeConverter.isLegal(op); });
```

Prime fields never hit this because `FieldToModArith` doesn't blanket-legalize
arith and `ModArithToArith` has the carve-out; every binary field (t3/t7/ghash)
failed.

## Why

fractalyze/xla#205 — XLA:CPU fused select+reduce over binary fields
(the `jnp.where(mask, x, 0)` + `jnp.sum` shape emitted by HLO fusions) fails
to compile with the error above. This pass-legality fix is the root cause;
the XLA side only adds regression tests (plus a pin bump once this lands via
stablehlo).

## Test

- New lit cases `@test_bf_select` (tower, i8) and `@test_bf_ghash_select`
  (flat GHASH basis, i128) in `tests/Dialect/Field/binary_field_to_arith.mlir`;
  both fail with the unresolved-materialization error before the fix.
- Full suite: 111/111 pass.
- Downstream (with this checkout overriding the pin): the three new XLA CPU
  select+reduce fusion tests for t3/t7/ghash flip FAIL → PASS, and the GPU
  mirrors pass.
