### PR TITLE
feat: specialize GHASH field.mul to NVPTX clmad

### DIFF
--- a/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldTables.h
+++ b/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldTables.h
@@ -187,8 +187,8 @@ constexpr unsigned kGhashOverflowShifts[] = {57, 62, 63}; // 64 - shift
 // Compute the GHASH reduction high * (x⁷ + x² + x + 1) for a 64-bit limb:
 // returns the value to XOR into the low 64 bits, plus the overflow bits that
 // spill past bit 63 (to be XORed into the next limb up). Shared by the x86
-// (PCLMULQDQ) and ARM (PMULL) specializers so the two carryless-multiply
-// backends can never drift apart.
+// (PCLMULQDQ), ARM (PMULL), and NVPTX (clmad) specializers so the
+// carryless-multiply backends can never drift apart.
 inline std::pair<Value, Value> reduceGhash(ImplicitLocOpBuilder &b,
                                            Value high) {
   auto i64Type = b.getI64Type();

--- a/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/BUILD.bazel
+++ b/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/BUILD.bazel
@@ -1,0 +1,54 @@
+# Copyright 2026 The PrimeIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("//bazel:prime_ir_cc.bzl", "prime_ir_cc_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+gentbl_cc_library(
+    name = "pass_inc_gen",
+    tbl_outs = {
+        "SpecializeBinaryFieldToNVPTX.h.inc": [
+            "-gen-pass-decls",
+            "-name=SpecializeBinaryFieldToNVPTX",
+        ],
+        "SpecializeBinaryFieldToNVPTX.md": ["-gen-pass-doc"],
+    },
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "SpecializeBinaryFieldToNVPTX.td",
+    deps = [
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)
+
+prime_ir_cc_library(
+    name = "SpecializeBinaryFieldToNVPTX",
+    srcs = ["SpecializeBinaryFieldToNVPTX.cpp"],
+    hdrs = ["SpecializeBinaryFieldToNVPTX.h"],
+    deps = [
+        ":pass_inc_gen",
+        "//prime_ir/Dialect/Field/Conversions/BinaryFieldToArith:BinaryFieldTables",
+        "//prime_ir/Dialect/Field/IR:Field",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LLVMDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:TransformUtils",
+    ],
+)

--- a/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.cpp
+++ b/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.cpp
@@ -1,0 +1,182 @@
+/* Copyright 2026 The PrimeIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldTables.h"
+#include "prime_ir/Dialect/Field/IR/FieldDialect.h"
+#include "prime_ir/Dialect/Field/IR/FieldOps.h"
+#include "prime_ir/Dialect/Field/IR/FieldTypes.h"
+
+namespace mlir::prime_ir::field {
+
+#define GEN_PASS_DEF_SPECIALIZEBINARYFIELDTONVPTX
+#include "prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.h.inc"
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// clmad Intrinsic Helper
+//===----------------------------------------------------------------------===//
+
+// Emit a single PTX `clmad.{lo,hi}.u64` (carryless multiply-add, PTX ISA 9.3):
+//   dst = carryless_product_{lo|hi}(a, b) XOR c
+// `lo` selects bits 0..63 of the 64x64 carryless product, `hi` bits 64..127.
+// The `c` operand chains the XOR-accumulation for free, which the schoolbook
+// below uses to fold cross terms without extra XOR ops. Kept as opaque inline
+// asm so `clmad` survives to PTX regardless of the LLVM NVPTX backend version;
+// only ptxas (CUDA 13.3+) needs to know the instruction.
+Value emitClmad(ImplicitLocOpBuilder &b, Value a, Value bv, Value c,
+                bool isHi) {
+  StringRef asmString =
+      isHi ? "clmad.hi.u64 $0, $1, $2, $3;" : "clmad.lo.u64 $0, $1, $2, $3;";
+  return LLVM::InlineAsmOp::create(
+             b, b.getI64Type(), ValueRange{a, bv, c}, asmString, "=l,l,l,l",
+             /*has_side_effects=*/false,
+             /*is_align_stack=*/false, LLVM::TailCallKind::None,
+             LLVM::AsmDialectAttr::get(b.getContext(),
+                                       LLVM::AsmDialect::AD_ATT),
+             /*operand_attrs=*/ArrayAttr())
+      .getResult(0);
+}
+
+//===----------------------------------------------------------------------===//
+// clmad-based GHASH Multiplication
+//===----------------------------------------------------------------------===//
+
+// Multiply two GHASH-basis i128 values using clmad. Eight clmad build the
+// 128x128 -> 256-bit carryless product as limbs r0..r3 (low to high), folding
+// the two cross terms via clmad's XOR-accumulate operand exactly as flock's
+// clmad kernel (optim/clmad/ghash_mul.ptx):
+//   r0 = ll_lo
+//   r1 = ll_hi ^ (a1·b0)_lo ^ (a0·b1)_lo   (= ll_hi ^ mid_lo)
+//   r2 = hh_lo ^ (a1·b0)_hi ^ (a0·b1)_hi   (= hh_lo ^ mid_hi)
+//   r3 = hh_hi
+// These are the same r0..r3 limbs the x86 PCLMULQDQ path produces, so the
+// reduction reuses the shared `reduceGhash` — the carryless-multiply backends
+// fold the high half identically and cannot drift.
+Value mulGhashClmad(ImplicitLocOpBuilder &b, Value lhsI128, Value rhsI128) {
+  auto i64Ty = b.getI64Type();
+  auto i128Ty = b.getIntegerType(128);
+  Value sh64 = arith::ConstantIntOp::create(b, 64, 128);
+
+  Value a0 = arith::TruncIOp::create(b, i64Ty, lhsI128);
+  Value a1 = arith::TruncIOp::create(b, i64Ty,
+                                     arith::ShRUIOp::create(b, lhsI128, sh64));
+  Value b0 = arith::TruncIOp::create(b, i64Ty, rhsI128);
+  Value b1 = arith::TruncIOp::create(b, i64Ty,
+                                     arith::ShRUIOp::create(b, rhsI128, sh64));
+
+  Value z = arith::ConstantIntOp::create(b, 0, 64);
+
+  Value r0 = emitClmad(b, a0, b0, z, /*isHi=*/false);
+  Value t1 = emitClmad(b, a1, b0, z, /*isHi=*/false);
+  t1 = emitClmad(b, a0, b1, t1, /*isHi=*/false);
+  Value r1 = emitClmad(b, a0, b0, t1, /*isHi=*/true);
+  Value t2 = emitClmad(b, a1, b0, z, /*isHi=*/true);
+  t2 = emitClmad(b, a0, b1, t2, /*isHi=*/true);
+  Value r2 = emitClmad(b, a1, b1, t2, /*isHi=*/false);
+  Value r3 = emitClmad(b, a1, b1, z, /*isHi=*/true);
+
+  // Fold the high half down via x¹²⁸ == x⁷ + x² + x + 1.
+  auto [r3Red, r3Overflow] = reduceGhash(b, r3);
+  r1 = arith::XOrIOp::create(b, r1, r3Red);
+  r2 = arith::XOrIOp::create(b, r2, r3Overflow);
+
+  auto [r2Red, r2Overflow] = reduceGhash(b, r2);
+  r0 = arith::XOrIOp::create(b, r0, r2Red);
+  r1 = arith::XOrIOp::create(b, r1, r2Overflow);
+
+  // Reassemble the 128-bit result: r0 | (r1 << 64).
+  Value r0Ext = arith::ExtUIOp::create(b, i128Ty, r0);
+  Value r1Ext = arith::ExtUIOp::create(b, i128Ty, r1);
+  Value r1Hi = arith::ShLIOp::create(b, r1Ext, sh64);
+  return arith::OrIOp::create(b, r0Ext, r1Hi);
+}
+
+//===----------------------------------------------------------------------===//
+// Conversion Pattern
+//===----------------------------------------------------------------------===//
+
+// Pattern for the GHASH-basis multiply (`bf<7, ghash>`) using clmad. As with
+// the x86 PCLMULQDQ path, tower bf<6>/bf<7> deliberately do NOT specialize --
+// the carryless product computes the flat GHASH product, not the tower -- so
+// they lower via the portable recursive mulTower in binary-field-to-arith.
+struct ConvertGhashMulToClmad : public OpRewritePattern<MulOp> {
+  using OpRewritePattern<MulOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(MulOp op,
+                                PatternRewriter &rewriter) const override {
+    Type ghashType = op.getResult().getType();
+    auto bfType = dyn_cast<BinaryFieldType>(ghashType);
+    if (!bfType || !bfType.isGhash())
+      return failure();
+
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+    auto i128Type = b.getIntegerType(128);
+
+    // Cast ghash -> i128; BinaryFieldToArith later reconciles these casts.
+    Value lhsI128 = UnrealizedConversionCastOp::create(b, i128Type, op.getLhs())
+                        .getResult(0);
+    Value rhsI128 = UnrealizedConversionCastOp::create(b, i128Type, op.getRhs())
+                        .getResult(0);
+
+    Value resultI128 = mulGhashClmad(b, lhsI128, rhsI128);
+
+    Value resultGhash =
+        UnrealizedConversionCastOp::create(b, ghashType, resultI128)
+            .getResult(0);
+    rewriter.replaceOp(op, resultGhash);
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Pass Implementation
+//===----------------------------------------------------------------------===//
+
+struct SpecializeBinaryFieldToNVPTX
+    : impl::SpecializeBinaryFieldToNVPTXBase<SpecializeBinaryFieldToNVPTX> {
+  using SpecializeBinaryFieldToNVPTXBase::SpecializeBinaryFieldToNVPTXBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ModuleOp module = getOperation();
+
+    RewritePatternSet patterns(context);
+    if (useClmad) {
+      patterns.add<ConvertGhashMulToClmad>(context);
+    }
+
+    // Greedy rewriting (not partial conversion) so unmatched field.mul ops
+    // fall through gracefully. Folding disabled: MLIR's folder doesn't
+    // understand binary field types (matches the x86/ARM specializers).
+    GreedyRewriteConfig config;
+    config.enableFolding(false);
+    if (failed(applyPatternsGreedily(module, std::move(patterns), config))) {
+      signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir::prime_ir::field

--- a/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.h
+++ b/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.h
@@ -1,0 +1,34 @@
+/* Copyright 2026 The PrimeIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// NOLINTNEXTLINE(whitespace/line_length)
+#ifndef PRIME_IR_DIALECT_FIELD_CONVERSIONS_SPECIALIZEBINARYFIELDTONVPTX_SPECIALIZEBINARYFIELDTONVPTX_H_
+// NOLINTNEXTLINE(whitespace/line_length)
+#define PRIME_IR_DIALECT_FIELD_CONVERSIONS_SPECIALIZEBINARYFIELDTONVPTX_SPECIALIZEBINARYFIELDTONVPTX_H_
+
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::prime_ir::field {
+
+#define GEN_PASS_DECL_SPECIALIZEBINARYFIELDTONVPTX
+#include "prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.h.inc" // NOLINT
+
+} // namespace mlir::prime_ir::field
+
+// NOLINTNEXTLINE(whitespace/line_length)
+#endif // ...SPECIALIZEBINARYFIELDTONVPTX_H_ NOLINT(build/header_guard)

--- a/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.td
+++ b/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.td
@@ -1,0 +1,55 @@
+/* Copyright 2026 The PrimeIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef PRIME_IR_DIALECT_FIELD_CONVERSIONS_SPECIALIZEBINARYFIELDTONVPTX_TD
+#define PRIME_IR_DIALECT_FIELD_CONVERSIONS_SPECIALIZEBINARYFIELDTONVPTX_TD
+
+include "mlir/Pass/PassBase.td"
+
+def SpecializeBinaryFieldToNVPTX : Pass<"specialize-binary-field-to-nvptx", "ModuleOp"> {
+  let summary = "Specialize binary field operations to NVPTX clmad instructions.";
+  let description = [{
+    Specializes GHASH-basis binary field multiplication to the hardware
+    carryless multiply-add instruction `clmad` (PTX ISA 9.3) for the CUDA GPU
+    backend.
+
+    The GPU analog of `SpecializeBinaryFieldToX86` (PCLMULQDQ) and
+    `SpecializeBinaryFieldToARM` (PMULL): it rewrites `field.mul` on
+    `bf<7, ghash>` into a 128x128 carryless product built from eight
+    `clmad.{lo,hi}.u64`, then the shared GHASH polynomial reduction
+    (x¹²⁸ + x⁷ + x² + x + 1). Operations not specialized fall through to the
+    portable software carryless multiply in `binary-field-to-arith`.
+
+    This pass must run BEFORE `binary-field-to-arith`. On the GPU codegen path
+    it is inserted directly ahead of `createBinaryFieldToArith` — the GPU
+    pipeline does not use the `field-to-llvm` pipeline where the x86/ARM
+    specializers sit.
+
+    The emitted `clmad` requires a CUDA-13.3+ ptxas to assemble; on older
+    toolchains leave this pass disabled and the portable path is used.
+  }];
+
+  let dependentDialects = [
+    "arith::ArithDialect",
+    "LLVM::LLVMDialect",
+  ];
+
+  let options = [
+    Option<"useClmad", "use-clmad", "bool", /*default=*/"true",
+           "Use clmad instructions for GHASH-basis binary field multiplication">,
+  ];
+}
+
+#endif // PRIME_IR_DIALECT_FIELD_CONVERSIONS_SPECIALIZEBINARYFIELDTONVPTX_TD

--- a/tests/Dialect/Field/specialize_binary_field_to_nvptx.mlir
+++ b/tests/Dialect/Field/specialize_binary_field_to_nvptx.mlir
@@ -1,0 +1,66 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// Test clmad specialization for GHASH-basis binary field multiplication.
+//
+// clmad computes a carryless product, realizing multiplication in the flat
+// GHASH polynomial basis (reduction x¹²⁸ + x⁷ + x² + x + 1). It does NOT match
+// the recursive tower basis, so the fast path applies only to `bf<7, ghash>`;
+// tower bf<6>/bf<7> stay portable (`field.mul`).
+
+// RUN: prime-ir-opt --specialize-binary-field-to-nvptx %s | FileCheck %s --check-prefix=CHECK-CLMAD
+
+// use-clmad=false disables specialization.
+// RUN: prime-ir-opt --specialize-binary-field-to-nvptx="use-clmad=false" %s | FileCheck %s --check-prefix=CHECK-OFF
+
+!BF64 = !field.bf<6>         // GF(2⁶⁴), tower basis
+!BF128 = !field.bf<7>        // GF(2¹²⁸), tower basis
+!GHASH = !field.bf<7, ghash> // GF(2¹²⁸), flat GHASH polynomial basis
+
+// GHASH-basis scalar multiplication should use clmad: eight clmad.{lo,hi}.u64
+// build the 128×128 carryless product, then the shared GHASH reduction.
+// CHECK-CLMAD-LABEL: @test_ghash_mul
+// CHECK-CLMAD: builtin.unrealized_conversion_cast
+// CHECK-CLMAD-COUNT-8: llvm.inline_asm{{.*}}clmad{{.*}}u64
+// CHECK-CLMAD: builtin.unrealized_conversion_cast
+// CHECK-OFF-LABEL: @test_ghash_mul
+// CHECK-OFF: field.mul
+// CHECK-OFF-NOT: clmad
+func.func @test_ghash_mul(%a: !GHASH, %b: !GHASH) -> !GHASH {
+  %c = field.mul %a, %b : !GHASH
+  return %c : !GHASH
+}
+
+// BF128 (tower) scalar multiplication stays portable — no carryless fast path.
+// CHECK-CLMAD-LABEL: @test_bf128_mul
+// CHECK-CLMAD: field.mul
+// CHECK-CLMAD-NOT: clmad
+// CHECK-OFF-LABEL: @test_bf128_mul
+// CHECK-OFF: field.mul
+func.func @test_bf128_mul(%a: !BF128, %b: !BF128) -> !BF128 {
+  %c = field.mul %a, %b : !BF128
+  return %c : !BF128
+}
+
+// BF64 (tower) scalar multiplication stays portable — no carryless fast path.
+// CHECK-CLMAD-LABEL: @test_bf64_mul
+// CHECK-CLMAD: field.mul
+// CHECK-CLMAD-NOT: clmad
+// CHECK-OFF-LABEL: @test_bf64_mul
+// CHECK-OFF: field.mul
+func.func @test_bf64_mul(%a: !BF64, %b: !BF64) -> !BF64 {
+  %c = field.mul %a, %b : !BF64
+  return %c : !BF64
+}

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -49,6 +49,7 @@ prime_ir_cc_binary(
         "//prime_ir/Dialect/Field/Conversions/ExtFieldToLLVM",
         "//prime_ir/Dialect/Field/Conversions/FieldToModArith",
         "//prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToARM",
+        "//prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX",
         "//prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToX86",
         "//prime_ir/Dialect/Field/IR:Field",
         "//prime_ir/Dialect/Field/Pipelines:Passes",

--- a/tools/prime-ir-opt.cpp
+++ b/tools/prime-ir-opt.cpp
@@ -28,6 +28,7 @@ limitations under the License.
 #include "prime_ir/Dialect/Field/Conversions/ExtFieldToLLVM/ExtFieldToLLVM.h"
 #include "prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.h"
 #include "prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToARM/SpecializeBinaryFieldToARM.h"
+#include "prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.h"
 #include "prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToX86/SpecializeBinaryFieldToX86.h"
 #include "prime_ir/Dialect/Field/IR/FieldDialect.h"
 #include "prime_ir/Dialect/Field/Pipelines/Passes.h"
@@ -69,6 +70,7 @@ int main(int argc, char **argv) {
   mlir::prime_ir::mod_arith::registerModArithToArithPasses();
   mlir::prime_ir::field::registerBinaryFieldToArithPasses();
   mlir::prime_ir::field::registerSpecializeBinaryFieldToARMPasses();
+  mlir::prime_ir::field::registerSpecializeBinaryFieldToNVPTXPasses();
   mlir::prime_ir::field::registerSpecializeBinaryFieldToX86Passes();
   mlir::prime_ir::field::registerFieldToModArithPasses();
   mlir::prime_ir::field::registerExtFieldToLLVMPasses();


### PR DESCRIPTION
## Description

The GPU binary-field multiply is the additive-NTT bottleneck: the fused
`lax.ntt` kernels run at a few percent of memory-bandwidth ceiling because the
software `xor`/`shift` carryless multiply dominates. `clmad` (PTX ISA 9.3,
carryless multiply-add) collapses the 128×128 GHASH product to eight
`clmad.{lo,hi}.u64` plus a shift/XOR reduce, so emitting it in the compiler
speeds up every binary-field multiply, not just the NTT.

Rather than a new reducer, the eight-`clmad` schoolbook produces the same
r0..r3 limbs as the existing x86 PCLMULQDQ specializer, so both carryless
backends share `reduceGhash` and cannot drift — correctness is inherited from
the proven x86 path (the lit test pins the lowering). The pass is gated on
`use-clmad` and runs before binary-field-to-arith; older toolchains without a
ptxas that assembles `clmad` fall through to the portable software multiply.

Downstream wiring (the GPU codegen path that invokes this pass) and the PTX
`.version 9.3` toolchain work live in the xla PR that bumps the prime_ir pin —
merge this first.

## Related Issues/PRs

Part of fractalyze/flock-zorch#24 (emit hardware clmad in binary-field mul);
unblocks fractalyze/flock-zorch#25 (PTX `.version 9.3`). Paired xla PR: the
NVPTX GPU-mul wiring + PTX-version caps.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline