### PR TITLE
perf(dialect/field): lower wide binary tower inverse via recursive norm descent

### DIFF
--- a/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldCodeGen.cpp
+++ b/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldCodeGen.cpp
@@ -70,8 +70,18 @@ BinaryFieldCodeGen BinaryFieldCodeGen::inverse() const {
     return inverseLookupTable();
   }
 
-  // Use Fermat's little theorem: a⁻¹ = a^(2ⁿ - 2) in GF(2ⁿ)
-  // where n = 2^towerLevel
+  // Levels ≥ 4: recursive tower descent. An inlined Fermat chain here is
+  // (n−1) squares + (n−2) full Karatsuba muls and grows ~6× per level —
+  // GF(2⁶⁴) is ~0.5M arith ops per scalar inverse, which blows up compile
+  // time in every consumer pipeline. Descent is I(k) = I(k−1) + O(M(k−1)).
+  if (towerLevel >= 4) {
+    Value result = inverseTower(value_, towerLevel);
+    return BinaryFieldCodeGen(bfType_, result, builder_);
+  }
+
+  // Levels ≤ 2 (n ≤ 4 bits): Fermat's little theorem, a⁻¹ = a^(2ⁿ - 2).
+  // At these widths the chain is at most 3 squares + 2 muls — smaller than
+  // the descent's constant overhead.
   unsigned bitWidth = bfType_.getBitWidth();
 
   // Start with a²
@@ -88,7 +98,58 @@ BinaryFieldCodeGen BinaryFieldCodeGen::inverse() const {
   return BinaryFieldCodeGen(bfType_, result, builder_);
 }
 
