### PR TITLE
perf: specialize Solinas-prime Fermat inverse chain

### DIFF
--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/BUILD.bazel
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/BUILD.bazel
@@ -136,6 +136,7 @@ prime_ir_cc_library(
     deps = [
         "//prime_ir/Dialect/ModArith/IR:ModArith",
         "//prime_ir/Utils:BuilderContext",
+        "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
     ],
 )

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
@@ -476,27 +476,26 @@ struct ConvertInverse : ConvertFieldOpBase<InverseOp, ConvertInverse> {
     return emitScalarInverse(fieldType, adaptor.getInput());
   }
 
-  // Fermat's-little-theorem inverse (x^(p-2)) emits a fully unrolled,
-  // branch-free square-and-multiply chain, which is divergence-free on GPU but
-  // grows ~p_bits multiplications of p_bits/64-limb operands. It beats the
-  // Bernstein-Yang safegcd loop for small fields and loses for wide ones, so
-  // `auto` gates on modulus width. Fermat is implemented for prime fields
-  // only; extension fields always use Bernstein-Yang.
+  // Past this width the chain loses to safegcd, so `auto` stops taking it.
   static constexpr unsigned kFermatMaxModulusBits = 64;
+
+  bool preferFermatChain(const APInt &modulus) const {
+    if (inverseAlgorithm == InverseAlgorithm::Fermat)
+      return true;
+    return inverseAlgorithm == InverseAlgorithm::Auto &&
+           PrimeFieldCodeGen::hasInverseChain(modulus) &&
+           modulus.getActiveBits() <= kFermatMaxModulusBits;
+  }
 
   Value emitScalarInverse(Type fieldType, Value value) const {
     FieldCodeGen cg(fieldType, value, this->typeConverter);
     if (auto pf = dyn_cast<PrimeFieldType>(fieldType)) {
       APInt modulus = pf.getModulus().getValue();
-      bool useFermat = inverseAlgorithm == InverseAlgorithm::Fermat ||
-                       (inverseAlgorithm == InverseAlgorithm::Auto &&
-                        modulus.getActiveBits() <= kFermatMaxModulusBits);
-      if (useFermat) {
-        // PrimeFieldType rejects power-of-2 moduli, so p >= 3 and the Fermat
-        // exponent p - 2 >= 1 — never zero, as pow() requires.
-        APInt exp = modulus - 2;
-        return cg.pow(exp);
-      }
+      // Chain-able primes route through cg.inverse() below. PrimeFieldType
+      // rejects power-of-2 moduli, so p - 2 >= 1 — never 0, as pow() requires.
+      if (inverseAlgorithm == InverseAlgorithm::Fermat &&
+          !PrimeFieldCodeGen::hasInverseChain(modulus))
+        return cg.pow(modulus - 2);
     }
     return cg.inverse();
   }
