### PR TITLE
feat(dialect/field): lower GHASH-basis field.inverse

### DIFF
--- a/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldToArith.cpp
+++ b/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldToArith.cpp
@@ -66,9 +66,11 @@ bool containsBinaryFieldType(Type type) {
 // Conversion Patterns
 //===----------------------------------------------------------------------===//
 
-// GHASH-basis multiply (`bf<7, ghash>`), defined below; used by the mul/square
-// patterns to split on basis.
+// GHASH-basis multiply/square/inverse (`bf<7, ghash>`), defined below; used by
+// the mul/square/inverse patterns to split on basis.
 Value emitGhashMul(ImplicitLocOpBuilder &b, Value a, Value bv);
+Value emitGhashSquare(ImplicitLocOpBuilder &b, Value a);
+Value emitGhashInverse(ImplicitLocOpBuilder &b, Value a);
 
 struct ConvertBinaryFieldConstant : public OpConversionPattern<ConstantOp> {
   using OpConversionPattern::OpConversionPattern;
@@ -213,12 +215,12 @@ struct ConvertBinaryFieldSquare : public OpConversionPattern<SquareOp> {
 
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
     if (bfType.isGhash()) {
-      // emitGhashMul is scalar-only (i64/i128 truncs and shifts); shaped GHASH
-      // is not lowered yet, so fail to legalize rather than emit invalid IR.
+      // emitGhashSquare is scalar-only (i64/i128 truncs and shifts); shaped
+      // GHASH is not lowered yet, so fail to legalize rather than emit invalid
+      // IR.
       if (isa<ShapedType>(op.getType()))
         return failure();
-      rewriter.replaceOp(
-          op, emitGhashMul(b, adaptor.getInput(), adaptor.getInput()));
+      rewriter.replaceOp(op, emitGhashSquare(b, adaptor.getInput()));
       return success();
     }
     BinaryFieldCodeGen input(bfType, adaptor.getInput(), b);
@@ -238,13 +240,16 @@ struct ConvertBinaryFieldInverse : public OpConversionPattern<InverseOp> {
     if (!bfType) {
       return failure();
     }
-    // GHASH-basis inverse is not yet lowered (the GPU prover path is
-    // mul/add-heavy); fail to legalize rather than apply the tower inverse.
-    if (bfType.isGhash()) {
-      return failure();
-    }
-
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+    if (bfType.isGhash()) {
+      // emitGhashInverse is scalar-only (i64/i128 truncs and shifts); shaped
+      // GHASH is not lowered yet, so fail to legalize rather than emit invalid
+      // IR.
+      if (isa<ShapedType>(op.getType()))
+        return failure();
+      rewriter.replaceOp(op, emitGhashInverse(b, adaptor.getInput()));
+      return success();
+    }
     BinaryFieldCodeGen input(bfType, adaptor.getInput(), b);
     BinaryFieldCodeGen result = input.inverse();
     rewriter.replaceOp(op, result.getValue());
@@ -434,6 +439,81 @@ Value emitGhashMul(ImplicitLocOpBuilder &b, Value a, Value bv) {
   Value loExt = arith::ExtUIOp::create(b, i128Ty, lo);
   Value hiExt = arith::ExtUIOp::create(b, i128Ty, hi);
   return arith::OrIOp::create(b, loExt, arith::ShLIOp::create(b, hiExt, sh64));
+}
+
+// Interleave zeros into the low 32 bits of an i64 (bit i -> bit 2i), the
+// classic mask-shift bit-spread.
+Value emitSpreadEven32(ImplicitLocOpBuilder &b, Value x) {
+  struct Step {
+    unsigned shift;
+    uint64_t mask;
+  };
+  constexpr Step kSteps[] = {{16, 0x0000FFFF0000FFFFULL},
+                             {8, 0x00FF00FF00FF00FFULL},
+                             {4, 0x0F0F0F0F0F0F0F0FULL},
+                             {2, 0x3333333333333333ULL},
+                             {1, 0x5555555555555555ULL}};
+  for (auto [shift, mask] : kSteps) {
+    Value shifted = arith::ShLIOp::create(b, x, i64Const(b, shift));
+    x = arith::AndIOp::create(b, arith::OrIOp::create(b, x, shifted),
+                              i64Const(b, mask));
+  }
+  return x;
+}
+
+// Spread an i64 limb into two even-bit i64 limbs (bit i -> bit 2i across the
+// 128-bit result).
+std::pair<Value, Value> emitSpreadEven64(ImplicitLocOpBuilder &b, Value a) {
+  Value lo32 = arith::AndIOp::create(b, a, i64Const(b, 0xFFFFFFFFULL));
+  Value hi32 = arith::ShRUIOp::create(b, a, i64Const(b, 32));
+  return {emitSpreadEven32(b, lo32), emitSpreadEven32(b, hi32)};
+}
+
+// Square a GHASH-basis i128 value. Squaring is linear in GF(2)[x] — the
+// carryless square of a(x) has bit i of `a` at bit 2i and no cross terms — so
+// it is a bit-spread of each 64-bit limb into the 256-bit product followed by
+// the shared reduction: ~40 arith ops instead of a full carryless multiply.
+Value emitGhashSquare(ImplicitLocOpBuilder &b, Value a) {
+  auto i64Ty = b.getI64Type();
+  auto i128Ty = b.getIntegerType(128);
+  Value sh64 = arith::ConstantIntOp::create(b, 64, 128);
+  Value a0 = arith::TruncIOp::create(b, i64Ty, a);
+  Value a1 =
+      arith::TruncIOp::create(b, i64Ty, arith::ShRUIOp::create(b, a, sh64));
+  auto [r0, r1] = emitSpreadEven64(b, a0);
+  auto [r2, r3] = emitSpreadEven64(b, a1);
+  auto [lo, hi] = emitGhashReduce(b, r0, r1, r2, r3);
+
+  Value loExt = arith::ExtUIOp::create(b, i128Ty, lo);
+  Value hiExt = arith::ExtUIOp::create(b, i128Ty, hi);
+  return arith::OrIOp::create(b, loExt, arith::ShLIOp::create(b, hiExt, sh64));
+}
+
+// Invert a GHASH-basis i128 value via Fermat: a⁻¹ = a^(2¹²⁸ − 2) (and 0 maps
+// to 0, matching the tower lowering). Uses the Itoh–Tsujii addition chain
+// t_k = a^(2^k − 1), t_{j+k} = t_j^(2^k) · t_k over
+// 1→2→3→6→7→14→28→56→63→126→127, then a⁻¹ = t₁₂₇². That is 127 squarings plus
+// 10 multiplies; the naive ∏ a^(2^i) form (flock's runtime inv) would emit 127
+// multiplies, and each multiply is a fully-unrolled ~1.2k-op carryless product
+// while the linearized squaring above is ~40 ops.
+Value emitGhashInverse(ImplicitLocOpBuilder &b, Value a) {
+  auto pow2k = [&](Value v, unsigned k) {
+    for (unsigned i = 0; i < k; ++i)
+      v = emitGhashSquare(b, v);
+    return v;
+  };
+  Value t1 = a;
+  Value t2 = emitGhashMul(b, pow2k(t1, 1), t1);
+  Value t3 = emitGhashMul(b, pow2k(t2, 1), t1);
+  Value t6 = emitGhashMul(b, pow2k(t3, 3), t3);
+  Value t7 = emitGhashMul(b, pow2k(t6, 1), t1);
+  Value t14 = emitGhashMul(b, pow2k(t7, 7), t7);
+  Value t28 = emitGhashMul(b, pow2k(t14, 14), t14);
+  Value t56 = emitGhashMul(b, pow2k(t28, 28), t28);
+  Value t63 = emitGhashMul(b, pow2k(t56, 7), t7);
+  Value t126 = emitGhashMul(b, pow2k(t63, 63), t63);
+  Value t127 = emitGhashMul(b, pow2k(t126, 1), t1);
+  return emitGhashSquare(b, t127);
 }
 
 //===----------------------------------------------------------------------===//

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
@@ -504,6 +504,11 @@ struct ConvertInverse : ConvertFieldOpBase<InverseOp, ConvertInverse> {
   LogicalResult
   matchAndRewrite(InverseOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    // Skip binary field operations - they are handled by BinaryFieldToArith
+    if (isa<BinaryFieldType>(getElementTypeOrSelf(op.getType()))) {
+      return failure();
+    }
+
     auto tensorType = dyn_cast<RankedTensorType>(op.getOutput().getType());
     if (!tensorType)
       return Base::matchAndRewrite(op, adaptor, rewriter);
@@ -1000,16 +1005,18 @@ void FieldToModArith::runOnOperation() {
   ConversionTarget target(*context);
 
   // Mark field operations as dynamically legal if they contain BinaryFieldType
-  // (those will be handled by BinaryFieldToArith pass instead)
-  target.addDynamicallyLegalOp<ConstantOp, CmpOp, PowUIOp>(
+  // (those will be handled by BinaryFieldToArith pass instead). InverseOp is
+  // included: FieldCodeGen only models prime/extension fields, so a
+  // binary-field inverse reaching ConvertInverse would assert.
+  target.addDynamicallyLegalOp<ConstantOp, CmpOp, PowUIOp, InverseOp>(
       [](Operation *op) { return operationContainsBinaryFieldType(op); });
 
   // ConvertFieldOpBase patterns cannot inline-codegen shaped extension field
   // types. ElementwiseMappable ops (add, sub, ...) are scalarized by
   // convert-elementwise-to-linalg. Mark them as legal here so
   // field-to-mod-arith passes through these ops without failing.
-  // Note: InverseOp is NOT listed — ConvertInverse handles all tensor inverses
-  // via Montgomery's batch inversion trick.
+  // Note: InverseOp is NOT listed — ConvertInverse handles all (non-binary)
+  // tensor inverses via Montgomery's batch inversion trick.
   target
       .addDynamicallyLegalOp<AddOp, SubOp, MulOp, NegateOp, DoubleOp, SquareOp>(
           [](Operation *op) {

--- a/tests/Dialect/Field/binary_field_to_arith.mlir
+++ b/tests/Dialect/Field/binary_field_to_arith.mlir
@@ -100,3 +100,17 @@ func.func @test_bf_ghash_select(%c: i1, %a: !GHASH, %b: !GHASH) -> !GHASH {
   %s = arith.select %c, %a, %b : !GHASH
   return %s : !GHASH
 }
+
+// Scalar GHASH inverse lowers to the Fermat chain (linearized squares +
+// carryless multiplies) on the i128 storage — no field ops survive.
+// CHECK-LABEL: @test_bf_ghash_inverse
+// CHECK-SAME: (%arg0: i128) -> i128
+func.func @test_bf_ghash_inverse(%a: !GHASH) -> !GHASH {
+  // CHECK: arith.trunci
+  // CHECK: arith.shrui
+  // CHECK: arith.xori
+  // CHECK: arith.ori
+  // CHECK-NOT: field.inverse
+  %c = field.inverse %a : !GHASH
+  return %c : !GHASH
+}

--- a/tests/Dialect/Field/ghash_runner.mlir
+++ b/tests/Dialect/Field/ghash_runner.mlir
@@ -92,10 +92,99 @@ func.func @test_ghash_reduce() {
 }
 // CHECK: [135]
 
+// The linearized squaring must hit the same reduction as the multiply:
+// (x^64)^2 = x^128 = 0x87 = 135 (test_ghash_square's 2^2 = 4 never reduces).
+func.func @test_ghash_square_reduce() {
+  %c64 = arith.constant 18446744073709551616 : i128   // 2^64 = x^64
+  %x64 = field.bitcast %c64 : i128 -> !G
+  %p = field.square %x64 : !G
+
+  %i = field.bitcast %p : !G -> i128
+  %r = arith.trunci %i : i128 to i32
+  %t = tensor.from_elements %r : tensor<1xi32>
+  %buf = bufferization.to_buffer %t : tensor<1xi32> to memref<1xi32>
+  %cast = memref.cast %buf : memref<1xi32> to memref<*xi32>
+  func.call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
+  return
+}
+// CHECK: [135]
+
+// Print 1 iff the full 128-bit value equals `expected` — the i32 print used
+// above only shows the low 32 bits, which is too lossy to pin an inverse.
+func.func @check_i128_eq(%v: i128, %expected: i128) {
+  %eq = arith.cmpi eq, %v, %expected : i128
+  %r = arith.extui %eq : i1 to i32
+  %t = tensor.from_elements %r : tensor<1xi32>
+  %buf = bufferization.to_buffer %t : tensor<1xi32> to memref<1xi32>
+  %cast = memref.cast %buf : memref<1xi32> to memref<*xi32>
+  func.call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
+  return
+}
+
+// inverse(1) = 1 (the identity is its own inverse in any basis).
+func.func @test_ghash_inverse_one() {
+  %a = field.constant 1 : !G
+  %inv = field.inverse %a : !G
+
+  %i = field.bitcast %inv : !G -> i128
+  %one = arith.constant 1 : i128
+  func.call @check_i128_eq(%i, %one) : (i128, i128) -> ()
+  return
+}
+// CHECK: [1]
+
+// a * a⁻¹ = 1 for a low-half value. The multiply is independently covered
+// above, so a wrong inverse cannot cancel into a spurious 1.
+func.func @test_ghash_inverse_roundtrip() {
+  %a = field.constant 12345 : !G
+  %inv = field.inverse %a : !G
+  %p = field.mul %a, %inv : !G
+
+  %i = field.bitcast %p : !G -> i128
+  %one = arith.constant 1 : i128
+  func.call @check_i128_eq(%i, %one) : (i128, i128) -> ()
+  return
+}
+// CHECK: [1]
+
+// a * a⁻¹ = 1 with all 128 bits set — the Fermat chain then exercises every
+// carry/overflow path of the reduction (mirrors flock's inverse tests on
+// high-half and near-max values).
+func.func @test_ghash_inverse_all_ones() {
+  %cmax = arith.constant -1 : i128                    // 2^128 - 1: all bits set
+  %a = field.bitcast %cmax : i128 -> !G
+  %inv = field.inverse %a : !G
+  %p = field.mul %a, %inv : !G
+
+  %i = field.bitcast %p : !G -> i128
+  %one = arith.constant 1 : i128
+  func.call @check_i128_eq(%i, %one) : (i128, i128) -> ()
+  return
+}
+// CHECK: [1]
+
+// inverse(0) = 0: Fermat's 0^(2^128 − 2) keeps the tower lowering's 0 ↦ 0
+// convention.
+func.func @test_ghash_inverse_zero() {
+  %a = field.constant 0 : !G
+  %inv = field.inverse %a : !G
+
+  %i = field.bitcast %inv : !G -> i128
+  %zero = arith.constant 0 : i128
+  func.call @check_i128_eq(%i, %zero) : (i128, i128) -> ()
+  return
+}
+// CHECK: [1]
+
 func.func @main() {
   func.call @test_ghash_mul() : () -> ()
   func.call @test_ghash_square() : () -> ()
   func.call @test_ghash_one() : () -> ()
   func.call @test_ghash_reduce() : () -> ()
+  func.call @test_ghash_square_reduce() : () -> ()
+  func.call @test_ghash_inverse_one() : () -> ()
+  func.call @test_ghash_inverse_roundtrip() : () -> ()
+  func.call @test_ghash_inverse_all_ones() : () -> ()
+  func.call @test_ghash_inverse_zero() : () -> ()
   return
 }

--- a/tests/Dialect/Field/ghash_shaped_unsupported.mlir
+++ b/tests/Dialect/Field/ghash_shaped_unsupported.mlir
@@ -36,3 +36,12 @@ func.func @vector_ghash_square(%a: vector<4x!G>) -> vector<4x!G> {
   %c = field.square %a : vector<4x!G>
   return %c : vector<4x!G>
 }
+
+// -----
+
+!G = !field.bf<7, ghash>
+func.func @tensor_ghash_inverse(%a: tensor<4x!G>) -> tensor<4x!G> {
+  // expected-error @+1 {{operand #0 must be field-like}}
+  %c = field.inverse %a : tensor<4x!G>
+  return %c : tensor<4x!G>
+}


### PR DESCRIPTION
## What

Two changes that make `field.inverse` work over binary fields:

1. **`fix(dialect/field)`: keep binary-field inverse out of FieldToModArith.** InverseOp was missing from the binary-field dynamic-legality group, so ConvertInverse matched binary-field inverses and its FieldCodeGen (prime/extension-only) `cast<ExtensionFieldType>`-asserted. Since `--field-to-llvm` runs field-to-mod-arith before binary-field-to-arith, **any** binary-field `field.inverse` crashed `prime-ir-opt` — latent until now because no test exercised one.
2. **`feat(dialect/field)`: lower GHASH-basis `field.inverse`.** `ConvertBinaryFieldInverse` bailed on `isGhash()`. Now lowered via Fermat `a⁻¹ = a^(2¹²⁸−2)` (0 ↦ 0) over the Itoh–Tsujii addition chain `1→2→3→6→7→14→28→56→63→126→127`: **127 squarings + 10 multiplies** instead of the naive chain's 127 multiplies. Each GHASH multiply is a fully-unrolled ~1.2k-op carryless product, while squaring in GF(2)[x] is linear (bit i → bit 2i) and lowers as four 32→64 zero-interleavings feeding the shared `emitGhashReduce` (~40 ops) — so the chain shape dominates emitted-IR size. `ConvertBinaryFieldSquare` switches to the linearized squaring too.

## Why

Binary-field division fails to compile in XLA (fractalyze/xla#211): jax traces `a/b` → `stablehlo.divide` → `field.mul(a, field.inverse(b))`, and the scalar `field.inverse` inside the fused region needs this lowering for the GHASH basis.

## Tests

- `ghash_runner.mlir`: `a·a⁻¹ = 1` for a low-half value and for all-128-bits-set (compared 128-bit-exact via `arith.cmpi`, not the truncated i32 print), `inverse(1)=1`, `inverse(0)=0`, plus `(x⁶⁴)² = 0x87` pinning the linearized square's reduction path.
- `binary_field_to_arith.mlir`: scalar GHASH inverse lowers to arith with no surviving field ops.
- `ghash_shaped_unsupported.mlir`: shaped GHASH inverse keeps failing cleanly (scalar-only, same as mul/square).
- Full local suite: 110/111 pass; `pairing_check_4pairs_runner` (tagged `long`) hit its 900s timeout on a heavily loaded box — unrelated path (BN254 PF/EF; this PR only touches binary-field legality/lowering), all other EF/PF inverse tests (fermat/batch/elementwise runners) pass. Flagging for a CI cross-check.

Validated end-to-end from XLA: `binary_field_ghash` HLO `divide` compiles and matches zk_dtypes host division plus hard-coded flat-basis anchors (6/3=2, 0x87/x⁶⁴=x⁶⁴) — regression tests land in the xla repo with the pin bumps.

Part of https://github.com/fractalyze/xla/issues/211.
