### PR TITLE
feat(field): add flat AES basis !field.bf<3, aes> + arith lowering

### DIFF
--- a/prime_ir/Dialect/Field/C/FieldTypes.cpp
+++ b/prime_ir/Dialect/Field/C/FieldTypes.cpp
@@ -61,8 +61,8 @@ bool primeIRTypeIsABinaryField(MlirType type) {
 }
 
 MlirType primeIRBinaryFieldTypeGet(MlirContext ctx, unsigned towerLevel,
-                                   bool isGhash) {
-  return wrap(BinaryFieldType::get(unwrap(ctx), towerLevel, isGhash));
+                                   bool isFlat) {
+  return wrap(BinaryFieldType::get(unwrap(ctx), towerLevel, isFlat));
 }
 
 unsigned primeIRBinaryFieldTypeGetTowerLevel(MlirType type) {
@@ -71,6 +71,10 @@ unsigned primeIRBinaryFieldTypeGetTowerLevel(MlirType type) {
 
 bool primeIRBinaryFieldTypeIsGhash(MlirType type) {
   return llvm::cast<BinaryFieldType>(unwrap(type)).isGhash();
+}
+
+bool primeIRBinaryFieldTypeIsAes(MlirType type) {
+  return llvm::cast<BinaryFieldType>(unwrap(type)).isAes();
 }
 
 //===----------------------------------------------------------------------===//

--- a/prime_ir/Dialect/Field/C/FieldTypes.h
+++ b/prime_ir/Dialect/Field/C/FieldTypes.h
@@ -54,18 +54,22 @@ MLIR_CAPI_EXPORTED MlirTypeID primeIRBinaryFieldTypeGetTypeID(void);
 // Checks whether the given type is a binary field type.
 MLIR_CAPI_EXPORTED bool primeIRTypeIsABinaryField(MlirType type);
 
-// Creates a binary field type GF(2^(2^towerLevel)) in the context. When isGhash
-// is true (valid only at towerLevel 7) the type selects the flat GHASH/POLYVAL
-// basis instead of the recursive tower basis. The type is owned by the context.
+// Creates a binary field type GF(2^(2^towerLevel)) in the context. When isFlat
+// is true the type selects the flat polynomial basis of that level instead of
+// the recursive tower basis: GHASH/POLYVAL at towerLevel 7, AES at towerLevel 3
+// (other levels have no flat basis). The type is owned by the context.
 MLIR_CAPI_EXPORTED MlirType primeIRBinaryFieldTypeGet(MlirContext ctx,
                                                       unsigned towerLevel,
-                                                      bool isGhash);
+                                                      bool isFlat);
 
 // Returns the tower level of the given binary field type.
 MLIR_CAPI_EXPORTED unsigned primeIRBinaryFieldTypeGetTowerLevel(MlirType type);
 
 // Checks whether the given binary field type uses the flat GHASH basis.
 MLIR_CAPI_EXPORTED bool primeIRBinaryFieldTypeIsGhash(MlirType type);
+
+// Checks whether the given binary field type uses the flat AES basis.
+MLIR_CAPI_EXPORTED bool primeIRBinaryFieldTypeIsAes(MlirType type);
 
 //===----------------------------------------------------------------------===//
 // ExtensionField types.

--- a/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldToArith.cpp
+++ b/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldToArith.cpp
@@ -56,7 +56,7 @@ public:
 };
 
 /// Check if a type contains a binary field this pass lowers: the tower `bf` or