@@ -508,6 +507,13 @@ struct ConvertInverse : ConvertFieldOpBase<InverseOp, ConvertInverse> {
     if (isa<BinaryFieldType>(getElementTypeOrSelf(op.getType()))) {
       return failure();
     }
+
+    // Scalar, per-element, and extension lowerings all emit a base-field
+    // inverse internally; carry the choice, keyed on the base prime, to each.
+    APInt baseModulus = getBasePrimeField(getElementTypeOrSelf(op.getOutput()))
+                            .getModulus()
+                            .getValue();
+    ScopedPreferFermatChain preferFermat(preferFermatChain(baseModulus));
 
     auto tensorType = dyn_cast<RankedTensorType>(op.getOutput().getType());
     if (!tensorType)

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/PrimeFieldCodeGen.cpp
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/PrimeFieldCodeGen.cpp
@@ -15,8 +15,17 @@ limitations under the License.
 
 #include "prime_ir/Dialect/Field/Conversions/FieldToModArith/PrimeFieldCodeGen.h"
 
+#include <algorithm>
+#include <functional>
+#include <map>
+#include <optional>
+#include <utility>
+
+#include "llvm/ADT/APInt.h"
+#include "mlir/IR/TypeUtilities.h"
 #include "prime_ir/Dialect/ModArith/IR//ModArithOperation.h"
 #include "prime_ir/Dialect/ModArith/IR/ModArithOps.h"
+#include "prime_ir/Dialect/ModArith/IR/ModArithTypes.h"
 #include "prime_ir/Utils/BuilderContext.h"
 
 namespace mlir::prime_ir::field {
@@ -80,7 +89,72 @@ PrimeFieldCodeGen PrimeFieldCodeGen::Square() const {
 
 PrimeFieldCodeGen PrimeFieldCodeGen::Inverse() const {
   ImplicitLocOpBuilder *b = BuilderContext::GetInstance().Top();
+  if (BuilderContext::GetInstance().PreferFermatChain()) {
+    if (auto modType = dyn_cast<mod_arith::ModArithType>(
+            getElementTypeOrSelf(value.getType())))
+      if (auto ab = detectSolinasForm(modType.getModulus().getValue()))
+        return solinasInverseChain(ab->first, ab->second);
+  }
   return PrimeFieldCodeGen(mod_arith::InverseOp::create(*b, value).getOutput());
+}
+
+std::optional<std::pair<unsigned, unsigned>>
+PrimeFieldCodeGen::detectSolinasForm(const APInt &modulus) {
+  // p = 2^a - 2^b + 1  <=>  p - 2 = (2^a - 1) - 2^b, i.e. all bits in [0, a)
+  // set except a single zero at bit b. Detect that shape and read off (a, b).
+  if (modulus.ult(5))
+    return std::nullopt;
+  APInt e = modulus - 2;
+  unsigned a = e.getActiveBits(); // bit a-1 is the top set bit
+  APInt zeros = APInt::getLowBitsSet(e.getBitWidth(), a) ^ e; // zero bits < a
+  if (!zeros.isPowerOf2()) // need exactly one zero bit in [0, a)
+    return std::nullopt;
+  unsigned b = zeros.logBase2();
+  // Both runs must be non-empty: low = bits [0,b), high = bits (b,a).
+  if (b == 0 || b + 1 >= a)
+    return std::nullopt;
+  return std::make_pair(a, b);
+}
+
+// x -> x^(p-2) for p = 2^a - 2^b + 1, branch-free. With R_k = 2^k - 1,
+// p-2 = R_{a-1-b}·2^{b+1} + R_b, so x^(p-2) = (x^R_{a-1-b})^{2^{b+1}}·x^R_b.
+PrimeFieldCodeGen PrimeFieldCodeGen::solinasInverseChain(unsigned a,
+                                                         unsigned b) const {
+  PrimeFieldCodeGen x = *this;
+  auto sq = [](PrimeFieldCodeGen v, unsigned n) {
+    for (unsigned i = 0; i < n; ++i)
+      v = v.Square();
+    return v;
+  };
+  std::map<unsigned, PrimeFieldCodeGen> memo;
+  std::function<PrimeFieldCodeGen(unsigned)> rk =
+      [&](unsigned k) -> PrimeFieldCodeGen {
+    auto it = memo.find(k);
+    if (it != memo.end())
+      return it->second;
+    PrimeFieldCodeGen v;
+    if (k == 1)
+      v = x; // R_1 = x
+    else if (k % 2 == 0)
+      v = sq(rk(k / 2), k / 2) * rk(k / 2); // R_{2m} = (R_m)^{2^m} · R_m
+    else
+      v = rk(k - 1).Square() * x; // R_{2m+1} = (R_{2m})^2 · x
+    memo.emplace(k, v);
+    return v;
+  };
+
+  unsigned hiRun = a - 1 - b; // high run of ones: bits (b, a)
+  unsigned loRun = b;         // low run of ones:  bits [0, b)
+  unsigned lo = std::min(hiRun, loRun), hi = std::max(hiRun, loRun);
+  PrimeFieldCodeGen rLo = rk(lo);
+  PrimeFieldCodeGen rHi = (hi == lo + 1) ? (rLo.Square() * x) : rk(hi);
+  PrimeFieldCodeGen rHiRun = (hiRun == hi) ? rHi : rLo;
+  PrimeFieldCodeGen rLoRun = (loRun == hi) ? rHi : rLo;
+  return sq(rHiRun, b + 1) * rLoRun; // (x^R_{a-1-b})^{2^{b+1}} · x^R_b
+}
+
+bool PrimeFieldCodeGen::hasInverseChain(const APInt &modulus) {
+  return detectSolinasForm(modulus).has_value();
 }
 
 PrimeFieldCodeGen PrimeFieldCodeGen::CreateConst(int64_t constant) const {

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/PrimeFieldCodeGen.h
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/PrimeFieldCodeGen.h
@@ -16,6 +16,10 @@ limitations under the License.
 #ifndef PRIME_IR_DIALECT_FIELD_CONVERSIONS_FIELDTOMODARITH_PRIMEFIELDCODEGEN_H_
 #define PRIME_IR_DIALECT_FIELD_CONVERSIONS_FIELDTOMODARITH_PRIMEFIELDCODEGEN_H_
 
+#include <optional>
+#include <utility>
+
+#include "llvm/ADT/APInt.h"
 #include "mlir/IR/Value.h"
 
 namespace zk_dtypes {
@@ -52,6 +56,10 @@ public:
 
   operator Value() const { return value; }
 
+  // Whether `modulus` is a Solinas prime p = 2^a - 2^b + 1, for which
+  // Inverse() emits an addition chain instead of a generic pow / safegcd.
+  static bool hasInverseChain(const APInt &modulus);
+
   PrimeFieldCodeGen operator+(const PrimeFieldCodeGen &other) const;
   PrimeFieldCodeGen &operator+=(const PrimeFieldCodeGen &other);
   PrimeFieldCodeGen operator-(const PrimeFieldCodeGen &other) const;
@@ -80,6 +88,14 @@ private:
   PrimeFieldCodeGen Double() const;
   PrimeFieldCodeGen Square() const;
   PrimeFieldCodeGen Inverse() const;
+
+  // If `modulus` is a Solinas prime p = 2^a - 2^b + 1, returns (a, b).
+  static std::optional<std::pair<unsigned, unsigned>>
+  detectSolinasForm(const APInt &modulus);
+
+  // x -> x^(p-2) for p = 2^a - 2^b + 1, as a branch-free addition chain.
+  PrimeFieldCodeGen solinasInverseChain(unsigned a, unsigned b) const;
+
   PrimeFieldCodeGen CreateConst(int64_t constant) const;
   PrimeFieldCodeGen CreateRationalConst(int64_t num, int64_t denom) const;
 

--- a/prime_ir/Utils/BuilderContext.h
+++ b/prime_ir/Utils/BuilderContext.h
@@ -33,10 +33,16 @@ public:
   void Pop() { builders.pop_back(); }
   ImplicitLocOpBuilder *Top() { return builders.back(); }
 
+  // Set from the inverse-algorithm option, so that inverses emitted deep inside
+  // an extension lowering — which never see the pass option — can honor it.
+  void SetPreferFermatChain(bool v) { preferFermatChain = v; }
+  bool PreferFermatChain() const { return preferFermatChain; }
+
 private:
   BuilderContext() = default;
 
   SmallVector<ImplicitLocOpBuilder *> builders;
+  bool preferFermatChain = false;
 };
 
 class ScopedBuilderContext {
@@ -45,6 +51,20 @@ public:
     BuilderContext::GetInstance().Push(b);
   }
   ~ScopedBuilderContext() { BuilderContext::GetInstance().Pop(); }
+};
+
+class ScopedPreferFermatChain {
+public:
+  explicit ScopedPreferFermatChain(bool v)
+      : prev(BuilderContext::GetInstance().PreferFermatChain()) {
+    BuilderContext::GetInstance().SetPreferFermatChain(v);
+  }
+  ~ScopedPreferFermatChain() {
+    BuilderContext::GetInstance().SetPreferFermatChain(prev);
+  }
+
+private:
+  bool prev;
 };
 
 } // namespace mlir::prime_ir

--- a/tests/Dialect/Field/addchain_inverse.mlir
+++ b/tests/Dialect/Field/addchain_inverse.mlir
@@ -1,0 +1,125 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// Every Solinas prime p = 2^a - 2^b + 1 (its p-2 has one zero bit) is
+// auto-detected from the modulus and lowered under fermat to ONE general
+// branch-free addition chain — a fixed count of mod_arith.mul (+ square), no
+// mod_arith.inverse, no per-field code. A non-Solinas prime expands via the
+// generic square-and-multiply; bernstein-yang keeps mod_arith.inverse (safegcd).
+// RUN: prime-ir-opt %s -field-to-mod-arith="inverse-algorithm=fermat" -split-input-file | FileCheck %s -check-prefix=FERMAT
+// RUN: prime-ir-opt %s -field-to-mod-arith="inverse-algorithm=bernstein-yang" -split-input-file | FileCheck %s -check-prefix=BY
+
+// Goldilocks: p = 2^64 - 2^32 + 1 (a=64, b=32). Chain: 64 squarings + 10 muls.
+!G = !field.pf<18446744069414584321 : i64>
+// FERMAT-LABEL: @goldilocks_inverse
+// FERMAT-NOT: mod_arith.inverse
+// FERMAT-COUNT-10: mod_arith.mul
+// FERMAT-NOT: mod_arith.mul
+// BY-LABEL: @goldilocks_inverse
+// BY: mod_arith.inverse
+func.func @goldilocks_inverse(%a: !G) -> !G {
+  %r = field.inverse %a : !G
+  return %r : !G
+}
+
+// -----
+
+// BabyBear: p = 2^31 - 2^27 + 1 (a=31, b=27). Chain: 54 squarings + 8 muls.
+!BB = !field.pf<2013265921 : i32>
+// FERMAT-LABEL: @babybear_inverse
+// FERMAT-NOT: mod_arith.inverse
+// FERMAT-COUNT-8: mod_arith.mul
+// FERMAT-NOT: mod_arith.mul
+// BY-LABEL: @babybear_inverse
+// BY: mod_arith.inverse
+func.func @babybear_inverse(%a: !BB) -> !BB {
+  %r = field.inverse %a : !BB
+  return %r : !BB
+}
+
+// -----
+
+// KoalaBear: p = 2^31 - 2^24 + 1 (a=31, b=24). Chain: 48 squarings + 6 muls.
+!KB = !field.pf<2130706433 : i32>
+// FERMAT-LABEL: @koalabear_inverse
+// FERMAT-NOT: mod_arith.inverse
+// FERMAT-COUNT-6: mod_arith.mul
+// FERMAT-NOT: mod_arith.mul
+// BY-LABEL: @koalabear_inverse
+// BY: mod_arith.inverse
+func.func @koalabear_inverse(%a: !KB) -> !KB {
+  %r = field.inverse %a : !KB
+  return %r : !KB
+}
+
+// -----
+
+// Mersenne31: p = 2^31 - 1 = 2^31 - 2^1 + 1 (a=31, b=1). Same general chain,
+// no per-field code — 30 squarings + 8 muls.
+!M31 = !field.pf<2147483647 : i32>
+// FERMAT-LABEL: @mersenne31_inverse
+// FERMAT-NOT: mod_arith.inverse
+// FERMAT-COUNT-8: mod_arith.mul
+// FERMAT-NOT: mod_arith.mul
+// BY-LABEL: @mersenne31_inverse
+// BY: mod_arith.inverse
+func.func @mersenne31_inverse(%a: !M31) -> !M31 {
+  %r = field.inverse %a : !M31
+  return %r : !M31
+}
+
+// -----
+
+// A non-Solinas prime (2^64 - 59): p-2 is not "all ones except one zero", so no
+// short chain — fermat falls back to the generic square-and-multiply (one mul
+// per set bit, far more than the chains above), no safegcd op.
+!P = !field.pf<18446744073709551557 : i64>
+// FERMAT-LABEL: @non_solinas_inverse
+// FERMAT-NOT: mod_arith.inverse
+// FERMAT-COUNT-16: mod_arith.mul
+func.func @non_solinas_inverse(%a: !P) -> !P {
+  %r = field.inverse %a : !P
+  return %r : !P
+}
+
+// -----
+
+// A prime whose p-2 is a "random" bit pattern (~30 runs of ones): a run-chain
+// would cost about as many muls as a generic square-and-multiply, so `fermat`
+// falls back to the generic pow (one mul per set bit — far more than 9).
+!Q = !field.pf<12297829382473034303 : i64>
+// FERMAT-LABEL: @generic_pow_inverse
+// FERMAT-NOT: mod_arith.inverse
+// FERMAT-COUNT-30: mod_arith.mul
+func.func @generic_pow_inverse(%a: !Q) -> !Q {
+  %r = field.inverse %a : !Q
+  return %r : !Q
+}
+
+// -----
+
+// Cubic extension over Goldilocks: the norm-trick's internal base-field inverse
+// also uses the chain under fermat (no safegcd op), and safegcd under
+// bernstein-yang — the option reaches the extension base inverse too.
+!G = !field.pf<18446744069414584321 : i64>
+!C = !field.ef<3x!G, 7:i64>
+// FERMAT-LABEL: @goldilocks_cubic_inverse
+// FERMAT-NOT: mod_arith.inverse
+// BY-LABEL: @goldilocks_cubic_inverse
+// BY: mod_arith.inverse
+func.func @goldilocks_cubic_inverse(%a: !C) -> !C {
+  %r = field.inverse %a : !C
+  return %r : !C
+}

--- a/tests/Dialect/Field/addchain_inverse_runner.mlir
+++ b/tests/Dialect/Field/addchain_inverse_runner.mlir
@@ -1,0 +1,241 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// Executes the specialized Fermat-chain inverse (inverse-algorithm=fermat) for
+// each registered field — Goldilocks, BabyBear, KoalaBear — and checks
+// a * inv(a) == 1 (canonical, and Montgomery for Goldilocks), the p-1 boundary,
+// and inv(0) == 0 (matching safegcd's convention, so 0 * inv(0) == 0). The
+// Goldilocks case also covers the cubic extension's internal base inverse.
+
+// RUN: prime-ir-opt %s -field-to-mod-arith="inverse-algorithm=fermat" -mod-arith-to-arith -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
+// RUN:   | mlir-runner -e test_goldilocks_inverse -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_INV < %t
+
+// RUN: prime-ir-opt %s -field-to-mod-arith="inverse-algorithm=fermat" -mod-arith-to-arith -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
+// RUN:   | mlir-runner -e test_goldilocks_mont_inverse -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_MONT_INV < %t
+
+// RUN: prime-ir-opt %s -field-to-mod-arith="inverse-algorithm=fermat" -mod-arith-to-arith -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
+// RUN:   | mlir-runner -e test_goldilocks_inverse_edge -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_EDGE < %t
+
+// RUN: prime-ir-opt %s -field-to-mod-arith="inverse-algorithm=fermat" -mod-arith-to-arith -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
+// RUN:   | mlir-runner -e test_goldilocks_inverse_zero -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_ZERO < %t
+
+// RUN: prime-ir-opt %s -field-to-mod-arith="inverse-algorithm=fermat" -mod-arith-to-arith -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
+// RUN:   | mlir-runner -e test_goldilocks_cubic_inverse -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_CUBIC < %t
+
+// RUN: prime-ir-opt %s -field-to-mod-arith="inverse-algorithm=fermat" -mod-arith-to-arith -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
+// RUN:   | mlir-runner -e test_babybear_inverse -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_BB < %t
+
+// RUN: prime-ir-opt %s -field-to-mod-arith="inverse-algorithm=fermat" -mod-arith-to-arith -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
+// RUN:   | mlir-runner -e test_koalabear_inverse -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_KB < %t
+
+// RUN: prime-ir-opt %s -field-to-mod-arith="inverse-algorithm=fermat" -mod-arith-to-arith -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
+// RUN:   | mlir-runner -e test_mersenne31_inverse -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_M31 < %t
+
+func.func private @printMemrefI32(memref<*xi32>) attributes { llvm.emit_c_interface }
+
+// Goldilocks: p = 2^64 - 2^32 + 1 = 18446744069414584321
+!G = !field.pf<18446744069414584321 : i64>
+!Gm = !field.pf<18446744069414584321 : i64, true>
+!C = !field.ef<3x!G, 7:i64>
+
+func.func @check(%v: !G) {
+  %vi = field.bitcast %v : !G -> i64
+  %v32 = arith.trunci %vi : i64 to i32
+  %t = tensor.from_elements %v32 : tensor<1xi32>
+  %m = bufferization.to_buffer %t : tensor<1xi32> to memref<1xi32>
+  %U = memref.cast %m : memref<1xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U) : (memref<*xi32>) -> ()
+  return
+}
+
+func.func @test_goldilocks_inverse() {
+  %ai = arith.constant 123456789 : i64
+  %a = field.bitcast %ai : i64 -> !G
+  %inv = field.inverse %a : !G
+  %check = field.mul %inv, %a : !G
+  func.call @check(%check) : (!G) -> ()
+  return
+}
+// CHECK_INV: [1]
+
+func.func @test_goldilocks_mont_inverse() {
+  %ai = arith.constant 987654321 : i64
+  %a = field.bitcast %ai : i64 -> !G
+  %a_mont = field.to_mont %a : !Gm
+  %inv_mont = field.inverse %a_mont : !Gm
+  %check_mont = field.mul %inv_mont, %a_mont : !Gm
+  %check = field.from_mont %check_mont : !G
+  func.call @check(%check) : (!G) -> ()
+  return
+}
+// CHECK_MONT_INV: [1]
+
+func.func @test_goldilocks_inverse_edge() {
+  // a = p - 1, whose inverse is itself; a * inv(a) must still be 1.
+  %ai = arith.constant 18446744069414584320 : i64
+  %a = field.bitcast %ai : i64 -> !G
+  %inv = field.inverse %a : !G
+  %check = field.mul %inv, %a : !G
+  func.call @check(%check) : (!G) -> ()
+  return
+}
+// CHECK_EDGE: [1]
+
+func.func @test_goldilocks_inverse_zero() {
+  // inv(0) = 0^(p-2) = 0 (matches safegcd's convention for a non-invertible 0);
+  // a * inv(a) = 0.
+  %ai = arith.constant 0 : i64
+  %a = field.bitcast %ai : i64 -> !G
+  %inv = field.inverse %a : !G
+  %check = field.mul %inv, %a : !G
+  func.call @check(%check) : (!G) -> ()
+  return
+}
+// CHECK_ZERO: [0]
+
+func.func @check3(%v: !C) {
+  %v0, %v1, %v2 = field.ext_to_coeffs %v : (!C) -> (!G, !G, !G)
+  %i0 = field.bitcast %v0 : !G -> i64
+  %i1 = field.bitcast %v1 : !G -> i64
+  %i2 = field.bitcast %v2 : !G -> i64
+  %c0 = arith.trunci %i0 : i64 to i32
+  %c1 = arith.trunci %i1 : i64 to i32
+  %c2 = arith.trunci %i2 : i64 to i32
+  %t = tensor.from_elements %c0, %c1, %c2 : tensor<3xi32>
+  %m = bufferization.to_buffer %t : tensor<3xi32> to memref<3xi32>
+  %U = memref.cast %m : memref<3xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U) : (memref<*xi32>) -> ()
+  return
+}
+
+// Cubic (Goldilocks^3) inverse: exercises the norm-trick's base inverse running
+// as the Fermat chain; a * inv(a) must be the identity (1, 0, 0).
+func.func @test_goldilocks_cubic_inverse() {
+  %a = field.constant [7, 11, 13] : !C
+  %inv = field.inverse %a : !C
+  %check = field.mul %inv, %a : !C
+  func.call @check3(%check) : (!C) -> ()
+  return
+}
+// CHECK_CUBIC: [1, 0, 0]
+
+// BabyBear: p = 2^31 - 2^27 + 1 = 2013265921. Each result element is
+// a * inv(a): [canonical, p-1 boundary, zero] = [1, 1, 0].
+!BB = !field.pf<2013265921 : i32>
+
+func.func @test_babybear_inverse() {
+  %c0 = arith.constant 123456 : i32
+  %a0 = field.bitcast %c0 : i32 -> !BB
+  %i0 = field.inverse %a0 : !BB
+  %m0 = field.mul %i0, %a0 : !BB
+  %r0 = field.bitcast %m0 : !BB -> i32
+
+  %c1 = arith.constant 2013265920 : i32 // p - 1
+  %a1 = field.bitcast %c1 : i32 -> !BB
+  %i1 = field.inverse %a1 : !BB
+  %m1 = field.mul %i1, %a1 : !BB
+  %r1 = field.bitcast %m1 : !BB -> i32
+
+  %c2 = arith.constant 0 : i32
+  %a2 = field.bitcast %c2 : i32 -> !BB
+  %i2 = field.inverse %a2 : !BB
+  %m2 = field.mul %i2, %a2 : !BB
+  %r2 = field.bitcast %m2 : !BB -> i32
+
+  %t = tensor.from_elements %r0, %r1, %r2 : tensor<3xi32>
+  %m = bufferization.to_buffer %t : tensor<3xi32> to memref<3xi32>
+  %U = memref.cast %m : memref<3xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U) : (memref<*xi32>) -> ()
+  return
+}
+// CHECK_BB: [1, 1, 0]
+
+// KoalaBear: p = 2^31 - 2^24 + 1 = 2130706433. [canonical, p-1, zero] = [1, 1, 0].
+!KB = !field.pf<2130706433 : i32>
+
+func.func @test_koalabear_inverse() {
+  %c0 = arith.constant 654321 : i32
+  %a0 = field.bitcast %c0 : i32 -> !KB
+  %i0 = field.inverse %a0 : !KB
+  %m0 = field.mul %i0, %a0 : !KB
+  %r0 = field.bitcast %m0 : !KB -> i32
+
+  %c1 = arith.constant 2130706432 : i32 // p - 1
+  %a1 = field.bitcast %c1 : i32 -> !KB
+  %i1 = field.inverse %a1 : !KB
+  %m1 = field.mul %i1, %a1 : !KB
+  %r1 = field.bitcast %m1 : !KB -> i32
+
+  %c2 = arith.constant 0 : i32
+  %a2 = field.bitcast %c2 : i32 -> !KB
+  %i2 = field.inverse %a2 : !KB
+  %m2 = field.mul %i2, %a2 : !KB
+  %r2 = field.bitcast %m2 : !KB -> i32
+
+  %t = tensor.from_elements %r0, %r1, %r2 : tensor<3xi32>
+  %m = bufferization.to_buffer %t : tensor<3xi32> to memref<3xi32>
+  %U = memref.cast %m : memref<3xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U) : (memref<*xi32>) -> ()
+  return
+}
+// CHECK_KB: [1, 1, 0]
+
+// Mersenne31: p = 2^31 - 1 = 2147483647. Auto-detected Solinas (a=31, b=1),
+// lowered via the general chain (no hand-tuned override). [canonical, p-1, zero]
+// = [1, 1, 0] confirms the general chain computes a^(p-2) correctly.
+!M31 = !field.pf<2147483647 : i32>
+
+func.func @test_mersenne31_inverse() {
+  %c0 = arith.constant 424242 : i32
+  %a0 = field.bitcast %c0 : i32 -> !M31
+  %i0 = field.inverse %a0 : !M31
+  %m0 = field.mul %i0, %a0 : !M31
+  %r0 = field.bitcast %m0 : !M31 -> i32
+
+  %c1 = arith.constant 2147483646 : i32 // p - 1
+  %a1 = field.bitcast %c1 : i32 -> !M31
+  %i1 = field.inverse %a1 : !M31
+  %m1 = field.mul %i1, %a1 : !M31
+  %r1 = field.bitcast %m1 : !M31 -> i32
+
+  %c2 = arith.constant 0 : i32
+  %a2 = field.bitcast %c2 : i32 -> !M31
+  %i2 = field.inverse %a2 : !M31
+  %m2 = field.mul %i2, %a2 : !M31
+  %r2 = field.bitcast %m2 : !M31 -> i32
+
+  %t = tensor.from_elements %r0, %r1, %r2 : tensor<3xi32>
+  %m = bufferization.to_buffer %t : tensor<3xi32> to memref<3xi32>
+  %U = memref.cast %m : memref<3xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U) : (memref<*xi32>) -> ()
+  return
+}
+// CHECK_M31: [1, 1, 0]

