### PR TITLE
fix(mod_arith): halve without overflowing the carrier

### DIFF
--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -1046,14 +1046,20 @@ struct ConvertMul : public BoundMapPattern<MulOp> {
               negRhsStd == montAttr.getInvTwoPowers()[i]) {
             bool isNegated = negRhsStd == montAttr.getInvTwoPowers()[i];
             if (i == 0) {
-              // Efficient halve: if odd, add modulus, then shift right by 1
+              // Halve: (lhs + modulus)/2 == (lhs >> 1) + (modulus+1)/2 for
+              // odd lhs. Adding the modulus before the shift would overflow
+              // the carrier for a headroom-free modulus (Goldilocks); this
+              // add is bounded by modulus - 1.
               Value lhs = adaptor.getLhs();
+              Value halfModPlusOne = createScalarOrSplatConstant(
+                  b, b.getLoc(), modAttr.getType(), modulus.lshr(1) + 1);
               auto lhsIsOdd = arith::AndIOp::create(b, lhs, one);
               auto needsAdd = arith::CmpIOp::create(b, arith::CmpIPredicate::ne,
                                                     lhsIsOdd, zero);
-              auto halvedInput = arith::SelectOp::create(
-                  b, needsAdd, arith::AddIOp::create(b, lhs, cmod), lhs);
-              auto halved = arith::ShRUIOp::create(b, halvedInput, one);
+              auto shifted = arith::ShRUIOp::create(b, lhs, one);
+              auto halved = arith::SelectOp::create(
+                  b, needsAdd,
+                  arith::AddIOp::create(b, shifted, halfModPlusOne), shifted);
               auto negatedHalved = arith::SubIOp::create(b, cmod, halved);
               rewriter.replaceOp(op, isNegated ? negatedHalved : halved);
               return success();

--- a/tests/Dialect/ModArith/halve_goldilocks_runner.mlir
+++ b/tests/Dialect/ModArith/halve_goldilocks_runner.mlir
@@ -1,0 +1,81 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// RUN: prime-ir-opt -canonicalize -mod-arith-to-arith %s | FileCheck %s --check-prefix=CHECK-LOWERING
+
+// RUN: prime-ir-opt %s -canonicalize -mod-arith-to-arith -convert-to-llvm \
+// RUN:   | mlir-runner -e main -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s < %t
+
+// Goldilocks leaves no headroom bit in its i64 carrier, so for an odd operand
+// above 2^64 - modulus an add-modulus-then-shift halve wraps and the shifted
+// result loses exactly 2^63. Pins the carry-free shift-then-add lowering on
+// operands that exercised the wrap (values with bit 63 set).
+
+func.func private @printMemrefI64(memref<*xi64>) attributes { llvm.emit_c_interface }
+
+!mod = !mod_arith.int<18446744069414584321 : i64>
+
+// CHECK-LOWERING-LABEL: func.func @halve(
+// CHECK-LOWERING: %[[SHIFTED:.*]] = arith.shrui %{{.*}}, %{{.*}} : i64
+// CHECK-LOWERING: %[[ODD_SUM:.*]] = arith.addi %[[SHIFTED]], %{{.*}} : i64
+// CHECK-LOWERING: arith.select %{{.*}}, %[[ODD_SUM]], %[[SHIFTED]] : i64
+func.func @halve(%arg0 : !mod) -> !mod {
+  %c2 = mod_arith.constant 2 : !mod
+  %inv_two = mod_arith.inverse %c2 : !mod
+  %res = mod_arith.mul %arg0, %inv_two : !mod
+  return %res : !mod
+}
+
+func.func @halve_negated(%arg0 : !mod) -> !mod {
+  %c2 = mod_arith.constant 2 : !mod
+  %inv_two = mod_arith.inverse %c2 : !mod
+  %neg_inv_two = mod_arith.negate %inv_two : !mod
+  %res = mod_arith.mul %arg0, %neg_inv_two : !mod
+  return %res : !mod
+}
+
+func.func @main() {
+  %mem = memref.alloca() : memref<1xi64>
+  %mem_cast = memref.cast %mem : memref<1xi64> to memref<*xi64>
+  %idx = arith.constant 0 : index
+
+  // 2^63 + 2^62 + 12345: odd, and odd + modulus wraps the i64 carrier.
+  %odd = mod_arith.constant 13835058055282176057 : !mod
+  %r0 = func.call @halve(%odd) : (!mod) -> !mod
+  %r0_int = mod_arith.bitcast %r0 : !mod -> i64
+  memref.store %r0_int, %mem[%idx] : memref<1xi64>
+  func.call @printMemrefI64(%mem_cast) : (memref<*xi64>) -> ()
+
+  // Its even neighbor halves by the plain shift on both lowerings.
+  %even = mod_arith.constant 13835058055282176058 : !mod
+  %r1 = func.call @halve(%even) : (!mod) -> !mod
+  %r1_int = mod_arith.bitcast %r1 : !mod -> i64
+  memref.store %r1_int, %mem[%idx] : memref<1xi64>
+  func.call @printMemrefI64(%mem_cast) : (memref<*xi64>) -> ()
+
+  %r2 = func.call @halve_negated(%odd) : (!mod) -> !mod
+  %r2_int = mod_arith.bitcast %r2 : !mod -> i64
+  memref.store %r2_int, %mem[%idx] : memref<1xi64>
+  func.call @printMemrefI64(%mem_cast) : (memref<*xi64>) -> ()
+  return
+}
+
+// (odd + modulus)/2 = 16140901062348380189; printMemrefI64 renders i64
+// signed, so the bit-63-set result prints negative.
+// CHECK: [-2305843011361171427]
+// CHECK: [6917529027641088029]
+// CHECK: [2305843007066204132]


### PR DESCRIPTION
## Description

`ConvertMul`'s multiply-by-2⁻¹ shortcut lowered the halve as "add modulus if odd, then shift": for an odd operand above `2^width − modulus` the add wraps the carrier and the shifted result silently loses `2^(width−1)`. Any headroom-free modulus hits it — Goldilocks halving any odd canonical value ≥ 2³² comes out exactly 2⁶³ low — while the i32-carrier fields (BabyBear, KoalaBear) always had a spare bit, which is why the existing `mul_by_inv_two_pow` coverage never caught it. The rewrite shifts first: `(lhs + modulus)/2 == (lhs >> 1) + (modulus+1)/2` for odd `lhs`, and that add is bounded by `modulus − 1`. Same op count, canonical output range unchanged.

Found in production: fractalyze/xla#305 decomposes small NTTs into elementwise HLO, so a length-2 INTT's `n_inv = 2⁻¹` multiply started reaching this shortcut on GPU — frx wheels from `dev20260722083811` on miscompute `lax.ntt(…, "INTT", ntt_length=2)` for affected values, which zisk-zorch's FRI fold hits through `zorch.fri_fold_k` at fold width 2 (`fold_test` red on GPU, green on CPU where the decomposer doesn't run). Verified end-to-end: a plugin built at xla `5bc813411b` (#305 included) with this fix passes the ntt repro matrix and zisk's `fold_test` on an RTX 5090; the new runner test fails against the previous lowering.

## Related Issues/PRs

Exposed by fractalyze/xla#305; unblocks the frx pin on fractalyze/zisk-zorch#77 (GPU fold regression warning in its `docs/development.md`).

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline

🤖 Generated with [Claude Code](https://claude.com/claude-code)