### PR TITLE
fix: report invalid elliptic curve attributes instead of aborting

### DIFF
--- a/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveAttributes.cpp
+++ b/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveAttributes.cpp
@@ -22,8 +22,25 @@ limitations under the License.
 
 namespace mlir::prime_ir::elliptic_curve {
 
+namespace {
+// Curve arithmetic resolves coordinates through field::getBasePrimeField,
+// which only knows prime and extension fields; a binary-field base would
+// abort there instead of reporting. Reject it while a diagnostic is still
+// possible.
+ParseResult validateCurveBaseField(AsmParser &parser, SMLoc loc,
+                                   Type baseField) {
+  if (isa<field::PrimeFieldType, field::ExtensionFieldType>(baseField))
+    return success();
+  return parser.emitError(loc)
+         << "elliptic curve base field must be a prime or extension field, "
+            "but got "
+         << baseField;
+}
+} // namespace
+
 // static
 Attribute ShortWeierstrassAttr::parse(AsmParser &parser, Type odsType) {
+  SMLoc loc = parser.getCurrentLocation();
   Attribute a, b, gX, gY;
   Type baseField;
   if (failed(parser.parseLess()) || failed(parser.parseAttribute(a)) ||
@@ -35,10 +52,11 @@ Attribute ShortWeierstrassAttr::parse(AsmParser &parser, Type odsType) {
       failed(field::parseColonFieldType(parser, baseField)))
     return nullptr;
 
-  if (failed(field::validateAttribute(parser, baseField, a, "a")) ||
-      failed(field::validateAttribute(parser, baseField, b, "b")) ||
-      failed(field::validateAttribute(parser, baseField, gX, "gX")) ||
-      failed(field::validateAttribute(parser, baseField, gY, "gY")))
+  if (failed(validateCurveBaseField(parser, loc, baseField)) ||
+      failed(field::validateAttribute(parser, loc, baseField, a, "a")) ||
+      failed(field::validateAttribute(parser, loc, baseField, b, "b")) ||
+      failed(field::validateAttribute(parser, loc, baseField, gX, "gX")) ||
+      failed(field::validateAttribute(parser, loc, baseField, gY, "gY")))
     return nullptr;
 
   a = field::maybeToMontgomery(baseField, a);
@@ -46,9 +64,12 @@ Attribute ShortWeierstrassAttr::parse(AsmParser &parser, Type odsType) {
   gX = field::maybeToMontgomery(baseField, gX);
   gY = field::maybeToMontgomery(baseField, gY);
 
-  return ShortWeierstrassAttr::get(a.getContext(), baseField,
-                                   cast<TypedAttr>(a), cast<TypedAttr>(b),
-                                   cast<TypedAttr>(gX), cast<TypedAttr>(gY));
+  // getChecked, not get: an off-curve generator must surface as a parse error
+  // rather than tripping the uniquer's verifyInvariants assertion.
+  return ShortWeierstrassAttr::getChecked(
+      [&] { return parser.emitError(loc); }, parser.getContext(), baseField,
+      cast<TypedAttr>(a), cast<TypedAttr>(b), cast<TypedAttr>(gX),
+      cast<TypedAttr>(gY));
 }
 
 void ShortWeierstrassAttr::print(AsmPrinter &printer) const {
@@ -57,7 +78,7 @@ void ShortWeierstrassAttr::print(AsmPrinter &printer) const {
   Attribute gX = field::maybeToStandard(getBaseField(), getGx());
   Attribute gY = field::maybeToStandard(getBaseField(), getGy());
 
-  printer << '<' << a << ',' << b << ",(" << gX << ',' << gY
+  printer << '<' << a << ", " << b << ", (" << gX << ", " << gY
           << ")> : " << getBaseField();
 }
 
@@ -80,6 +101,7 @@ ShortWeierstrassAttr::verify(llvm::function_ref<InFlightDiagnostic()> emitError,
 
 // static
 Attribute TwistedEdwardsAttr::parse(AsmParser &parser, Type odsType) {
+  SMLoc loc = parser.getCurrentLocation();
   Attribute a, d, gX, gY;
   Type baseField;
   if (failed(parser.parseLess()) || failed(parser.parseAttribute(a)) ||
@@ -91,10 +113,11 @@ Attribute TwistedEdwardsAttr::parse(AsmParser &parser, Type odsType) {
       failed(field::parseColonFieldType(parser, baseField)))
     return nullptr;
 
-  if (failed(field::validateAttribute(parser, baseField, a, "a")) ||
-      failed(field::validateAttribute(parser, baseField, d, "d")) ||
-      failed(field::validateAttribute(parser, baseField, gX, "gX")) ||
-      failed(field::validateAttribute(parser, baseField, gY, "gY")))
+  if (failed(validateCurveBaseField(parser, loc, baseField)) ||
+      failed(field::validateAttribute(parser, loc, baseField, a, "a")) ||
+      failed(field::validateAttribute(parser, loc, baseField, d, "d")) ||
+      failed(field::validateAttribute(parser, loc, baseField, gX, "gX")) ||
+      failed(field::validateAttribute(parser, loc, baseField, gY, "gY")))
     return nullptr;
 
   a = field::maybeToMontgomery(baseField, a);
@@ -102,9 +125,12 @@ Attribute TwistedEdwardsAttr::parse(AsmParser &parser, Type odsType) {
   gX = field::maybeToMontgomery(baseField, gX);
   gY = field::maybeToMontgomery(baseField, gY);
 
-  return TwistedEdwardsAttr::get(a.getContext(), baseField, cast<TypedAttr>(a),
-                                 cast<TypedAttr>(d), cast<TypedAttr>(gX),
-                                 cast<TypedAttr>(gY));
+  // getChecked, not get: a generator off the curve must surface as a parse
+  // error rather than tripping the uniquer's verifyInvariants assertion.
+  return TwistedEdwardsAttr::getChecked(
+      [&] { return parser.emitError(loc); }, parser.getContext(), baseField,
+      cast<TypedAttr>(a), cast<TypedAttr>(d), cast<TypedAttr>(gX),
+      cast<TypedAttr>(gY));
 }
 
 void TwistedEdwardsAttr::print(AsmPrinter &printer) const {
@@ -113,7 +139,7 @@ void TwistedEdwardsAttr::print(AsmPrinter &printer) const {
   Attribute gX = field::maybeToStandard(getBaseField(), getGx());
   Attribute gY = field::maybeToStandard(getBaseField(), getGy());
 
-  printer << '<' << a << ',' << d << ",(" << gX << ',' << gY
+  printer << '<' << a << ", " << d << ", (" << gX << ", " << gY
           << ")> : " << getBaseField();
 }
 

--- a/prime_ir/Dialect/Field/IR/FieldTypes.cpp
+++ b/prime_ir/Dialect/Field/IR/FieldTypes.cpp
@@ -65,20 +65,41 @@ ParseResult parseColonFieldType(AsmParser &parser, Type &type) {
       "expected prime field, binary field, or extension field type");
 }
 
-ParseResult validateAttribute(AsmParser &parser, Type type, Attribute attr,
-                              std::string_view attrName) {
-  if (auto pfType = dyn_cast<field::PrimeFieldType>(type)) {
-    if (!isa<IntegerAttr>(attr)) {
-      return parser.emitError(parser.getCurrentLocation(),
-                              "expected integer attribute for " +
-                                  std::string(attrName));
+ParseResult validateAttribute(AsmParser &parser, SMLoc loc, Type type,
+                              Attribute attr, std::string_view attrName) {
+  // Callers feed the validated attribute straight into field arithmetic, which
+  // compares APInts against the modulus and requires equal bit widths — a
+  // narrower or wider literal aborts rather than diagnosing. So the storage
+  // type has to be checked here, not just the attribute kind.
+  if (auto pfType = dyn_cast<PrimeFieldType>(type)) {
+    auto intAttr = dyn_cast<IntegerAttr>(attr);
+    if (!intAttr) {
+      return parser.emitError(loc, "expected integer attribute for " +
+                                       std::string(attrName));
+    }
+    if (intAttr.getType() != pfType.getStorageType()) {
+      return parser.emitError(loc)
+             << "expected " << pfType.getStorageType() << " attribute for "
+             << attrName << ", but got " << intAttr.getType();
     }
     return success();
   }
-  if (!isa<DenseIntElementsAttr>(attr)) {
-    return parser.emitError(parser.getCurrentLocation(),
-                            "expected dense int elements attribute for " +
-                                std::string(attrName));
+
+  auto denseAttr = dyn_cast<DenseIntElementsAttr>(attr);
+  if (!denseAttr) {
+    return parser.emitError(loc, "expected dense int elements attribute for " +
+                                     std::string(attrName));
+  }
+  if (auto efType = dyn_cast<ExtensionFieldType>(type)) {
+    Type storageType = efType.getBasePrimeField().getStorageType();
+    SmallVector<int64_t> expectedShape = efType.getAttrShape();
+    ShapedType attrType = denseAttr.getType();
+    if (attrType.getElementType() != storageType ||
+        attrType.getShape() != ArrayRef<int64_t>(expectedShape)) {
+      return parser.emitError(loc)
+             << "expected " << RankedTensorType::get(expectedShape, storageType)
+             << " attribute for " << attrName << ", but got " << attrType;
+    }
   }
   return success();
 }

--- a/prime_ir/Dialect/Field/IR/FieldTypes.h
+++ b/prime_ir/Dialect/Field/IR/FieldTypes.h
@@ -51,8 +51,8 @@ unsigned getIntOrPrimeFieldBitWidth(Type type);
 mod_arith::ModArithType convertPrimeFieldType(PrimeFieldType type);
 
 ParseResult parseColonFieldType(AsmParser &parser, Type &type);
-ParseResult validateAttribute(AsmParser &parser, Type type, Attribute attr,
-                              std::string_view attrName);
+ParseResult validateAttribute(AsmParser &parser, SMLoc loc, Type type,
+                              Attribute attr, std::string_view attrName);
 Attribute maybeToMontgomery(Type type, Attribute attr);
 Attribute maybeToStandard(Type type, Attribute attr);
 

--- a/tests/Dialect/EllipticCurve/curve_attr_invalid.mlir
+++ b/tests/Dialect/EllipticCurve/curve_attr_invalid.mlir
@@ -1,0 +1,53 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// RUN: prime-ir-opt -split-input-file -verify-diagnostics %s
+
+// Every case here reaches curve arithmetic, which resolves coordinates through
+// the base prime field and compares APInts against the modulus. Anything the
+// parser lets through mismatched aborts instead of reporting, so these all have
+// to be rejected while a diagnostic is still possible.
+
+// A coordinate literal defaults to i64 while the base field stores i32.
+// expected-error@+1 {{expected 'i32' attribute for gY, but got 'i64'}}
+#sw_width = #elliptic_curve.sw<0:i32, 3:i32, (2412:i32, 1)> : !field.pf<7681 : i32>
+
+// -----
+
+// Generator not on y² = x³ + ax + b.
+// expected-error@+1 {{a, b, gX, and gY must satisfy the equation}}
+#sw_off_curve = #elliptic_curve.sw<0:i32, 3:i32, (2412:i32, 1:i32)> : !field.pf<7681 : i32>
+
+// -----
+
+// Binary fields have no base prime field to resolve coordinates through.
+// expected-error@+1 {{elliptic curve base field must be a prime or extension field, but got '!field.bf<7>'}}
+#sw_binary_base = #elliptic_curve.sw<0:i8, 3:i8, (1:i8, 2:i8)> : !field.bf<7>
+
+// -----
+
+!pf = !field.pf<21888242871839275222246405745257275088696311157297823662689037894645226208583:i256>
+!ef = !field.ef<2x!pf, 21888242871839275222246405745257275088696311157297823662689037894645226208582:i256>
+
+// An Fp2 coefficient vector carries one entry per degree; three is not a
+// coordinate over this field.
+// expected-error@+1 {{expected 'tensor<2xi256>' attribute for a, but got 'tensor<3xi256>'}}
+#sw_ef_shape = #elliptic_curve.sw<dense<0> : tensor<3xi256>, dense<0> : tensor<2xi256>, (dense<0> : tensor<2xi256>, dense<0> : tensor<2xi256>)> : !ef
+
+// -----
+
+// Twisted Edwards runs the same validation before its own curve equation.
+// expected-error@+1 {{expected 'i32' attribute for gX, but got 'i64'}}
+#te_width = #elliptic_curve.te<1:i32, 2:i32, (1, 0:i32)> : !field.pf<7681 : i32>


### PR DESCRIPTION
## What

Three ways a malformed `#elliptic_curve.sw` / `#elliptic_curve.te` attribute
crashed the compiler instead of producing a diagnostic. Each of these aborts
today:

```mlir
// coordinate defaults to i64, base field stores i32
//   -> APInt::operator== assertion, "Comparison requires equal bit widths"
#a = #elliptic_curve.sw<0:i32, 3:i32, (2412:i32, 1)> : !field.pf<7681 : i32>

// generator not on the curve
//   -> diagnostic IS emitted, then StorageUserBase::get asserts anyway
#b = #elliptic_curve.sw<0:i32, 3:i32, (2412:i32, 1:i32)> : !field.pf<7681 : i32>

// binary-field base
//   -> getBasePrimeField casts to a prime field that isn't there
#c = #elliptic_curve.sw<0:i8, 3:i8, (1:i8, 2:i8)> : !field.bf<7>
```

All three now report and point at the attribute:

```
error: expected 'i32' attribute for gY, but got 'i64'
error: a, b, gX, and gY must satisfy the equation y² = x³ + ax + b
error: elliptic curve base field must be a prime or extension field, but got '!field.bf<7>'
```

## How

**`field::validateAttribute`** checked the attribute *kind* only — `IntegerAttr`
vs `DenseIntElementsAttr` — and never its storage type. Callers hand the result
straight to `FieldOperation::fromUnchecked`, which compares against the modulus
and requires equal widths, so a mismatched literal had no way to be caught. It
now checks the storage type for prime fields, and element type plus coefficient
shape for extension fields.

**Both attribute parsers** built their result with `Attr::get`, so a `verify`
failure hit the uniquer's `verifyInvariants` assertion rather than returning
null. `getChecked` makes it an ordinary parse error. `get` is left alone at the
C API and in `PointOperation.h` — those take already-verified attributes or
match MLIR's convention of asserting on programmatic contract violations; the
parser is the one handling untrusted text.

**Binary-field bases** are rejected up front, because `field::getBasePrimeField`
`cast`s anything non-extension to `PrimeFieldType` and would abort there.

Two smaller quality-of-life changes ride along: the validators take the
attribute's `SMLoc`, so diagnostics point at the attribute rather than wherever
the parser stopped; and the printers use MLIR's `, ` operand spacing instead of
bare `,`.

`validateAttribute` is called only by the two EC attribute parsers, so the
signature change is contained. No CHECK line in the tree asserts curve-attribute
text, so the spacing change moves no expectation.

## Tests

New `tests/Dialect/EllipticCurve/curve_attr_invalid.mlir` covers all five
rejection paths (four short-Weierstrass, one twisted Edwards) under
`-verify-diagnostics`; `glob_lit_tests` picks it up automatically. Verified it
is not vacuously passing — mutating one expected message makes it fail.

## Test run

118/119 pass locally. The one failure is `pairing_check_4pairs_runner`, which
**times out** at its 900s `long` budget with an empty log — no assertion, no
diagnostic. It is unrelated to this change:

- parsing the full pairing input (the only stage this PR touches) takes
  **0.03s**; lowering takes 21s; the rest is `mlir-runner` JIT and execution,
  which this PR does not touch
- a validation regression would fail fast with the diagnostic text, not hang
- the sibling `pairing_check_runner`, also declared `long`, passes

I could not get a green run of that single test on this machine, which had
several large bazel workspaces running concurrently. Worth confirming on CI.