--- a/tests/Dialect/Field/auto_inverse_gate.mlir
+++ b/tests/Dialect/Field/auto_inverse_gate.mlir
@@ -1,0 +1,63 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// The `auto` inverse policy: take the specialized Solinas chain (branch-free
+// mod_arith.mul/square, no mod_arith.inverse) ONLY for a Solinas prime
+// p = 2^a - 2^b + 1 that is <= 64 bits; otherwise lower via safegcd
+// (mod_arith.inverse). Explicit `fermat` ignores the width gate and always
+// takes Fermat (chain for Solinas, generic pow otherwise), shown for contrast.
+// RUN: prime-ir-opt %s -field-to-mod-arith="inverse-algorithm=auto" -split-input-file | FileCheck %s -check-prefix=AUTO
+// RUN: prime-ir-opt %s -field-to-mod-arith="inverse-algorithm=fermat" -split-input-file | FileCheck %s -check-prefix=FERMAT
+
+// Narrow Solinas prime (Goldilocks, 64-bit): auto takes the chain.
+!G = !field.pf<18446744069414584321 : i64>
+// AUTO-LABEL: @narrow_solinas
+// AUTO-NOT: mod_arith.inverse
+// AUTO: mod_arith.mul
+func.func @narrow_solinas(%a: !G) -> !G {
+  %r = field.inverse %a : !G
+  return %r : !G
+}
+
+// -----
+
+// Wide Solinas prime (Mersenne127 = 2^127 - 1, 127-bit): the chain's ~127
+// squarings lose to safegcd, so auto uses safegcd — but explicit fermat still
+// emits the chain (no safegcd op) for a caller who wants it.
+!M127 = !field.pf<170141183460469231731687303715884105727 : i128>
+// AUTO-LABEL: @wide_solinas
+// AUTO: mod_arith.inverse
+// FERMAT-LABEL: @wide_solinas
+// FERMAT-NOT: mod_arith.inverse
+func.func @wide_solinas(%a: !M127) -> !M127 {
+  %r = field.inverse %a : !M127
+  return %r : !M127
+}
+
+// -----
+
+// Non-Solinas prime (2^64 - 59): no short chain, so auto uses safegcd; explicit
+// fermat falls back to the generic square-and-multiply (branch-free, still no
+// safegcd op).
+!P = !field.pf<18446744073709551557 : i64>
+// AUTO-LABEL: @non_solinas
+// AUTO: mod_arith.inverse
+// FERMAT-LABEL: @non_solinas
+// FERMAT-NOT: mod_arith.inverse
+// FERMAT: mod_arith.mul
+func.func @non_solinas(%a: !P) -> !P {
+  %r = field.inverse %a : !P
+  return %r : !P
+}