+Value BinaryFieldCodeGen::inverseTower(Value a, unsigned towerLevel) const {
+  // Base case: GF(2⁸) table lookup (0 → 0, matching binius invert_or_zero).
+  if (towerLevel == 3) {
+    return inverseLookupTable8b(a);
+  }
+
+  // Fan-Paar descent for a = a₀ + a₁·X over GF(2^(2ᵏ⁻¹)), X² = β·X + 1:
+  // the Frobenius conjugate is ā = (a₀ + β·a₁) + a₁·X (X ↦ X + β, the other
+  // root), and the norm N = a·ā = a₀² + β·a₀·a₁ + a₁² lies in the subfield
+  // (its X coefficient cancels in characteristic 2). Then a⁻¹ = ā·N⁻¹, so
+  // one level costs 3 muls + 2 squares + 2 β-muls + one recursive inverse.
+  // a = 0 gives N = 0 and propagates 0 up from the base case.
+  unsigned halfBits = 1u << (towerLevel - 1);
+  IntegerType halfType = IntegerType::get(builder_.getContext(), halfBits);
+  IntegerType fullType = IntegerType::get(builder_.getContext(), halfBits * 2);
+
+  Value a0 = arith::TruncIOp::create(builder_, halfType, a);
+  Value halfBitsConst = arith::ConstantIntOp::create(
+      builder_, static_cast<int64_t>(halfBits), fullType.getWidth());
+  Value a1 = arith::TruncIOp::create(
+      builder_, halfType, arith::ShRUIOp::create(builder_, a, halfBitsConst));
+
+  // conj_lo = a₀ + β·a₁ (the conjugate's X coefficient is a₁ unchanged).
+  Value betaA1 = mulXTower(a1, towerLevel - 1);
+  Value conjLo = arith::XOrIOp::create(builder_, a0, betaA1);
+
+  // N = a₀² + β·(a₀·a₁) + a₁²
+  Value a0a1 = mulTower(a0, a1, towerLevel - 1);
+  Value betaA0a1 = mulXTower(a0a1, towerLevel - 1);
+  Value a0Sq = squareTower(a0, towerLevel - 1);
+  Value a1Sq = squareTower(a1, towerLevel - 1);
+  Value norm = arith::XOrIOp::create(
+      builder_, arith::XOrIOp::create(builder_, a0Sq, betaA0a1), a1Sq);
+
+  Value normInv = inverseTower(norm, towerLevel - 1);
+
+  // a⁻¹ = (a₀ + β·a₁)·N⁻¹ + a₁·N⁻¹·X
+  Value resultLo = mulTower(conjLo, normInv, towerLevel - 1);
+  Value resultHi = mulTower(a1, normInv, towerLevel - 1);
+
+  Value resultLoExt = arith::ExtUIOp::create(builder_, fullType, resultLo);
+  Value resultHiExt = arith::ExtUIOp::create(builder_, fullType, resultHi);
+  Value resultHiShifted =
+      arith::ShLIOp::create(builder_, resultHiExt, halfBitsConst);
+  return arith::OrIOp::create(builder_, resultLoExt, resultHiShifted);
+}
+
 BinaryFieldCodeGen BinaryFieldCodeGen::inverseLookupTable() const {
+  return BinaryFieldCodeGen(bfType_, inverseLookupTable8b(value_), builder_);
+}
+
+Value BinaryFieldCodeGen::inverseLookupTable8b(Value a) const {
   // Generate lookup table as a global constant memref and use it
   // For now, generate inline switch-case style code using arith ops
   // Future optimization: use LLVM global constant + load
@@ -106,7 +167,7 @@ BinaryFieldCodeGen BinaryFieldCodeGen::inverseLookupTable() const {
   // which will be lowered to an efficient jump table
 
   auto indexValue =
-      arith::IndexCastUIOp::create(builder_, builder_.getIndexType(), value_);
+      arith::IndexCastUIOp::create(builder_, builder_.getIndexType(), a);
 
   // Create switch with all 256 cases
   SmallVector<int64_t> caseValues;
@@ -140,7 +201,7 @@ BinaryFieldCodeGen BinaryFieldCodeGen::inverseLookupTable() const {
   // Move insertion point back after switch
   builder_.setInsertionPointAfter(switchOp);
 
-  return BinaryFieldCodeGen(bfType_, switchOp.getResult(0), builder_);
+  return switchOp.getResult(0);
 }
 
 BinaryFieldCodeGen BinaryFieldCodeGen::constant(BinaryFieldType bfType,

--- a/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldCodeGen.h
+++ b/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldCodeGen.h
@@ -36,7 +36,8 @@ namespace mlir::prime_ir::field {
 // - Doubling: Zero (2a = a + a = 0 in characteristic 2)
 // - Multiplication: Karatsuba tower multiplication
 // - Squaring: Optimized using Frobenius endomorphism
-// - Inverse: Fermat's little theorem: a⁻¹ = a^(2ⁿ - 2)
+// - Inverse: recursive tower descent via the subfield norm (levels ≥ 4),
+//   lookup table (level 3), Fermat's little theorem (levels ≤ 2)
 class BinaryFieldCodeGen {
 public:
   BinaryFieldCodeGen(BinaryFieldType bfType, Value value,
@@ -99,9 +100,18 @@ private:
   // realized recursively rather than as a multiply by an α table entry.
   Value mulXTower(Value a, unsigned towerLevel) const;
 
+  // Recursive tower-descent inverse for tower level k ≥ 3: one inverse a
+  // level down plus a constant number of level-(k−1) muls/squares, so the
+  // generated IR grows linearly in level instead of the ~6ᵏ of an inlined
+  // Fermat chain. Bottoms out in the level-3 lookup table.
+  Value inverseTower(Value a, unsigned towerLevel) const;
+
   // Lookup table-based inverse for bf<8> (tower level 3)
   // Uses O(1) table lookup instead of O(n) Fermat computation
   BinaryFieldCodeGen inverseLookupTable() const;
+
+  // Same lookup on an explicit level-3 (i8) value — the descent base case.
+  Value inverseLookupTable8b(Value a) const;
 };
 
 } // namespace mlir::prime_ir::field

--- a/tests/Dialect/Field/binary_field_runner.mlir
+++ b/tests/Dialect/Field/binary_field_runner.mlir
@@ -251,8 +251,9 @@ func.func @test_bf128_inverse_known() {
 }
 // CHECK: {{^}}[3]
 
-// Test: BF128 full-width inverse round-trip — prints the low i32 of x·x⁻¹
-// (1) and the XOR-fold of the three upper 32-bit limbs (0).
+// Test: BF128 full-width inverse round-trip — prints all four 32-bit limbs
+// of x·x⁻¹ independently (an XOR-fold of the upper limbs could false-pass,
+// e.g. [1, e, e, 0]).
 func.func @test_bf128_inverse_roundtrip() {
   %x = field.constant 0x0123456789ABCDEFFEDCBA9876543210 : !BF128
   %xinv = field.inverse %x : !BF128
@@ -263,22 +264,19 @@ func.func @test_bf128_inverse_roundtrip() {
   %c32 = arith.constant 32 : i128
   %c64 = arith.constant 64 : i128
   %c96 = arith.constant 96 : i128
-  %l1 = arith.trunci %p_i128 : i128 to i32
   %s1 = arith.shrui %p_i128, %c32 : i128
   %s2 = arith.shrui %p_i128, %c64 : i128
   %s3 = arith.shrui %p_i128, %c96 : i128
   %h1 = arith.trunci %s1 : i128 to i32
   %h2 = arith.trunci %s2 : i128 to i32
   %h3 = arith.trunci %s3 : i128 to i32
-  %hx = arith.xori %h1, %h2 : i32
-  %hi = arith.xori %hx, %h3 : i32
-  %tensor = tensor.from_elements %lo, %hi : tensor<2xi32>
-  %buffer = bufferization.to_buffer %tensor : tensor<2xi32> to memref<2xi32>
-  %cast = memref.cast %buffer : memref<2xi32> to memref<*xi32>
+  %tensor = tensor.from_elements %lo, %h1, %h2, %h3 : tensor<4xi32>
+  %buffer = bufferization.to_buffer %tensor : tensor<4xi32> to memref<4xi32>
+  %cast = memref.cast %buffer : memref<4xi32> to memref<*xi32>
   func.call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
   return
 }
-// CHECK: {{^}}[1, 0]
+// CHECK: {{^}}[1, 0, 0, 0]
 
 // Test: BF64 inverse of zero is zero (invert_or_zero, matching binius and
 // the level-3 lookup table's 0 → 0 entry).
@@ -288,6 +286,22 @@ func.func @test_bf64_inverse_zero() {
 
   %result_i64 = field.bitcast %c : !BF64 -> i64
   %result = arith.trunci %result_i64 : i64 to i32
+  %tensor = tensor.from_elements %result : tensor<1xi32>
+  %buffer = bufferization.to_buffer %tensor : tensor<1xi32> to memref<1xi32>
+  %cast = memref.cast %buffer : memref<1xi32> to memref<*xi32>
+  func.call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
+  return
+}
+// CHECK: {{^}}[0]
+
+// Test: BF128 inverse of zero is zero — one more descent level of the
+// norm-zero propagation than the BF64 case.
+func.func @test_bf128_inverse_zero() {
+  %a = field.constant 0 : !BF128
+  %c = field.inverse %a : !BF128
+
+  %result_i128 = field.bitcast %c : !BF128 -> i128
+  %result = arith.trunci %result_i128 : i128 to i32
   %tensor = tensor.from_elements %result : tensor<1xi32>
   %buffer = bufferization.to_buffer %tensor : tensor<1xi32> to memref<1xi32>
   %cast = memref.cast %buffer : memref<1xi32> to memref<*xi32>
@@ -312,5 +326,6 @@ func.func @main() {
   func.call @test_bf128_inverse_known() : () -> ()
   func.call @test_bf128_inverse_roundtrip() : () -> ()
   func.call @test_bf64_inverse_zero() : () -> ()
+  func.call @test_bf128_inverse_zero() : () -> ()
   return
 }

--- a/tests/Dialect/Field/binary_field_runner.mlir
+++ b/tests/Dialect/Field/binary_field_runner.mlir
@@ -22,6 +22,7 @@
 // RUN: FileCheck %s < %t
 
 !BF8 = !field.bf<3>     // GF(2^8) tower field
+!BF64 = !field.bf<6>    // GF(2^64) tower field
 !BF128 = !field.bf<7>   // GF(2^128) tower field
 
 func.func private @printMemrefI32(memref<*xi32>) attributes { llvm.emit_c_interface }
@@ -196,6 +197,105 @@ func.func @test_bf128_mul_cross() {
 }
 // CHECK: {{^}}[15]
 
+// Test: BF64 inverse via tower descent. 2 = ω lives in the GF(4) subfield
+// (invariant across tower levels), and ω·(ω+1) = 1, so 2⁻¹ = 3 at every
+// level — an exact known value that exercises the full descent to the
+// level-3 lookup base.
+func.func @test_bf64_inverse_known() {
+  %a = field.constant 2 : !BF64
+  %c = field.inverse %a : !BF64
+
+  %result_i64 = field.bitcast %c : !BF64 -> i64
+  %result = arith.trunci %result_i64 : i64 to i32
+  %tensor = tensor.from_elements %result : tensor<1xi32>
+  %buffer = bufferization.to_buffer %tensor : tensor<1xi32> to memref<1xi32>
+  %cast = memref.cast %buffer : memref<1xi32> to memref<*xi32>
+  func.call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
+  return
+}
+// CHECK: {{^}}[3]
+
+// Test: BF64 full-width inverse round-trip — x·x⁻¹ = 1 for an x that fills
+// all 64 bits, so every descent level does real work. Prints the low i32 of
+// the product (1) then the folded-down high bits (0).
+func.func @test_bf64_inverse_roundtrip() {
+  %x = field.constant 0xDEADBEEFCAFEBABE : !BF64
+  %xinv = field.inverse %x : !BF64
+  %p = field.mul %x, %xinv : !BF64
+
+  %p_i64 = field.bitcast %p : !BF64 -> i64
+  %lo = arith.trunci %p_i64 : i64 to i32
+  %c32 = arith.constant 32 : i64
+  %hi64 = arith.shrui %p_i64, %c32 : i64
+  %hi = arith.trunci %hi64 : i64 to i32
+  %tensor = tensor.from_elements %lo, %hi : tensor<2xi32>
+  %buffer = bufferization.to_buffer %tensor : tensor<2xi32> to memref<2xi32>
+  %cast = memref.cast %buffer : memref<2xi32> to memref<*xi32>
+  func.call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
+  return
+}
+// CHECK: {{^}}[1, 0]
+
+// Test: BF128 inverse known value (same GF(4) embedding as BF64 above).
+func.func @test_bf128_inverse_known() {
+  %a = field.constant 2 : !BF128
+  %c = field.inverse %a : !BF128
+
+  %result_i128 = field.bitcast %c : !BF128 -> i128
+  %result = arith.trunci %result_i128 : i128 to i32
+  %tensor = tensor.from_elements %result : tensor<1xi32>
+  %buffer = bufferization.to_buffer %tensor : tensor<1xi32> to memref<1xi32>
+  %cast = memref.cast %buffer : memref<1xi32> to memref<*xi32>
+  func.call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
+  return
+}
+// CHECK: {{^}}[3]
+
+// Test: BF128 full-width inverse round-trip — prints the low i32 of x·x⁻¹
+// (1) and the XOR-fold of the three upper 32-bit limbs (0).
+func.func @test_bf128_inverse_roundtrip() {
+  %x = field.constant 0x0123456789ABCDEFFEDCBA9876543210 : !BF128
+  %xinv = field.inverse %x : !BF128
+  %p = field.mul %x, %xinv : !BF128
+
+  %p_i128 = field.bitcast %p : !BF128 -> i128
+  %lo = arith.trunci %p_i128 : i128 to i32
+  %c32 = arith.constant 32 : i128
+  %c64 = arith.constant 64 : i128
+  %c96 = arith.constant 96 : i128
+  %l1 = arith.trunci %p_i128 : i128 to i32
+  %s1 = arith.shrui %p_i128, %c32 : i128
+  %s2 = arith.shrui %p_i128, %c64 : i128
+  %s3 = arith.shrui %p_i128, %c96 : i128
+  %h1 = arith.trunci %s1 : i128 to i32
+  %h2 = arith.trunci %s2 : i128 to i32
+  %h3 = arith.trunci %s3 : i128 to i32
+  %hx = arith.xori %h1, %h2 : i32
+  %hi = arith.xori %hx, %h3 : i32
+  %tensor = tensor.from_elements %lo, %hi : tensor<2xi32>
+  %buffer = bufferization.to_buffer %tensor : tensor<2xi32> to memref<2xi32>
+  %cast = memref.cast %buffer : memref<2xi32> to memref<*xi32>
+  func.call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
+  return
+}
+// CHECK: {{^}}[1, 0]
+
+// Test: BF64 inverse of zero is zero (invert_or_zero, matching binius and
+// the level-3 lookup table's 0 → 0 entry).
+func.func @test_bf64_inverse_zero() {
+  %a = field.constant 0 : !BF64
+  %c = field.inverse %a : !BF64
+
+  %result_i64 = field.bitcast %c : !BF64 -> i64
+  %result = arith.trunci %result_i64 : i64 to i32
+  %tensor = tensor.from_elements %result : tensor<1xi32>
+  %buffer = bufferization.to_buffer %tensor : tensor<1xi32> to memref<1xi32>
+  %cast = memref.cast %buffer : memref<1xi32> to memref<*xi32>
+  func.call @printMemrefI32(%cast) : (memref<*xi32>) -> ()
+  return
+}
+// CHECK: {{^}}[0]
+
 func.func @main() {
   func.call @test_bf8_add() : () -> ()
   func.call @test_bf8_mul() : () -> ()
@@ -207,5 +307,10 @@ func.func @main() {
   func.call @test_bf128_mul() : () -> ()
   func.call @test_bf128_mul_self() : () -> ()
   func.call @test_bf128_mul_cross() : () -> ()
+  func.call @test_bf64_inverse_known() : () -> ()
+  func.call @test_bf64_inverse_roundtrip() : () -> ()
+  func.call @test_bf128_inverse_known() : () -> ()
+  func.call @test_bf128_inverse_roundtrip() : () -> ()
+  func.call @test_bf64_inverse_zero() : () -> ()
   return
 }

--- a/tests/Dialect/Field/binary_field_to_arith.mlir
+++ b/tests/Dialect/Field/binary_field_to_arith.mlir
@@ -18,6 +18,7 @@
 // Test binary field to arith lowering
 
 !BF8 = !field.bf<3>  // GF(2^8)
+!BF64 = !field.bf<6>  // GF(2^64) tower
 !GHASH = !field.bf<7, ghash>  // GF(2^128), flat GHASH basis
 
 // CHECK-LABEL: @test_bf_constant
@@ -113,4 +114,17 @@ func.func @test_bf_ghash_inverse(%a: !GHASH) -> !GHASH {
   // CHECK-NOT: field.inverse
   %c = field.inverse %a : !GHASH
   return %c : !GHASH
+}
+
+// Wide tower inverse lowers via recursive descent: the presence of the
+// level-3 lookup's scf.index_switch proves the descent reached its base
+// instead of unrolling a Fermat chain (which never emits a switch and is
+// ~0.5M ops at this width).
+// CHECK-LABEL: @test_bf64_inverse_descent
+// CHECK-SAME: (%arg0: i64) -> i64
+func.func @test_bf64_inverse_descent(%a: !BF64) -> !BF64 {
+  // CHECK: scf.index_switch
+  // CHECK-NOT: field.inverse
+  %c = field.inverse %a : !BF64
+  return %c : !BF64
 }


### PR DESCRIPTION
## Description

The inlined Fermat chain for tower `field.inverse` — `a^(2ⁿ−2)` as (n−1) squares + (n−2) full Karatsuba muls — grows ~6× per tower level: one scalar GF(2⁶⁴) inverse was ~0.5M arith ops, GF(2¹²⁸) ~2.9M. Consumers pay that at compile time in every pipeline stage that walks the block (conversion, canonicalize/CSE, isel, ptxas): jax `a / a` on `bf<6>`/`bf<7>` exceeded 600 s and got killed (fractalyze/jax#123 F5). GHASH already sidesteps this with an Itoh–Tsujii chain; the tower path had nothing equivalent.

Levels ≥ 4 now invert by recursive norm descent: for `a = a₀ + a₁·X` over the subfield with `X² = β·X + 1`, the Frobenius conjugate is `ā = (a₀ + β·a₁) + a₁·X`, the norm `N = a·ā = a₀² + β·a₀·a₁ + a₁²` lands in the subfield (its X coefficient cancels in characteristic 2), and `a⁻¹ = ā·N⁻¹`. One recursive inverse + 3 muls + 2 squares + 2 β-muls per level, bottoming out at the existing level-3 lookup table — so `inverse(0) = 0` (binius `invert_or_zero`) propagates through the norm for free.

Generated-IR sizes: `bf<6>` 14.6k ops (was ~490k), `bf<7>` 42.4k (was ~2.9M). End-to-end jax `a/a` compile, before → after: CPU t5 28.6 s → 0.67 s, t6 killed → 2.3 s, t7 killed → 11.3 s; GPU t6 killed → 2.6 s, t7 killed → 162.9 s (the GPU t7 residual is ptxas being super-linear on the one 42k-op kernel — the fork already documents that pathology; outlining the per-level tower ops is the follow-up if t7 GPU compile matters). `a/a == 1` and `(a·b)/b == a` hold on all of t4–t7/ghash/gf8_aes, both backends.

Flat bases are untouched — ghash/aes inverse splits off on `!isTower()` before reaching `BinaryFieldCodeGen`. Fermat stays for levels ≤ 2 (at most 3 squares + 2 muls, smaller than the descent's constant overhead).

The new runner cases are the first *executed* coverage of wide tower inverse (Fermat made them infeasible to even compile in a lit test); they pin the exact value `2⁻¹ = 3` — valid at every level since GF(4) embeds invariantly in the tower — plus full-width `x·x⁻¹ = 1` round-trips and `inverse(0) = 0`. Note: `BinaryFieldOperationTest` exercises only the fold-side APInt math, not this codegen path.

## Related Issues/PRs

Part of fractalyze/jax#123 (family F5). Reaches XLA via the stablehlo→prime_ir pin-bump chain.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline

https://claude.ai/code/session_01DmPoaJz577J6Z1wU3TXQSk