-/// the flat-basis `ghash` (both GF(2^n), both lowered here).
+/// a flat basis (`ghash`, `aes` — both GF(2^n), both lowered here).
 bool containsBinaryFieldType(Type type) {
   Type elemType = getElementTypeOrSelf(type);
   return isa<BinaryFieldType>(elemType);
@@ -66,11 +66,14 @@ bool containsBinaryFieldType(Type type) {
 // Conversion Patterns
 //===----------------------------------------------------------------------===//
 
-// GHASH-basis multiply/square/inverse (`bf<7, ghash>`), defined below; used by
-// the mul/square/inverse patterns to split on basis.
+// Flat-basis multiply/square/inverse (`bf<7, ghash>` and `bf<3, aes>`),
+// defined below; used by the mul/square/inverse patterns to split on basis.
 Value emitGhashMul(ImplicitLocOpBuilder &b, Value a, Value bv);
 Value emitGhashSquare(ImplicitLocOpBuilder &b, Value a);
 Value emitGhashInverse(ImplicitLocOpBuilder &b, Value a);
+Value emitAesMul(ImplicitLocOpBuilder &b, Value a, Value bv);
+Value emitAesSquare(ImplicitLocOpBuilder &b, Value a);
+Value emitAesInverse(ImplicitLocOpBuilder &b, Value a);
 
 struct ConvertBinaryFieldConstant : public OpConversionPattern<ConstantOp> {
   using OpConversionPattern::OpConversionPattern;
@@ -185,13 +188,16 @@ struct ConvertBinaryFieldMul : public OpConversionPattern<MulOp> {
     }
 
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
-    if (bfType.isGhash()) {
-      // emitGhashMul is scalar-only (i64/i128 truncs and shifts); shaped GHASH
-      // is not lowered yet, so fail to legalize rather than emit invalid IR.
+    if (!bfType.isTower()) {
+      // The flat-basis emitters are scalar-only (integer truncs and shifts);
+      // shaped flat values are not lowered yet, so fail to legalize rather
+      // than emit invalid IR.
       if (isa<ShapedType>(op.getType()))
         return failure();
-      rewriter.replaceOp(op,
-                         emitGhashMul(b, adaptor.getLhs(), adaptor.getRhs()));
+      rewriter.replaceOp(
+          op, bfType.isGhash()
+                  ? emitGhashMul(b, adaptor.getLhs(), adaptor.getRhs())
+                  : emitAesMul(b, adaptor.getLhs(), adaptor.getRhs()));
       return success();
     }
     BinaryFieldCodeGen lhs(bfType, adaptor.getLhs(), b);
@@ -214,13 +220,15 @@ struct ConvertBinaryFieldSquare : public OpConversionPattern<SquareOp> {
     }
 
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
-    if (bfType.isGhash()) {
-      // emitGhashSquare is scalar-only (i64/i128 truncs and shifts); shaped
-      // GHASH is not lowered yet, so fail to legalize rather than emit invalid
-      // IR.
+    if (!bfType.isTower()) {
+      // The flat-basis emitters are scalar-only (integer truncs and shifts);
+      // shaped flat values are not lowered yet, so fail to legalize rather
+      // than emit invalid IR.
       if (isa<ShapedType>(op.getType()))
         return failure();
-      rewriter.replaceOp(op, emitGhashSquare(b, adaptor.getInput()));
+      rewriter.replaceOp(op, bfType.isGhash()
+                                 ? emitGhashSquare(b, adaptor.getInput())
+                                 : emitAesSquare(b, adaptor.getInput()));
       return success();
     }
     BinaryFieldCodeGen input(bfType, adaptor.getInput(), b);
@@ -241,13 +249,15 @@ struct ConvertBinaryFieldInverse : public OpConversionPattern<InverseOp> {
       return failure();
     }
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
-    if (bfType.isGhash()) {
-      // emitGhashInverse is scalar-only (i64/i128 truncs and shifts); shaped
-      // GHASH is not lowered yet, so fail to legalize rather than emit invalid
-      // IR.
+    if (!bfType.isTower()) {
+      // The flat-basis emitters are scalar-only (integer truncs and shifts);
+      // shaped flat values are not lowered yet, so fail to legalize rather
+      // than emit invalid IR.
       if (isa<ShapedType>(op.getType()))
         return failure();
-      rewriter.replaceOp(op, emitGhashInverse(b, adaptor.getInput()));
+      rewriter.replaceOp(op, bfType.isGhash()
+                                 ? emitGhashInverse(b, adaptor.getInput())
+                                 : emitAesInverse(b, adaptor.getInput()));
       return success();
     }
     BinaryFieldCodeGen input(bfType, adaptor.getInput(), b);
@@ -514,6 +524,111 @@ Value emitGhashInverse(ImplicitLocOpBuilder &b, Value a) {
   Value t126 = emitGhashMul(b, pow2k(t63, 63), t63);
   Value t127 = emitGhashMul(b, pow2k(t126, 1), t1);
   return emitGhashSquare(b, t127);
+}
+
+//===----------------------------------------------------------------------===//
+// AES-basis multiply (`bf<3, aes>`)
+//===----------------------------------------------------------------------===//
+//
+// `bf<3, aes>` is GF(2)[x]/(x⁸ + x⁴ + x³ + x + 1) (0x11B) in the monomial
+// basis (NOT the x²+x+α tower of the default `bf<3>`). Only the multiply
+// differs; it is an 8-bit carryless product reduced mod the AES polynomial.
+// The whole product fits in i16, so the lowering works in i16 throughout and
+// truncates back to the i8 storage at the end. Portable shift-XOR (GPU-safe);
+// no host clmul specialization — at 8 bits it would not pay for itself.
+
+Value i16Const(ImplicitLocOpBuilder &b, uint64_t v) {
+  return arith::ConstantIntOp::create(b, static_cast<int64_t>(v), 16);
+}
+
+// Portable 8x8 -> 15-bit carryless (GF(2)[x]) product in i16, bit-serial
+// shift-XOR (mirrors zk_dtypes' Gf8AesMul).
+Value emitClmul8(ImplicitLocOpBuilder &b, Value a16, Value b16) {
+  Value zero = i16Const(b, 0);
+  Value one = i16Const(b, 1);
+  Value acc = zero;
+  for (unsigned i = 0; i < 8; ++i) {
+    Value bShifted = b16;
+    Value aShl = a16;
+    if (i != 0) {
+      Value shiftI = i16Const(b, i);
+      bShifted = arith::ShRUIOp::create(b, b16, shiftI);
+      aShl = arith::ShLIOp::create(b, a16, shiftI);
+    }
+    Value bit = arith::AndIOp::create(b, bShifted, one);
+    Value mask = arith::SubIOp::create(b, zero, bit); // 0 or all-ones
+    acc = arith::XOrIOp::create(b, acc, arith::AndIOp::create(b, mask, aShl));
+  }
+  return acc;
+}
+
+// Reduce a degree-<=14 carryless product (i16) mod x⁸ + x⁴ + x³ + x + 1,
+// returning the low byte still in i16. Two folds via x⁸ == x⁴ + x³ + x + 1;
+// the first fold can re-overflow bit 8, so a second pass is required
+// (mirrors zk_dtypes' Gf8AesReduce).
+Value emitAesReduce(ImplicitLocOpBuilder &b, Value p) {
+  auto shl = [&](Value v, unsigned s) {
+    return arith::ShLIOp::create(b, v, i16Const(b, s));
+  };
+  auto shr = [&](Value v, unsigned s) {
+    return arith::ShRUIOp::create(b, v, i16Const(b, s));
+  };
+  auto x = [&](Value p, Value q) { return arith::XOrIOp::create(b, p, q); };
+  Value mask = i16Const(b, 0xFF);
+
+  Value h = shr(p, 8);
+  Value t =
+      x(x(x(x(arith::AndIOp::create(b, p, mask), h), shl(h, 1)), shl(h, 3)),
+        shl(h, 4));
+  Value h2 = shr(t, 8);
+  Value r = x(x(x(x(t, h2), shl(h2, 1)), shl(h2, 3)), shl(h2, 4));
+  return arith::AndIOp::create(b, r, mask);
+}
+
+// Multiply two AES-basis i8 values: 8×8 carryless product reduced mod 0x11B.
+Value emitAesMul(ImplicitLocOpBuilder &b, Value a, Value bv) {
+  auto i16Ty = b.getIntegerType(16);
+  Value a16 = arith::ExtUIOp::create(b, i16Ty, a);
+  Value b16 = arith::ExtUIOp::create(b, i16Ty, bv);
+  Value r = emitAesReduce(b, emitClmul8(b, a16, b16));
+  return arith::TruncIOp::create(b, b.getI8Type(), r);
+}
+
+// Square an AES-basis i8 value. Squaring is linear in GF(2)[x] — bit i of `a`
+// lands at bit 2i with no cross terms — so it is a mask-shift bit-spread of
+// the byte into i16 followed by the shared reduction.
+Value emitAesSquare(ImplicitLocOpBuilder &b, Value a) {
+  auto i16Ty = b.getIntegerType(16);
+  Value x = arith::ExtUIOp::create(b, i16Ty, a);
+  struct Step {
+    unsigned shift;
+    uint64_t mask;
+  };
+  constexpr Step kSteps[] = {{4, 0x0F0F}, {2, 0x3333}, {1, 0x5555}};
+  for (auto [shift, mask] : kSteps) {
+    Value shifted = arith::ShLIOp::create(b, x, i16Const(b, shift));
+    x = arith::AndIOp::create(b, arith::OrIOp::create(b, x, shifted),
+                              i16Const(b, mask));
+  }
+  Value r = emitAesReduce(b, x);
+  return arith::TruncIOp::create(b, b.getI8Type(), r);
+}
+
+// Invert an AES-basis i8 value via Fermat: a⁻¹ = a^(2⁸ − 2) = a²⁵⁴ (and 0 maps
+// to 0, matching the tower lowering). Itoh–Tsujii chain t_k = a^(2^k − 1) over
+// 1→2→3→6→7, then a⁻¹ = t₇² — 7 squarings plus 4 multiplies.
+Value emitAesInverse(ImplicitLocOpBuilder &b, Value a) {
+  auto pow2k = [&](Value v, unsigned k) {
+    for (unsigned i = 0; i < k; ++i)
+      v = emitAesSquare(b, v);
+    return v;
+  };
+  Value t1 = a;
+  Value t2 = emitAesMul(b, pow2k(t1, 1), t1);
+  Value t3 = emitAesMul(b, pow2k(t2, 1), t1);
+  Value t6 = emitAesMul(b, pow2k(t3, 3), t3);
+  Value t7 = emitAesMul(b, pow2k(t6, 1), t1);
+  return emitAesSquare(b, t7);
 }
 
 //===----------------------------------------------------------------------===//

--- a/prime_ir/Dialect/Field/IR/FieldOps.cpp
+++ b/prime_ir/Dialect/Field/IR/FieldOps.cpp
@@ -1927,17 +1927,17 @@ ParseResult MulOp::parse(OpAsmParser &parser, OperationState &result) {
 
 //===----------------------------------------------------------------------===//
 
-// The GHASH basis (`bf<7, ghash>`) has no compile-time multiplicative
-// evaluator: zk_dtypes::BinaryMul/BinarySquare/BinaryInverse implement only the
-// recursive tower basis, and the flat GHASH product is defined solely by the
-// runtime shift-XOR lowering (emitGhashMul in BinaryFieldToArith). Folding
-// mul/square/inverse through the tower evaluator would silently emit tower
-// values (e.g. 2·3 = 1 instead of 6), so leave those ops for the lowering.
-// Additive ops (add/sub/negate/double) are basis-independent (XOR) and still
-// fold.
-static bool isGhashResult(Type type) {
+// The flat bases (`bf<7, ghash>`, `bf<3, aes>`) have no compile-time
+// multiplicative evaluator: zk_dtypes::BinaryMul/BinarySquare/BinaryInverse
+// implement only the recursive tower basis, and the flat products are defined
+// solely by the runtime shift-XOR lowerings (emitGhashMul/emitAesMul in
+// BinaryFieldToArith). Folding mul/square/inverse through the tower evaluator
+// would silently emit tower values (e.g. ghash 2·3 = 1 instead of 6, aes
+// 2·2 = 3 instead of 4), so leave those ops for the lowering. Additive ops
+// (add/sub/negate/double) are basis-independent (XOR) and still fold.
+static bool isFlatBasisResult(Type type) {
   auto bfType = dyn_cast<BinaryFieldType>(getElementTypeOrSelf(type));
-  return bfType && bfType.isGhash();
+  return bfType && !bfType.isTower();
 }
 
 OpFoldResult NegateOp::fold(FoldAdaptor adaptor) {
@@ -1951,14 +1951,14 @@ OpFoldResult DoubleOp::fold(FoldAdaptor adaptor) {
 }
 
 OpFoldResult SquareOp::fold(FoldAdaptor adaptor) {
-  if (isGhashResult(getType()))
+  if (isFlatBasisResult(getType()))
     return {};
   return foldUnaryOp(this, adaptor,
                      [](const FieldOperation &op) { return op.square(); });
 }
 
 OpFoldResult InverseOp::fold(FoldAdaptor adaptor) {
-  if (isGhashResult(getType()))
+  if (isFlatBasisResult(getType()))
     return {};
   return foldUnaryOp(this, adaptor,
                      [](const FieldOperation &op) { return op.inverse(); });
@@ -1999,7 +1999,7 @@ OpFoldResult SubOp::fold(FoldAdaptor adaptor) {
 }
 
 OpFoldResult MulOp::fold(FoldAdaptor adaptor) {
-  if (isGhashResult(getType()))
+  if (isFlatBasisResult(getType()))
     return {};
   return foldMultiplicativeBinaryOp(
       this, adaptor,

--- a/prime_ir/Dialect/Field/IR/FieldTypes.cpp
+++ b/prime_ir/Dialect/Field/IR/FieldTypes.cpp
@@ -186,15 +186,15 @@ ShapedType PrimeFieldType::overrideShapedType(ShapedType type) const {
 // static
 LogicalResult
 BinaryFieldType::verify(function_ref<InFlightDiagnostic()> emitError,
-                        unsigned towerLevel, bool isGhash) {
+                        unsigned towerLevel, bool isFlat) {
   if (towerLevel > kMaxTowerLevel) {
     return emitError() << "binary field tower level must be between 0 and "
                        << kMaxTowerLevel << ", got " << towerLevel;
   }
-  if (isGhash && towerLevel != kMaxTowerLevel) {
-    return emitError() << "the ghash basis is GF(2¹²⁸), only valid at tower "
-                          "level "
-                       << kMaxTowerLevel << ", got " << towerLevel;
+  if (isFlat && towerLevel != kMaxTowerLevel && towerLevel != kAesTowerLevel) {
+    return emitError() << "a flat basis exists only at tower level "
+                       << kMaxTowerLevel << " (ghash) or " << kAesTowerLevel
+                       << " (aes), got " << towerLevel;
   }
   return success();
 }
@@ -217,33 +217,51 @@ Type BinaryFieldType::parse(AsmParser &parser) {
     return nullptr;
   }
 
-  // Optional ", ghash" selects the flat GHASH polynomial basis (level 7 only).
-  bool isGhash = false;
+  // Optional ", ghash" / ", aes" selects the flat polynomial basis at the
+  // level the polynomial defines (ghash: GF(2¹²⁸), aes: GF(2⁸)).
+  bool isFlat = false;
   if (succeeded(parser.parseOptionalComma())) {
-    if (failed(parser.parseKeyword("ghash"))) {
+    StringRef basis;
+    if (failed(parser.parseKeyword(&basis))) {
       return nullptr;
     }
-    isGhash = true;
-    if (towerLevel != kMaxTowerLevel) {
-      parser.emitError(
-          parser.getCurrentLocation(),
-          "the ghash basis is GF(2¹²⁸), only valid at tower level ")
-          << kMaxTowerLevel;
+    if (basis == "ghash") {
+      if (towerLevel != kMaxTowerLevel) {
+        parser.emitError(
+            parser.getCurrentLocation(),
+            "the ghash basis is GF(2¹²⁸), only valid at tower level ")
+            << kMaxTowerLevel;
+        return nullptr;
+      }
+    } else if (basis == "aes") {
+      if (towerLevel != kAesTowerLevel) {
+        parser.emitError(parser.getCurrentLocation(),
+                         "the aes basis is GF(2⁸), only valid at tower level ")
+            << kAesTowerLevel;
+        return nullptr;
+      }
+    } else {
+      parser.emitError(parser.getCurrentLocation(),
+                       "expected 'ghash' or 'aes', got '")
+          << basis << "'";
       return nullptr;
     }
+    isFlat = true;
   }
 
   if (failed(parser.parseGreater())) {
     return nullptr;
   }
 
-  return BinaryFieldType::get(parser.getContext(), towerLevel, isGhash);
+  return BinaryFieldType::get(parser.getContext(), towerLevel, isFlat);
 }
 
 void BinaryFieldType::print(AsmPrinter &printer) const {
   printer << "<" << getTowerLevel();
-  if (getIsGhash()) {
+  if (isGhash()) {
     printer << ", ghash";
+  } else if (isAes()) {
+    printer << ", aes";
   }
   printer << ">";
 }

--- a/prime_ir/Dialect/Field/IR/FieldTypes.td
+++ b/prime_ir/Dialect/Field/IR/FieldTypes.td
@@ -103,8 +103,8 @@ def Field_PrimeFieldType : Field_Type<"PrimeField", "pf", [
   let hasCustomAssemblyFormat = 1;
 }
 
-// Binary field type: GF(2^(2^level)), in the recursive tower basis or (at
-// level 7 only) the flat GHASH polynomial basis.
+// Binary field type: GF(2^(2^level)), in the recursive tower basis or a flat
+// polynomial basis (GHASH at level 7, AES at level 3).
 def Field_BinaryFieldType : Field_Type<"BinaryField", "bf", [
   MemRefElementTypeInterface,
   VectorElementTypeInterface,
@@ -126,34 +126,39 @@ def Field_BinaryFieldType : Field_Type<"BinaryField", "bf", [
     - level 6: GF(2⁶⁴)   = 64 bits
     - level 7: GF(2¹²⁸)  = 128 bits
 
-    Two bases are supported, selected by the `ghash` flag (valid at level 7
-    only, since GHASH is GF(2¹²⁸)):
-    - default (tower): the recursive x²+x+α tower basis (Fan–Paar). `2·3 = 1`.
-    - `ghash`: the flat GHASH/POLYVAL polynomial basis
+    Each level uses the recursive x²+x+α tower basis (Fan–Paar) by default;
+    two levels additionally support a FLAT polynomial basis, selected by the
+    flat flag and named in the assembly by its polynomial:
+    - `ghash` (level 7 only): the flat GHASH/POLYVAL polynomial basis
       GF(2)[x]/(x¹²⁸ + x⁷ + x² + x + 1) (reduction constant 0x87, natural
       monomial bit order). `2·3 = 6` (2 = x, 3 = x+1, so 2·3 = x²+x). Same
       abstract field as `bf<7>` but a different, NOT bit-compatible
       representation — the one GHASH/AES-GCM uses, and that provers hashing raw
-      field bytes need byte-identity with. Only the multiply differs between the
-      two bases; add/sub/negate/double/cmp/constant are identical.
+      field bytes need byte-identity with.
+    - `aes` (level 3 only): the flat AES/Rijndael polynomial basis
+      GF(2)[x]/(x⁸ + x⁴ + x³ + x + 1) (0x11B, reduction constant 0x1B, natural
+      monomial bit order). `2·2 = 4` where the tower `bf<3>` gives 3.
+    Only the multiply differs between a flat basis and the tower;
+    add/sub/negate/double/cmp/constant are identical.
 
     All operations are characteristic 2: add and sub are XOR, negation is
     identity, doubling yields zero.
 
     Example:
     ```
-    !BF8 = !field.bf<3>          // GF(2⁸), tower basis
+    !BF8 = !field.bf<3>          // GF(2⁸), tower basis,    2·2 = 3
     !BF128 = !field.bf<7>        // GF(2¹²⁸), tower basis,  2·3 = 1
     !G = !field.bf<7, ghash>     // GF(2¹²⁸), GHASH basis,  2·3 = 6
+    !A = !field.bf<3, aes>       // GF(2⁸), AES basis,      2·2 = 4
     ```
   }];
   let parameters = (ins
     "unsigned": $towerLevel,
-    DefaultValuedParameter<"bool", "false">: $isGhash
+    DefaultValuedParameter<"bool", "false">: $isFlat
   );
   let builders = [
     TypeBuilder<(ins "unsigned":$towerLevel), [{
-      return $_get(context, towerLevel, /*isGhash=*/false);
+      return $_get(context, towerLevel, /*isFlat=*/false);
     }]>,
   ];
   let extraClassDeclaration = [{
@@ -172,14 +177,20 @@ def Field_BinaryFieldType : Field_Type<"BinaryField", "bf", [
     [[deprecated("use getTypeSizeInBits() instead")]]
     unsigned getStorageBitWidth() const { return getTypeSizeInBits(); }
 
-    /// True for the recursive tower basis (the default), false for GHASH.
-    bool isTower() const { return !getIsGhash(); }
+    /// True for the recursive tower basis (the default).
+    bool isTower() const { return !getIsFlat(); }
 
-    /// True for the flat GHASH polynomial basis.
-    bool isGhash() const { return getIsGhash(); }
+    /// True for the flat GHASH polynomial basis (flat GF(2¹²⁸)).
+    bool isGhash() const { return getIsFlat() && getTowerLevel() == 7; }
+
+    /// True for the flat AES polynomial basis (flat GF(2⁸)).
+    bool isAes() const { return getIsFlat() && getTowerLevel() == 3; }
 
     /// Maximum supported tower level (GF(2¹²⁸)).
     static constexpr unsigned kMaxTowerLevel = 7;
+
+    /// Tower level of the flat AES basis (GF(2⁸)).
+    static constexpr unsigned kAesTowerLevel = 3;
   }];
   let hasCustomAssemblyFormat = 1;
   let genVerifyDecl = 1;

--- a/prime_ir/Dialect/Field/Python/FieldTypes.cpp
+++ b/prime_ir/Dialect/Field/Python/FieldTypes.cpp
@@ -51,16 +51,18 @@ void PyPrimeFieldType::bindDerived(ClassTy &c) {
 void PyBinaryFieldType::bindDerived(ClassTy &c) {
   c.def_static(
       "get",
-      [](unsigned towerLevel, bool isGhash,
+      [](unsigned towerLevel, bool isFlat,
          DefaultingPyMlirContext context) -> PyBinaryFieldType {
         MlirType t =
-            primeIRBinaryFieldTypeGet(context->get(), towerLevel, isGhash);
+            primeIRBinaryFieldTypeGet(context->get(), towerLevel, isFlat);
         return PyBinaryFieldType(context->getRef(), t);
       },
-      nb::arg("tower_level"), nb::arg("is_ghash") = false,
+      nb::arg("tower_level"), nb::arg("is_flat") = false,
       nb::arg("context") = nb::none(),
-      "Create a binary field type GF(2^(2^tower_level)); is_ghash selects the "
-      "flat GHASH basis (valid at tower_level 7 only)");
+      "Create a binary field type GF(2^(2^tower_level)); is_flat selects the "
+      "flat polynomial basis of that level instead of the recursive tower: "
+      "GHASH at tower_level 7, AES at tower_level 3 (other levels have no "
+      "flat basis)");
   c.def_prop_ro(
       "tower_level",
       [](PyBinaryFieldType &self) -> unsigned {
@@ -73,6 +75,12 @@ void PyBinaryFieldType::bindDerived(ClassTy &c) {
         return primeIRBinaryFieldTypeIsGhash(self);
       },
       "Returns whether this uses the flat GHASH basis");
+  c.def_prop_ro(
+      "is_aes",
+      [](PyBinaryFieldType &self) -> bool {
+        return primeIRBinaryFieldTypeIsAes(self);
+      },
+      "Returns whether this uses the flat AES basis");
 }
 
 // static

--- a/tests/Dialect/Field/aes_runner.mlir
+++ b/tests/Dialect/Field/aes_runner.mlir
@@ -1,0 +1,130 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// End-to-end test for the flat-basis AES field (`!field.bf<3, aes>`), GF(2^8)
+// as GF(2)[x]/(x^8 + x^4 + x^3 + x + 1). Exercises the portable
+// (shift-XOR, no CLMUL) lowering in BinaryFieldToArith.
+
+// RUN: prime-ir-opt %s --field-to-llvm \
+// RUN:   | mlir-runner -e main -entry-point-result=void \
+// RUN:      --shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s < %t
+
+!A = !field.bf<3, aes>   // GF(2^8), AES polynomial basis
+
+func.func private @printMemrefI32(memref<*xi32>) attributes { llvm.emit_c_interface }
+
+func.func @print_aes(%v: !A) {
+  %i = field.bitcast %v : !A -> i8
+  %r = arith.extui %i : i8 to i32
+  %t = tensor.from_elements %r : tensor<1xi32>
+  %buf = bufferization.to_buffer %t : tensor<1xi32> to memref<1xi32>
+  %cast = memref.cast %buf : memref<1xi32> to memref<*xi32>
+  func.call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
+  return
+}
+
+// 2 * 2 = 4: in the AES basis 2 = x, so 2*2 = x^2 = 4 (no reduction).
+// (In the bf<3> tower this would be 3 — the bases are not bit-compatible.)
+func.func @test_aes_mul() {
+  %a = field.constant 2 : !A
+  %b = field.constant 2 : !A
+  %c = field.mul %a, %b : !A
+  func.call @print_aes(%c) : (!A) -> ()
+  return
+}
+// CHECK: [4]
+
+// 1 * 42 = 42 (multiplicative identity).
+func.func @test_aes_one() {
+  %a = field.constant 1 : !A
+  %b = field.constant 42 : !A
+  %c = field.mul %a, %b : !A
+  func.call @print_aes(%c) : (!A) -> ()
+  return
+}
+// CHECK: [42]
+
+// Reduction: x^7 * x = x^8 = x^4 + x^3 + x + 1 = 0x1B = 27.
+func.func @test_aes_reduce() {
+  %a = field.constant 128 : !A
+  %b = field.constant 2 : !A
+  %c = field.mul %a, %b : !A
+  func.call @print_aes(%c) : (!A) -> ()
+  return
+}
+// CHECK: [27]
+
+// AES standard vector: {53} * {CA} = {01} (FIPS-197 §4.2 example inverses).
+func.func @test_aes_fips_vector() {
+  %a = field.constant 83 : !A     // 0x53
+  %b = field.constant 202 : !A    // 0xCA
+  %c = field.mul %a, %b : !A
+  func.call @print_aes(%c) : (!A) -> ()
+  return
+}
+// CHECK: [1]
+
+// The linearized squaring must hit the same reduction as the multiply:
+// (x^7)^2 = x^14 = 0x9A = 154 (2^2 = 4 never reduces).
+func.func @test_aes_square_reduce() {
+  %a = field.constant 128 : !A
+  %c = field.square %a : !A
+  func.call @print_aes(%c) : (!A) -> ()
+  return
+}
+// CHECK: [154]
+
+// inverse({53}) = {CA} — the FIPS-197 pair pins the Fermat chain to the basis.
+func.func @test_aes_inverse_fips() {
+  %a = field.constant 83 : !A     // 0x53
+  %inv = field.inverse %a : !A
+  func.call @print_aes(%inv) : (!A) -> ()
+  return
+}
+// CHECK: [202]
+
+// a * a⁻¹ = 1. The multiply is independently covered above, so a wrong
+// inverse cannot cancel into a spurious 1.
+func.func @test_aes_inverse_roundtrip() {
+  %a = field.constant 42 : !A
+  %inv = field.inverse %a : !A
+  %p = field.mul %a, %inv : !A
+  func.call @print_aes(%p) : (!A) -> ()
+  return
+}
+// CHECK: [1]
+
+// inverse(0) = 0: Fermat's 0^(2^8 − 2) keeps the tower lowering's 0 ↦ 0
+// convention.
+func.func @test_aes_inverse_zero() {
+  %a = field.constant 0 : !A
+  %inv = field.inverse %a : !A
+  func.call @print_aes(%inv) : (!A) -> ()
+  return
+}
+// CHECK: [0]
+
+func.func @main() {
+  func.call @test_aes_mul() : () -> ()
+  func.call @test_aes_one() : () -> ()
+  func.call @test_aes_reduce() : () -> ()
+  func.call @test_aes_fips_vector() : () -> ()
+  func.call @test_aes_square_reduce() : () -> ()
+  func.call @test_aes_inverse_fips() : () -> ()
+  func.call @test_aes_inverse_roundtrip() : () -> ()
+  func.call @test_aes_inverse_zero() : () -> ()
+  return
+}

--- a/tests/Dialect/Field/aes_shaped_unsupported.mlir
+++ b/tests/Dialect/Field/aes_shaped_unsupported.mlir
@@ -1,0 +1,38 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// The portable AES multiply (`emitAesMul`) is scalar-only, like the GHASH one:
+// it hard-codes i8/i16 truncs, shifts, and constants. Shaped (tensor/vector)
+// `bf<3, aes>` mul/square is not lowered yet, so the conversion must fail
+// cleanly instead of building invalid IR. Scalar AES is covered end-to-end by
+// aes_runner.mlir.
+
+// RUN: prime-ir-opt %s --binary-field-to-arith --split-input-file --verify-diagnostics
+
+!A = !field.bf<3, aes>
+func.func @tensor_aes_mul(%a: tensor<4x!A>, %b: tensor<4x!A>) -> tensor<4x!A> {
+  // expected-error @+1 {{operand #0 must be field-like}}
+  %c = field.mul %a, %b : tensor<4x!A>
+  return %c : tensor<4x!A>
+}
+
+// -----
+
+!A = !field.bf<3, aes>
+func.func @vector_aes_square(%a: vector<4x!A>) -> vector<4x!A> {
+  // expected-error @+1 {{operand #0 must be field-like}}
+  %c = field.square %a : vector<4x!A>
+  return %c : vector<4x!A>
+}

--- a/tests/python/field_test.py
+++ b/tests/python/field_test.py
@@ -38,15 +38,24 @@ class FieldTest(absltest.TestCase):
       self.assertEqual(bf8.tower_level, 3)
       self.assertFalse(bf8.is_ghash)
 
-      # is_ghash selects the flat GHASH basis at level 7; the two level-7 types
-      # are distinct (tower 2*3 = 1 vs flat 2*3 = 6).
+      # is_flat selects the flat basis of the level: GHASH at level 7, AES at
+      # level 3. Each flat type is distinct from its tower sibling
+      # (tower 2*3 = 1 vs ghash 2*3 = 6; tower 2*2 = 3 vs aes 2*2 = 4).
       tower = field.BinaryFieldType.get(7, context=ctx)
       ghash = field.BinaryFieldType.get(7, True, ctx)
       self.assertEqual(str(tower), "!field.bf<7>")
       self.assertEqual(str(ghash), "!field.bf<7, ghash>")
       self.assertFalse(tower.is_ghash)
       self.assertTrue(ghash.is_ghash)
+      self.assertFalse(ghash.is_aes)
       self.assertNotEqual(tower, ghash)
+
+      aes = field.BinaryFieldType.get(3, is_flat=True, context=ctx)
+      self.assertEqual(str(aes), "!field.bf<3, aes>")
+      self.assertEqual(aes.tower_level, 3)
+      self.assertTrue(aes.is_aes)
+      self.assertFalse(aes.is_ghash)
+      self.assertNotEqual(bf8, aes)
 
   def testExtensionFieldTypes(self):
     with Context() as ctx, Location.unknown():

--- a/third_party/zk_dtypes/workspace.bzl
+++ b/third_party/zk_dtypes/workspace.bzl
@@ -17,8 +17,8 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def repo():
-    ZK_DTYPES_COMMIT = "523cdb7bb689a3cf729db842b86b4ea34798c05d"
-    ZK_DTYPES_SHA256 = "d1b1c7580d7bd353503c2336f6dd3c01e538f273fd08250383fcdfca05782991"
+    ZK_DTYPES_COMMIT = "ed835e6d0df77008d1c957e8dcd5e88984fb9ebd"
+    ZK_DTYPES_SHA256 = "8054748dcf87a6a141a1f5f4774eb67ae73401d8492614b7018e223fb1fd43b7"
     http_archive(
         name = "zk_dtypes",
         sha256 = ZK_DTYPES_SHA256,


### PR DESCRIPTION
## Description

GF(2⁸) in the AES/Rijndael basis (p(x) = x⁸ + x⁴ + x³ + x + 1, 0x11B) as a
second flat binary-field basis, one level below `ghash`. The type's flat flag
widens from `isGhash` to `isFlat` — flat selects the level's canonical
polynomial basis (GHASH at level 7, AES at level 3; verifier rejects other
levels). The AES basis is bit-incompatible with the tower `bf<3>`
(flat 2·2 = 4 vs tower 3), so AES-byte-identity consumers get their own type,
the exact precedent `ghash` set.

`BinaryFieldToArith` gains portable shift-XOR `emitAesMul/Square/Inverse`
(GPU-safe, scalar-only like the ghash emitters; Itoh–Tsujii a²⁵⁴ inverse).
Constant folding of flat mul/square/inverse stays disabled — the
FieldOperation evaluator is tower-only. C API keeps `IsGhash`, adds `IsAes`;
python `get()` kwarg becomes `is_flat`, properties `is_ghash`/`is_aes`.

Covered by `aes_runner.mlir` (e2e portable lowering: 2·2=4, x⁷·x=0x1B,
FIPS-197 {53}·{CA}={01}, inverse chain, 0↦0), `aes_shaped_unsupported.mlir`,
and python binding assertions.

Note for reviewers: `getIsGhash()` callers downstream must move to
`getIsFlat()` — stablehlo has a 1-line companion PR.

## Related Issues/PRs

Progresses fractalyze/flock-zorch#88 (re-scoped fractalyze/flock-zorch#15).
Depends on nothing; downstream: stablehlo VhloTypes follow-up, then
fractalyze/xla, fractalyze/jax.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline

https://claude.ai/code/session_01NbTN2G6JNKi3bxdXxQuhvq