### PR TITLE
fix(utils): assert signature match on outliner name-dedup hit

### DIFF
--- a/prime_ir/Utils/FunctionOutlinerBase.h
+++ b/prime_ir/Utils/FunctionOutlinerBase.h
@@ -16,6 +16,8 @@ limitations under the License.
 #ifndef PRIME_IR_UTILS_FUNCTIONOUTLINERBASE_H_
 #define PRIME_IR_UTILS_FUNCTIONOUTLINERBASE_H_
 
+#include <cassert>
+
 #include "llvm/ADT/SmallVector.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMAttrs.h"
@@ -75,10 +77,16 @@ protected:
   func::FuncOp getOrCreateFunction(StringRef funcName, TypeRange inputs,
                                    TypeRange outputs,
                                    BodyGeneratorFn &&bodyGenerator) {
-    if (auto existing = symbolTable_.lookup<func::FuncOp>(funcName))
-      return existing;
-
     auto funcType = FunctionType::get(module_.getContext(), inputs, outputs);
+    if (auto existing = symbolTable_.lookup<func::FuncOp>(funcName)) {
+      // Dedup is by name only; a signature mismatch on the hit means the
+      // caller is about to bind a call to a helper with different types — a
+      // silent miscompile downstream (e.g. an outliner pass running twice
+      // around a partial lowering, fractalyze/prime-ir#407).
+      assert(existing.getFunctionType() == funcType &&
+             "outlined helper name reused with a different signature");
+      return existing;
+    }
 
     OpBuilder builder(module_.getContext());
     builder.setInsertionPointToEnd(module_.getBody());

--- a/tests/Utils/BUILD.bazel
+++ b/tests/Utils/BUILD.bazel
@@ -1,6 +1,19 @@
 load("//bazel:prime_ir_cc.bzl", "prime_ir_cc_test")
 
 prime_ir_cc_test(
+    name = "FunctionOutlinerBaseTest",
+    srcs = ["FunctionOutlinerBaseTest.cpp"],
+    deps = [
+        "//prime_ir/Utils:FunctionOutlinerBase",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LLVMDialect",
+    ],
+)
+
+prime_ir_cc_test(
     name = "BitSerialAlgorithmTest",
     srcs = ["BitSerialAlgorithmTest.cpp"],
     deps = [

--- a/tests/Utils/FunctionOutlinerBaseTest.cpp
+++ b/tests/Utils/FunctionOutlinerBaseTest.cpp
@@ -1,0 +1,79 @@
+/* Copyright 2026 The PrimeIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "prime_ir/Utils/FunctionOutlinerBase.h"
+
+#include "gtest/gtest.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+
+namespace mlir::prime_ir {
+namespace {
+
+class TestOutliner : public FunctionOutlinerBase<TestOutliner> {
+  using Base = FunctionOutlinerBase<TestOutliner>;
+
+public:
+  explicit TestOutliner(ModuleOp module) : Base(module) {}
+
+  func::FuncOp getOrCreate(StringRef name, Type in, Type out) {
+    return getOrCreateFunction(name, {in}, {out}, [](func::FuncOp func) {
+      OpBuilder builder(func.getContext());
+      auto args = Base::setupFunctionBody(func, builder);
+      Base::emitReturn(builder, func.getLoc(), args[0]);
+    });
+  }
+};
+
+class FunctionOutlinerBaseTest : public testing::Test {
+protected:
+  void SetUp() override {
+    context.loadDialect<func::FuncDialect, LLVM::LLVMDialect>();
+    module = ModuleOp::create(UnknownLoc::get(&context));
+  }
+
+  MLIRContext context;
+  OwningOpRef<ModuleOp> module;
+};
+
+TEST_F(FunctionOutlinerBaseTest, SameNameSameSignatureDedups) {
+  TestOutliner outliner(*module);
+  Type i64 = IntegerType::get(&context, 64);
+
+  func::FuncOp first = outliner.getOrCreate("helper", i64, i64);
+  func::FuncOp second = outliner.getOrCreate("helper", i64, i64);
+
+  EXPECT_EQ(first, second);
+}
+
+#if !defined(NDEBUG) && defined(GTEST_HAS_DEATH_TEST)
+TEST_F(FunctionOutlinerBaseTest, SameNameDifferentSignatureAsserts) {
+  TestOutliner outliner(*module);
+  Type i64 = IntegerType::get(&context, 64);
+  Type i32 = IntegerType::get(&context, 32);
+
+  outliner.getOrCreate("helper", i64, i64);
+  EXPECT_DEATH(outliner.getOrCreate("helper", i32, i32),
+               "reused with a different signature");
+}
+#endif
+
+} // namespace
+} // namespace mlir::prime_ir


### PR DESCRIPTION
## Description

`getOrCreateFunction` returns a symbol-table hit by name alone. A caller that
reuses a helper name across pipeline runs — e.g. fractalyze/xla's field-mul
outliner running once before each `FieldToModArith` wave — is type-safe only
as long as external invariants hold; if one breaks, the call silently binds
to a helper with different types and the failure surfaces as a downstream
miscompile instead of a build error. A signature mismatch on the hit is
always a caller bug, so an assert (not a recoverable error) is the right
strength. Found during review of fractalyze/xla#341.

## Related Issues/PRs

Fixes #407
Refs fractalyze/xla#341

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline

🤖 Generated with [Claude Code](https://claude.com/claude-code)