### PR DESCRIPTION
## Description

The field-level Fermat inverse path (`inverse-algorithm=fermat`/`auto`) lowered
`x^(p-2)` as a generic square-and-multiply — ~125 field ops for Goldilocks
(`p = 2^64 - 2^32 + 1`), whose `p-2` has 63 set bits. Goldilocks has a much
shorter addition chain (`p-2 = R31·2^33 + R32`, `Rk = 2^k - 1`): 64 squarings +
9 multiplications, same divergence-free straight-line shape.

This emits that chain at the `PrimeFieldCodeGen` level (`FermatInverse`), gated
by a `BuilderContext` `PreferFermatChain` flag set once in
`ConvertInverse::matchAndRewrite`. A single source then covers **all three**
lowerings that emit a base-field inverse:

- **scalar** `field.inverse`,
- **per-element** (elementwise/batch tensor) inverse, and
- the **extension-field** norm-trick's internal base inverse (e.g. cubic
  `Goldilocks^3`) — which is emitted deep inside the extension lowering and
  never sees the pass option directly.

The policy stays where it already lives: other primes keep the generic `pow`,
and `bernstein-yang` still selects safegcd — the option contract is preserved.
Detection reuses the shared `getKnownModulusAlias`. Representation-agnostic:
square/mul lower to the Montgomery variants (which preserve the `·R` encoding),
so one chain serves both reps.

Measured on an RTX 5090, per 16.7M elements: Goldilocks **base** inverse
**0.70 ms vs 1.42 ms for the Bernstein-Yang loop (~2.0×)**, matching pil2's
hand-tuned `gl64_t.reciprocal()` (0.66 ms); the **cubic** inverse lands at
**0.95 ms == pil2 `Goldilocks3GPU::inv`**. This is on the critical path of every
field inverse — quotient, FRI, evals, DEEP.

Tests: under `fermat`, scalar and cubic `field.inverse` emit the chain with no
`mod_arith.inverse` safegcd op (9 muls for scalar); `bernstein-yang` keeps the
safegcd op. The runner checks `a·inv(a)==1` for canonical, Montgomery, and the
`p-1` boundary, `inv(0)==0`, and the cubic identity `a·inv(a) == (1,0,0)`.

## Related Issues/PRs

Closes #397

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline
