### PR TITLE
feat: specialize tower bf<4>/bf<5> mul to clmad via flat-basis conversion

### DIFF
--- a/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/BUILD.bazel
+++ b/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/BUILD.bazel
@@ -39,11 +39,11 @@ gentbl_cc_library(
 
 prime_ir_cc_library(
     name = "SpecializeBinaryFieldToNVPTX",
-    srcs = ["SpecializeBinaryFieldToNVPTX.cpp"],
-    hdrs = [
-        "SpecializeBinaryFieldToNVPTX.h",
+    srcs = [
+        "SpecializeBinaryFieldToNVPTX.cpp",
         "TowerFlatBasis.h",
     ],
+    hdrs = ["SpecializeBinaryFieldToNVPTX.h"],
     deps = [
         ":pass_inc_gen",
         "//prime_ir/Dialect/Field/Conversions/BinaryFieldToArith:BinaryFieldTables",

--- a/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/BUILD.bazel
+++ b/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/BUILD.bazel
@@ -40,7 +40,10 @@ gentbl_cc_library(
 prime_ir_cc_library(
     name = "SpecializeBinaryFieldToNVPTX",
     srcs = ["SpecializeBinaryFieldToNVPTX.cpp"],
-    hdrs = ["SpecializeBinaryFieldToNVPTX.h"],
+    hdrs = [
+        "SpecializeBinaryFieldToNVPTX.h",
+        "TowerFlatBasis.h",
+    ],
     deps = [
         ":pass_inc_gen",
         "//prime_ir/Dialect/Field/Conversions/BinaryFieldToArith:BinaryFieldTables",

--- a/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.cpp
+++ b/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldTables.h"
+#include "prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/TowerFlatBasis.h"
 #include "prime_ir/Dialect/Field/IR/FieldDialect.h"
 #include "prime_ir/Dialect/Field/IR/FieldOps.h"
 #include "prime_ir/Dialect/Field/IR/FieldTypes.h"
@@ -113,13 +114,74 @@ Value mulGhashClmad(ImplicitLocOpBuilder &b, Value lhsI128, Value rhsI128) {
 }
 
 //===----------------------------------------------------------------------===//
-// Conversion Pattern
+// clmad-based Tower Multiplication (via flat-basis conversion)
+//===----------------------------------------------------------------------===//
+
+// A raw carryless product does not compute a tower product, but the tower is
+// isomorphic to a flat polynomial basis and the isomorphism is GF(2)-linear
+// (TowerFlatBasis.h). Converting through it turns a tower multiply into the
+// same clmad + low-weight reduction shape as GHASH:
+//
+//   mul(a, b) = fromFlat(reduce(clmul(toFlat(a), toFlat(b))))
+//
+// The conversion ladders cost ~3n selects+xors for n-bit fields, against the
+// ~3^k-op recursive mulTower they displace (xla#392 measured the bf<5> NTT
+// ALU-bound on that recursion). Consumers that keep values in the flat basis
+// across many multiplies can hoist the ladders entirely.
+
+// Apply the GF(2)-linear map `cols` (column i = image of basis bit i) to an
+// n-bit value: XOR together the columns selected by the set bits.
+Value emitBitMatrix(ImplicitLocOpBuilder &b, Value x, ArrayRef<uint64_t> cols,
+                    unsigned n) {
+  Value zero = arith::ConstantIntOp::create(b, 0, n);
+  Value acc = zero;
+  for (unsigned i = 0; i < n; ++i) {
+    Value shifted = x;
+    if (i != 0) {
+      Value sh = arith::ConstantIntOp::create(b, i, n);
+      shifted = arith::ShRUIOp::create(b, x, sh);
+    }
+    Value bit = arith::TruncIOp::create(b, b.getI1Type(), shifted);
+    Value col =
+        arith::ConstantIntOp::create(b, static_cast<int64_t>(cols[i]), n);
+    Value sel = arith::SelectOp::create(b, bit, col, zero);
+    acc = arith::XOrIOp::create(b, acc, sel);
+  }
+  return acc;
+}
+
+// Multiply two flat-basis values of width n (16 or 32) held in i64, reducing
+// mod y^n + fLow. The product fits 2n-1 <= 63 bits, so one clmad.lo covers
+// it; two folds finish because fLow has degree < 8:
+//   p  = clmul(a, b)                      (bits 0 .. 2n-2)
+//   t1 = p ^ clmul(p >> n, fLow)          (bits 0..n-1 correct, junk above)
+//   h2 = (t1 >> n) ^ (p >> n)             (= fold1 >> n, the second fold input)
+//   t2 = t1 ^ clmul(h2, fLow)             (bits 0..n-1 are the result)
+// The final truncation to n bits discards the junk the folds leave above.
+Value mulFlatClmad(ImplicitLocOpBuilder &b, Value a64, Value b64, unsigned n,
+                   uint64_t fLow) {
+  Value z = arith::ConstantIntOp::create(b, 0, 64);
+  Value shN = arith::ConstantIntOp::create(b, n, 64);
+  Value fLowC = arith::ConstantIntOp::create(b, static_cast<int64_t>(fLow), 64);
+
+  Value p = emitClmad(b, a64, b64, z, /*isHi=*/false);
+  Value hi = arith::ShRUIOp::create(b, p, shN);
+  Value t1 = emitClmad(b, hi, fLowC, p, /*isHi=*/false);
+  Value h2 = arith::XOrIOp::create(b, arith::ShRUIOp::create(b, t1, shN), hi);
+  return emitClmad(b, h2, fLowC, t1, /*isHi=*/false);
+}
+
+//===----------------------------------------------------------------------===//
+// Conversion Patterns
 //===----------------------------------------------------------------------===//
 
 // Pattern for the GHASH-basis multiply (`bf<7, ghash>`) using clmad. As with
-// the x86 PCLMULQDQ path, tower bf<6>/bf<7> deliberately do NOT specialize --
-// the carryless product computes the flat GHASH product, not the tower -- so
-// they lower via the portable recursive mulTower in binary-field-to-arith.
+// the x86 PCLMULQDQ path, tower bf<6>/bf<7> do NOT specialize -- a carryless
+// product computes the flat GHASH product, not the tower -- so they lower via
+// the portable recursive mulTower in binary-field-to-arith. Tower bf<4>/bf<5>
+// DO specialize through the flat-basis conversion (ConvertTowerMulToClmad
+// below); extending that to bf<6> needs a clmad.hi limb and a degree-64
+// modulus in TowerFlatBasis.h.
 struct ConvertGhashMulToClmad : public OpRewritePattern<MulOp> {
   using OpRewritePattern<MulOp>::OpRewritePattern;
 
@@ -149,6 +211,59 @@ struct ConvertGhashMulToClmad : public OpRewritePattern<MulOp> {
   }
 };
 
+// Tower bf<4>/bf<5> multiply via flat-basis conversion + one clmad product.
+struct ConvertTowerMulToClmad : public OpRewritePattern<MulOp> {
+  using OpRewritePattern<MulOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(MulOp op,
+                                PatternRewriter &rewriter) const override {
+    Type towerType = op.getResult().getType();
+    auto bfType = dyn_cast<BinaryFieldType>(towerType);
+    if (!bfType || !bfType.isTower())
+      return failure();
+    unsigned level = bfType.getTowerLevel();
+    if (level != 4 && level != 5)
+      return failure();
+    const unsigned n = 1u << level;
+
+    SmallVector<uint64_t, 32> toFlat, fromFlat;
+    uint64_t fLow;
+    if (level == 4) {
+      toFlat.assign(std::begin(kTowerToFlat16), std::end(kTowerToFlat16));
+      fromFlat.assign(std::begin(kFlatToTower16), std::end(kFlatToTower16));
+      fLow = kFlatModLow16;
+    } else {
+      toFlat.assign(std::begin(kTowerToFlat32), std::end(kTowerToFlat32));
+      fromFlat.assign(std::begin(kFlatToTower32), std::end(kFlatToTower32));
+      fLow = kFlatModLow32;
+    }
+
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+    auto intNType = b.getIntegerType(n);
+    auto i64Type = b.getI64Type();
+
+    // Cast tower -> iN; BinaryFieldToArith later reconciles these casts.
+    Value lhsN = UnrealizedConversionCastOp::create(b, intNType, op.getLhs())
+                     .getResult(0);
+    Value rhsN = UnrealizedConversionCastOp::create(b, intNType, op.getRhs())
+                     .getResult(0);
+
+    Value lhsFlat =
+        arith::ExtUIOp::create(b, i64Type, emitBitMatrix(b, lhsN, toFlat, n));
+    Value rhsFlat =
+        arith::ExtUIOp::create(b, i64Type, emitBitMatrix(b, rhsN, toFlat, n));
+
+    Value prodFlat64 = mulFlatClmad(b, lhsFlat, rhsFlat, n, fLow);
+    Value prodFlat = arith::TruncIOp::create(b, intNType, prodFlat64);
+
+    Value resultN = emitBitMatrix(b, prodFlat, fromFlat, n);
+    Value resultTower =
+        UnrealizedConversionCastOp::create(b, towerType, resultN).getResult(0);
+    rewriter.replaceOp(op, resultTower);
+    return success();
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // Pass Implementation
 //===----------------------------------------------------------------------===//
@@ -163,7 +278,7 @@ struct SpecializeBinaryFieldToNVPTX
 
     RewritePatternSet patterns(context);
     if (useClmad) {
-      patterns.add<ConvertGhashMulToClmad>(context);
+      patterns.add<ConvertGhashMulToClmad, ConvertTowerMulToClmad>(context);
     }
 
     // Greedy rewriting (not partial conversion) so unmatched field.mul ops

--- a/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.cpp
+++ b/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.cpp
@@ -117,17 +117,10 @@ Value mulGhashClmad(ImplicitLocOpBuilder &b, Value lhsI128, Value rhsI128) {
 // clmad-based Tower Multiplication (via flat-basis conversion)
 //===----------------------------------------------------------------------===//
 
-// A raw carryless product does not compute a tower product, but the tower is
-// isomorphic to a flat polynomial basis and the isomorphism is GF(2)-linear
-// (TowerFlatBasis.h). Converting through it turns a tower multiply into the
-// same clmad + low-weight reduction shape as GHASH:
+// Tower bf<4>/bf<5> multiply through the isomorphic flat polynomial basis
+// (constants and rationale in TowerFlatBasis.h):
 //
 //   mul(a, b) = fromFlat(reduce(clmul(toFlat(a), toFlat(b))))
-//
-// The conversion ladders cost ~3n selects+xors for n-bit fields, against the
-// ~3^k-op recursive mulTower they displace (xla#392 measured the bf<5> NTT
-// ALU-bound on that recursion). Consumers that keep values in the flat basis
-// across many multiplies can hoist the ladders entirely.
 
 // Apply the GF(2)-linear map `cols` (column i = image of basis bit i) to an
 // n-bit value: XOR together the columns selected by the set bits.
@@ -176,12 +169,9 @@ Value mulFlatClmad(ImplicitLocOpBuilder &b, Value a64, Value b64, unsigned n,
 //===----------------------------------------------------------------------===//
 
 // Pattern for the GHASH-basis multiply (`bf<7, ghash>`) using clmad. As with
-// the x86 PCLMULQDQ path, tower bf<6>/bf<7> do NOT specialize -- a carryless
-// product computes the flat GHASH product, not the tower -- so they lower via
-// the portable recursive mulTower in binary-field-to-arith. Tower bf<4>/bf<5>
-// DO specialize through the flat-basis conversion (ConvertTowerMulToClmad
-// below); extending that to bf<6> needs a clmad.hi limb and a degree-64
-// modulus in TowerFlatBasis.h.
+// the x86 PCLMULQDQ path, tower bf<6>/bf<7> deliberately do NOT specialize --
+// the carryless product computes the flat GHASH product, not the tower -- so
+// they lower via the portable recursive mulTower in binary-field-to-arith.
 struct ConvertGhashMulToClmad : public OpRewritePattern<MulOp> {
   using OpRewritePattern<MulOp>::OpRewritePattern;
 
@@ -212,6 +202,7 @@ struct ConvertGhashMulToClmad : public OpRewritePattern<MulOp> {
 };
 
 // Tower bf<4>/bf<5> multiply via flat-basis conversion + one clmad product.
+// bf<6> would additionally need clmad.hi limbs and a degree-64 modulus.
 struct ConvertTowerMulToClmad : public OpRewritePattern<MulOp> {
   using OpRewritePattern<MulOp>::OpRewritePattern;
 
@@ -226,17 +217,11 @@ struct ConvertTowerMulToClmad : public OpRewritePattern<MulOp> {
       return failure();
     const unsigned n = 1u << level;
 
-    SmallVector<uint64_t, 32> toFlat, fromFlat;
-    uint64_t fLow;
-    if (level == 4) {
-      toFlat.assign(std::begin(kTowerToFlat16), std::end(kTowerToFlat16));
-      fromFlat.assign(std::begin(kFlatToTower16), std::end(kFlatToTower16));
-      fLow = kFlatModLow16;
-    } else {
-      toFlat.assign(std::begin(kTowerToFlat32), std::end(kTowerToFlat32));
-      fromFlat.assign(std::begin(kFlatToTower32), std::end(kFlatToTower32));
-      fLow = kFlatModLow32;
-    }
+    ArrayRef<uint64_t> toFlat =
+        level == 4 ? ArrayRef(kTowerToFlat16) : ArrayRef(kTowerToFlat32);
+    ArrayRef<uint64_t> fromFlat =
+        level == 4 ? ArrayRef(kFlatToTower16) : ArrayRef(kFlatToTower32);
+    uint64_t fLow = level == 4 ? kFlatModLow16 : kFlatModLow32;
 
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
     auto intNType = b.getIntegerType(n);

--- a/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.td
+++ b/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.td
@@ -32,10 +32,10 @@ def SpecializeBinaryFieldToNVPTX : Pass<"specialize-binary-field-to-nvptx", "Mod
     (x¹²⁸ + x⁷ + x² + x + 1). Tower `bf<4>`/`bf<5>` multiplies also
     specialize: a carryless product does not compute a tower product
     directly, so they convert through the isomorphic flat polynomial basis
-    (a GF(2)-linear select/xor ladder, constants in `TowerFlatBasis.h`),
-    multiply with one `clmad.lo.u64` plus a low-weight reduction, and
-    convert back. Operations not specialized fall through to the portable
-    software carryless multiply in `binary-field-to-arith`.
+    (constants in `TowerFlatBasis.h`), multiply with one `clmad.lo.u64`
+    plus a low-weight reduction, and convert back. Operations not
+    specialized fall through to the portable software carryless multiply
+    in `binary-field-to-arith`.
 
     This pass must run BEFORE `binary-field-to-arith`. On the GPU codegen path
     it is inserted directly ahead of `createBinaryFieldToArith` — the GPU

--- a/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.td
+++ b/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.td
@@ -29,8 +29,13 @@ def SpecializeBinaryFieldToNVPTX : Pass<"specialize-binary-field-to-nvptx", "Mod
     `SpecializeBinaryFieldToARM` (PMULL): it rewrites `field.mul` on
     `bf<7, ghash>` into a 128x128 carryless product built from eight
     `clmad.{lo,hi}.u64`, then the shared GHASH polynomial reduction
-    (x¹²⁸ + x⁷ + x² + x + 1). Operations not specialized fall through to the
-    portable software carryless multiply in `binary-field-to-arith`.
+    (x¹²⁸ + x⁷ + x² + x + 1). Tower `bf<4>`/`bf<5>` multiplies also
+    specialize: a carryless product does not compute a tower product
+    directly, so they convert through the isomorphic flat polynomial basis
+    (a GF(2)-linear select/xor ladder, constants in `TowerFlatBasis.h`),
+    multiply with one `clmad.lo.u64` plus a low-weight reduction, and
+    convert back. Operations not specialized fall through to the portable
+    software carryless multiply in `binary-field-to-arith`.
 
     This pass must run BEFORE `binary-field-to-arith`. On the GPU codegen path
     it is inserted directly ahead of `createBinaryFieldToArith` — the GPU

--- a/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/TowerFlatBasis.h
+++ b/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/TowerFlatBasis.h
@@ -1,0 +1,68 @@
+/* Copyright 2026 The PrimeIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef PRIME_IR_DIALECT_FIELD_CONVERSIONS_SPECIALIZEBINARYFIELDTONVPTX_TOWERFLATBASIS_H_
+#define PRIME_IR_DIALECT_FIELD_CONVERSIONS_SPECIALIZEBINARYFIELDTONVPTX_TOWERFLATBASIS_H_
+
+#include <cstdint>
+
+namespace mlir::prime_ir::field {
+
+// GF(2)-linear basis-change constants between the Fan-Paar tower basis
+// (BinaryFieldCodeGen.cpp: bit i of a bf<k> is the multilinear monomial
+// prod_j X_{j+1}^{i_j}) and an isomorphic flat polynomial basis
+// GF(2)[y]/(f_k). In the flat basis a tower multiply is one carry-less
+// product plus a low-weight polynomial reduction — the clmad shape the
+// GHASH path already uses — so a tower multiply becomes
+//   fromFlat(reduce(clmul(toFlat(a), toFlat(b)))).
+// Column i of kTowerToFlat* is the flat image of tower basis monomial i;
+// kFlatToTower* is the inverse matrix. The constants are generated and
+// checked (homomorphism + inverse) by tools/derive_tower_flat_basis.py.
+
+// bf<4>: f_4(y) = y^16 + y^5 + y^3 + y + 1. Low part (f_4 minus the y^16
+// term) drives the reduction fold.
+inline constexpr uint64_t kFlatModLow16 = 0x2b;
+inline constexpr uint16_t kTowerToFlat16[16] = {
+    0x1,    0x732,  0xa785, 0x2f29, 0xf6bc, 0x2ee3, 0xb115, 0x46ff,
+    0x3394, 0xd651, 0x644c, 0xcdd9, 0xc696, 0x88e0, 0xc682, 0xe708,
+};
+inline constexpr uint16_t kFlatToTower16[16] = {
+    0x1,    0xd056, 0xdb5d, 0x8e62, 0x8b5d, 0x499c, 0x7533, 0xde9a,
+    0xf5b5, 0x7d97, 0x9ab7, 0x6079, 0xb2a3, 0xb51b, 0xba0,  0xa24c,
+};
+
+// bf<5>: f_5(y) = y^32 + y^7 + y^3 + y^2 + 1.
+inline constexpr uint64_t kFlatModLow32 = 0x8d;
+inline constexpr uint32_t kTowerToFlat32[32] = {
+    0x1,        0x54fd1264, 0xccec155c, 0xbaa88a9e, 0x843b36b,  0xcc269e97,
+    0x664dc6fd, 0xc876bf36, 0xa733cc5a, 0x41bbf9ff, 0xaa45f221, 0xe618ffea,
+    0x2e3bbbd1, 0xff2b2070, 0xb2b073d9, 0x94ebfc3f, 0x821f5c70, 0xdb81a57e,
+    0x65def133, 0xb6c97b11, 0x9649d335, 0x419e9963, 0x2c04fc23, 0x6bd658c9,
+    0x5364a11f, 0x7f52f2fc, 0x52adf73b, 0x50bb1f53, 0xffd615a8, 0x13385531,
+    0xa3c08108, 0xe4df4d8c,
+};
+inline constexpr uint32_t kFlatToTower32[32] = {
+    0x1,        0x844f21ff, 0x68356949, 0xe957cff,  0xfbc61024, 0x75024e3a,
+    0x2ed00246, 0xd90bc8b7, 0x81c74306, 0x2768f200, 0x2bb29802, 0xdc866f4a,
+    0x189cacd1, 0xd202507f, 0x27bb949b, 0xfdc28fb3, 0xd8b56f02, 0xa8612168,
+    0xdafc5bda, 0xb1045c0a, 0x911c4d02, 0xb3bd3f19, 0x9f3b4d27, 0x7cb4f66e,
+    0xa1f4fd7a, 0x6e3b232e, 0xf1eb9570, 0xaf14d03b, 0x67fc4d14, 0x92dd619b,
+    0xe8670202, 0x8c0db4cc,
+};
+
+} // namespace mlir::prime_ir::field
+
+#endif // ...SPECIALIZEBINARYFIELDTONVPTX_TOWERFLATBASIS_H_
+       // NOLINT(build/header_guard)

--- a/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/TowerFlatBasis.h
+++ b/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/TowerFlatBasis.h
@@ -23,29 +23,29 @@ namespace mlir::prime_ir::field {
 // GF(2)-linear basis-change constants between the Fan-Paar tower basis
 // (BinaryFieldCodeGen.cpp: bit i of a bf<k> is the multilinear monomial
 // prod_j X_{j+1}^{i_j}) and an isomorphic flat polynomial basis
-// GF(2)[y]/(f_k). In the flat basis a tower multiply is one carry-less
-// product plus a low-weight polynomial reduction — the clmad shape the
-// GHASH path already uses — so a tower multiply becomes
-//   fromFlat(reduce(clmul(toFlat(a), toFlat(b)))).
-// Column i of kTowerToFlat* is the flat image of tower basis monomial i;
-// kFlatToTower* is the inverse matrix. The constants are generated and
-// checked (homomorphism + inverse) by tools/derive_tower_flat_basis.py.
+// GF(2)[y]/(f_k), where a multiply is a single carry-less product plus a
+// low-weight reduction. Column i of kTowerToFlat* is the flat image of
+// tower basis monomial i; kFlatToTower* is the inverse matrix. Values fit
+// the field width; the tables are uint64_t so they feed the i64 clmad
+// domain without per-use widening. Generated and proven (irreducibility,
+// homomorphism on all basis pairs, inverse) by
+// tools/derive_tower_flat_basis.py.
 
 // bf<4>: f_4(y) = y^16 + y^5 + y^3 + y + 1. Low part (f_4 minus the y^16
 // term) drives the reduction fold.
 inline constexpr uint64_t kFlatModLow16 = 0x2b;
-inline constexpr uint16_t kTowerToFlat16[16] = {
+inline constexpr uint64_t kTowerToFlat16[16] = {
     0x1,    0x732,  0xa785, 0x2f29, 0xf6bc, 0x2ee3, 0xb115, 0x46ff,
     0x3394, 0xd651, 0x644c, 0xcdd9, 0xc696, 0x88e0, 0xc682, 0xe708,
 };
-inline constexpr uint16_t kFlatToTower16[16] = {
+inline constexpr uint64_t kFlatToTower16[16] = {
     0x1,    0xd056, 0xdb5d, 0x8e62, 0x8b5d, 0x499c, 0x7533, 0xde9a,
     0xf5b5, 0x7d97, 0x9ab7, 0x6079, 0xb2a3, 0xb51b, 0xba0,  0xa24c,
 };
 
 // bf<5>: f_5(y) = y^32 + y^7 + y^3 + y^2 + 1.
 inline constexpr uint64_t kFlatModLow32 = 0x8d;
-inline constexpr uint32_t kTowerToFlat32[32] = {
+inline constexpr uint64_t kTowerToFlat32[32] = {
     0x1,        0x54fd1264, 0xccec155c, 0xbaa88a9e, 0x843b36b,  0xcc269e97,
     0x664dc6fd, 0xc876bf36, 0xa733cc5a, 0x41bbf9ff, 0xaa45f221, 0xe618ffea,
     0x2e3bbbd1, 0xff2b2070, 0xb2b073d9, 0x94ebfc3f, 0x821f5c70, 0xdb81a57e,
@@ -53,7 +53,7 @@ inline constexpr uint32_t kTowerToFlat32[32] = {
     0x5364a11f, 0x7f52f2fc, 0x52adf73b, 0x50bb1f53, 0xffd615a8, 0x13385531,
     0xa3c08108, 0xe4df4d8c,
 };
-inline constexpr uint32_t kFlatToTower32[32] = {
+inline constexpr uint64_t kFlatToTower32[32] = {
     0x1,        0x844f21ff, 0x68356949, 0xe957cff,  0xfbc61024, 0x75024e3a,
     0x2ed00246, 0xd90bc8b7, 0x81c74306, 0x2768f200, 0x2bb29802, 0xdc866f4a,
     0x189cacd1, 0xd202507f, 0x27bb949b, 0xfdc28fb3, 0xd8b56f02, 0xa8612168,
@@ -64,5 +64,5 @@ inline constexpr uint32_t kFlatToTower32[32] = {
 
 } // namespace mlir::prime_ir::field
 
-#endif // ...SPECIALIZEBINARYFIELDTONVPTX_TOWERFLATBASIS_H_
-       // NOLINT(build/header_guard)
+// NOLINTNEXTLINE(whitespace/line_length)
+#endif // PRIME_IR_DIALECT_FIELD_CONVERSIONS_SPECIALIZEBINARYFIELDTONVPTX_TOWERFLATBASIS_H_

--- a/tests/Dialect/Field/specialize_binary_field_to_nvptx.mlir
+++ b/tests/Dialect/Field/specialize_binary_field_to_nvptx.mlir
@@ -15,17 +15,20 @@
 
 // Test clmad specialization for binary field multiplication.
 //
-// clmad computes a carryless product, realizing multiplication in a flat
-// polynomial basis. `bf<7, ghash>` multiplies directly (reduction
-// x¹²⁸ + x⁷ + x² + x + 1). Tower bf<4>/bf<5> specialize through the
-// GF(2)-linear tower->flat basis conversion (TowerFlatBasis.h): ladder in,
-// one clmad.lo product + two reduction folds, ladder out. Tower bf<6>/bf<7>
-// stay portable (`field.mul`) until a clmad.hi limb + degree-64 modulus land.
+// clmad computes a carryless product: `bf<7, ghash>` multiplies directly,
+// tower bf<4>/bf<5> go through the flat-basis conversion (TowerFlatBasis.h),
+// and tower bf<6>/bf<7> stay portable (`field.mul`).
 
 // RUN: prime-ir-opt --specialize-binary-field-to-nvptx %s | FileCheck %s --check-prefix=CHECK-CLMAD
 
 // use-clmad=false disables specialization.
 // RUN: prime-ir-opt --specialize-binary-field-to-nvptx="use-clmad=false" %s | FileCheck %s --check-prefix=CHECK-OFF
+
+// The emitted tower<->iN casts must be reconciled by the downstream
+// binary-field-to-arith lowering — no field ops or casts may survive the pair.
+// RUN: prime-ir-opt --specialize-binary-field-to-nvptx --binary-field-to-arith %s | FileCheck %s --check-prefix=CHECK-PIPELINE
+// CHECK-PIPELINE-NOT: field.mul
+// CHECK-PIPELINE-NOT: unrealized_conversion_cast
 
 !BF16 = !field.bf<4>         // GF(2¹⁶), tower basis
 !BF32 = !field.bf<5>         // GF(2³²), tower basis
@@ -61,7 +64,7 @@ func.func @test_bf32_mul(%a: !BF32, %b: !BF32) -> !BF32 {
   return %c : !BF32
 }
 
-// BF16 (tower) takes the same flat-basis path with the degree-16 modulus.
+// BF16 (tower) takes the same flat-basis path.
 // CHECK-CLMAD-LABEL: @test_bf16_mul
 // CHECK-CLMAD: builtin.unrealized_conversion_cast
 // CHECK-CLMAD-COUNT-3: llvm.inline_asm{{.*}}clmad.lo{{.*}}u64
@@ -94,4 +97,14 @@ func.func @test_bf128_mul(%a: !BF128, %b: !BF128) -> !BF128 {
 func.func @test_bf64_mul(%a: !BF64, %b: !BF64) -> !BF64 {
   %c = field.mul %a, %b : !BF64
   return %c : !BF64
+}
+
+// Square is not specialized (only MulOp patterns are registered); it stays on
+// the portable recursive tower square.
+// CHECK-CLMAD-LABEL: @test_bf32_square
+// CHECK-CLMAD: field.square
+// CHECK-CLMAD-NOT: clmad
+func.func @test_bf32_square(%a: !BF32) -> !BF32 {
+  %c = field.square %a : !BF32
+  return %c : !BF32
 }

--- a/tests/Dialect/Field/specialize_binary_field_to_nvptx.mlir
+++ b/tests/Dialect/Field/specialize_binary_field_to_nvptx.mlir
@@ -13,18 +13,22 @@
 // limitations under the License.
 // ==============================================================================
 
-// Test clmad specialization for GHASH-basis binary field multiplication.
+// Test clmad specialization for binary field multiplication.
 //
-// clmad computes a carryless product, realizing multiplication in the flat
-// GHASH polynomial basis (reduction x¹²⁸ + x⁷ + x² + x + 1). It does NOT match
-// the recursive tower basis, so the fast path applies only to `bf<7, ghash>`;
-// tower bf<6>/bf<7> stay portable (`field.mul`).
+// clmad computes a carryless product, realizing multiplication in a flat
+// polynomial basis. `bf<7, ghash>` multiplies directly (reduction
+// x¹²⁸ + x⁷ + x² + x + 1). Tower bf<4>/bf<5> specialize through the
+// GF(2)-linear tower->flat basis conversion (TowerFlatBasis.h): ladder in,
+// one clmad.lo product + two reduction folds, ladder out. Tower bf<6>/bf<7>
+// stay portable (`field.mul`) until a clmad.hi limb + degree-64 modulus land.
 
 // RUN: prime-ir-opt --specialize-binary-field-to-nvptx %s | FileCheck %s --check-prefix=CHECK-CLMAD
 
 // use-clmad=false disables specialization.
 // RUN: prime-ir-opt --specialize-binary-field-to-nvptx="use-clmad=false" %s | FileCheck %s --check-prefix=CHECK-OFF
 
+!BF16 = !field.bf<4>         // GF(2¹⁶), tower basis
+!BF32 = !field.bf<5>         // GF(2³²), tower basis
 !BF64 = !field.bf<6>         // GF(2⁶⁴), tower basis
 !BF128 = !field.bf<7>        // GF(2¹²⁸), tower basis
 !GHASH = !field.bf<7, ghash> // GF(2¹²⁸), flat GHASH polynomial basis
@@ -41,6 +45,33 @@
 func.func @test_ghash_mul(%a: !GHASH, %b: !GHASH) -> !GHASH {
   %c = field.mul %a, %b : !GHASH
   return %c : !GHASH
+}
+
+// BF32 (tower) multiplies via the flat basis: three clmad.lo.u64 (one product
+// + two reduction folds) between the conversion ladders.
+// CHECK-CLMAD-LABEL: @test_bf32_mul
+// CHECK-CLMAD: builtin.unrealized_conversion_cast
+// CHECK-CLMAD-COUNT-3: llvm.inline_asm{{.*}}clmad.lo{{.*}}u64
+// CHECK-CLMAD: builtin.unrealized_conversion_cast
+// CHECK-OFF-LABEL: @test_bf32_mul
+// CHECK-OFF: field.mul
+// CHECK-OFF-NOT: clmad
+func.func @test_bf32_mul(%a: !BF32, %b: !BF32) -> !BF32 {
+  %c = field.mul %a, %b : !BF32
+  return %c : !BF32
+}
+
+// BF16 (tower) takes the same flat-basis path with the degree-16 modulus.
+// CHECK-CLMAD-LABEL: @test_bf16_mul
+// CHECK-CLMAD: builtin.unrealized_conversion_cast
+// CHECK-CLMAD-COUNT-3: llvm.inline_asm{{.*}}clmad.lo{{.*}}u64
+// CHECK-CLMAD: builtin.unrealized_conversion_cast
+// CHECK-OFF-LABEL: @test_bf16_mul
+// CHECK-OFF: field.mul
+// CHECK-OFF-NOT: clmad
+func.func @test_bf16_mul(%a: !BF16, %b: !BF16) -> !BF16 {
+  %c = field.mul %a, %b : !BF16
+  return %c : !BF16
 }
 
 // BF128 (tower) scalar multiplication stays portable — no carryless fast path.

--- a/tests/Dialect/Field/specialize_binary_field_to_nvptx_shaped.mlir
+++ b/tests/Dialect/Field/specialize_binary_field_to_nvptx_shaped.mlir
@@ -1,0 +1,44 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// Shaped tower multiplies must NOT match the clmad specialization — the
+// emitted trunci/shrui ladder is scalar-only, so a shaped match would build
+// invalid IR. These pin the pattern's scalar dyn_cast guard against a
+// getElementTypeOrSelf refactor. Kept out of
+// specialize_binary_field_to_nvptx.mlir because its pipeline RUN also lowers
+// through binary-field-to-arith, where shaped *tower* mul does not legalize
+// yet (scalar materializations against the tensor type) — a pre-existing gap
+// in that pass, unlike shaped ghash which the verifier rejects outright
+// (ghash_shaped_unsupported.mlir).
+
+// RUN: prime-ir-opt --specialize-binary-field-to-nvptx %s | FileCheck %s
+
+!BF32 = !field.bf<5>
+
+// CHECK-LABEL: @tensor_bf32_mul
+// CHECK: field.mul
+// CHECK-NOT: clmad
+func.func @tensor_bf32_mul(%a: tensor<4x!BF32>, %b: tensor<4x!BF32>) -> tensor<4x!BF32> {
+  %c = field.mul %a, %b : tensor<4x!BF32>
+  return %c : tensor<4x!BF32>
+}
+
+// CHECK-LABEL: @vector_bf32_mul
+// CHECK: field.mul
+// CHECK-NOT: clmad
+func.func @vector_bf32_mul(%a: vector<4x!BF32>, %b: vector<4x!BF32>) -> vector<4x!BF32> {
+  %c = field.mul %a, %b : vector<4x!BF32>
+  return %c : vector<4x!BF32>
+}

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -13,10 +13,21 @@
 # limitations under the License.
 # ==============================================================================
 
+load("@rules_python//python:defs.bzl", "py_test")
 load("//bazel:prime_ir_cc.bzl", "prime_ir_cc_binary")
 
 package(
     default_visibility = ["//visibility:public"],
+)
+
+# Runs the derivation's proofs (irreducibility, homomorphism on all basis
+# pairs, inverse, clmad fold schedule) so a drifted TowerFlatBasis.h edit
+# without a rerun is at least caught on the math side.
+py_test(
+    name = "derive_tower_flat_basis_test",
+    size = "small",
+    srcs = ["derive_tower_flat_basis.py"],
+    main = "derive_tower_flat_basis.py",
 )
 
 prime_ir_cc_binary(

--- a/tools/derive_tower_flat_basis.py
+++ b/tools/derive_tower_flat_basis.py
@@ -1,20 +1,37 @@
-# Derive the tower<->flat basis-change constants for SpecializeBinaryFieldToNVPTX.
+# Copyright 2026 The PrimeIR Authors.
 #
-# The Fan-Paar tower (BinaryFieldCodeGen.cpp) is GF(2^(2^k)) =
-# subfield[X_k]/(X_k^2 + X_{k-1}*X_k + 1) with X_0 = 1; storage bit i of a
-# bf<k> encodes the multilinear monomial prod_j X_{j+1}^{i_j}. A flat
-# GF(2^(2^k)) = GF(2)[y]/(f_k(y)) is isomorphic to it, and the isomorphism is
-# GF(2)-linear, so it is a (2^k x 2^k) bit matrix M_k: flat(a) = M_k * a.
-# With M_k in hand, tower mul specializes to
-#   from_flat(clmul_reduce(to_flat(a), to_flat(b)))
-# where clmul_reduce is one carry-less product + reduction mod f_k -- the
-# same shape as the existing GHASH clmad path.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This script constructs M_k for k in {4, 5} (bf<4>, bf<5>), checks the
-# isomorphism (dense grid + corner sweep for bf<4>, random samples for
-# bf<5>), and prints the matrices as C++ column tables.
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# Run: python3 tools/derive_tower_flat_basis.py
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Derive and prove the tower<->flat basis constants in TowerFlatBasis.h.
+
+The Fan-Paar tower (BinaryFieldCodeGen.cpp) is GF(2^(2^k)) =
+subfield[X_k]/(X_k^2 + X_{k-1}*X_k + 1) with X_0 = 1; storage bit i of a
+bf<k> encodes the multilinear monomial prod_j X_{j+1}^{i_j}. This script
+constructs, for k in {4, 5}, the GF(2)-linear isomorphism onto the flat
+basis GF(2)[y]/(f_k) as a bit-matrix pair, and proves it:
+
+  - f_k irreducibility (Rabin);
+  - the multiplication homomorphism on ALL basis pairs — by bilinearity of
+    both sides this certifies every input pair, unlike random sampling;
+  - the two matrices are mutually inverse on every basis vector;
+  - the two-fold clmad reduction schedule emitted by mulFlatClmad
+    (SpecializeBinaryFieldToNVPTX.cpp) against a plain long-division
+    reduction, on basis pairs plus random and all-ones operands.
+
+Prints the tables in the exact form TowerFlatBasis.h carries.
+
+Run: python3 tools/derive_tower_flat_basis.py
+"""
 
 import random
 
@@ -77,6 +94,24 @@ def flat_reduce(a: int, level: int) -> int:
 
 def mul_flat(a: int, b: int, level: int) -> int:
   return flat_reduce(clmul(a, b), level)
+
+
+def mul_flat_clmad_schedule(a: int, b: int, level: int) -> int:
+  """The exact fold schedule mulFlatClmad emits, in i64 semantics.
+
+  p = clmul(a,b); t1 = p ^ clmul(p>>n, fLow); h2 = (t1>>n) ^ (p>>n);
+  t2 = t1 ^ clmul(h2, fLow); result = trunc_n(t2). Every intermediate must
+  fit 64 bits or clmad.lo would truncate information.
+  """
+  n = 1 << level
+  f_low = FLAT_MODULUS[level] & ((1 << n) - 1)
+  p = clmul(a, b)
+  hi = p >> n
+  t1 = p ^ clmul(hi, f_low)
+  h2 = (t1 >> n) ^ hi
+  t2 = t1 ^ clmul(h2, f_low)
+  assert max(p, t1, t2).bit_length() <= 64
+  return t2 & ((1 << n) - 1)
 
 
 def pow_flat(a: int, e: int, level: int) -> int:
@@ -219,8 +254,9 @@ def invert_matrix(cols: list[int], n: int) -> list[int]:
 
 
 def dump(name: str, n: int, cols: list[int]) -> None:
-  ctype = f"uint{n}_t"
-  print(f"static constexpr {ctype} {name}[{n}] = {{")
+  # uint64_t regardless of field width: the consumer feeds the i64 clmad
+  # domain (TowerFlatBasis.h).
+  print(f"inline constexpr uint64_t {name}[{n}] = {{")
   for i in range(0, n, 4):
     print("    " + ", ".join(hex(c) for c in cols[i : i + 4]) + ",")
   print("};")
@@ -234,27 +270,32 @@ def main() -> None:
     cols = basis_matrix(level)
     inv = invert_matrix(cols, n)
 
-    if level == 4:
-      samples = [
-          (a, b) for a in range(0, 1 << 16, 251) for b in range(0, 1 << 16, 257)
-      ]
-      samples += [(a, b) for a in range(64) for b in range(64)]
-    else:
-      rng = random.Random(392)
-      samples = [
-          (rng.getrandbits(32), rng.getrandbits(32)) for _ in range(20000)
-      ]
-    for a, b in samples:
-      lhs = apply_matrix(cols, mul_tower(a, b, level))
-      rhs = mul_flat(apply_matrix(cols, a), apply_matrix(cols, b), level)
-      assert lhs == rhs, (level, a, b)
-    rng = random.Random(392 + level)
-    for _ in range(1000):
-      x = rng.getrandbits(n)
-      assert apply_matrix(inv, apply_matrix(cols, x)) == x
+    # Both mul_tower and flat-multiply-of-images are GF(2)-bilinear, so
+    # agreement on all n^2 basis pairs proves agreement on all 2^n x 2^n
+    # input pairs. (Random sampling cannot certify this: the difference is
+    # bilinear, not linear, in the pair.)
+    for i in range(n):
+      for j in range(n):
+        a, b = 1 << i, 1 << j
+        lhs = apply_matrix(cols, mul_tower(a, b, level))
+        rhs = mul_flat(apply_matrix(cols, a), apply_matrix(cols, b), level)
+        assert lhs == rhs, (level, i, j)
+    # Inverse on every basis vector; a square matrix with a one-sided
+    # inverse is invertible, so this is complete too.
+    for i in range(n):
+      assert apply_matrix(inv, apply_matrix(cols, 1 << i)) == 1 << i
 
-    print(f"// bf<{level}>: flat modulus f(y) = {hex(f)}, homomorphism and")
-    print(f"// inverse checked over {len(samples)} products.")
+    # The emitted fold schedule vs plain reduction: basis pairs, the
+    # all-ones worst case for intermediate widths, and random operands.
+    rng = random.Random(392 + level)
+    ops = [(1 << i, 1 << j) for i in range(n) for j in range(n)]
+    ops.append(((1 << n) - 1, (1 << n) - 1))
+    ops += [(rng.getrandbits(n), rng.getrandbits(n)) for _ in range(2000)]
+    for a, b in ops:
+      assert mul_flat_clmad_schedule(a, b, level) == mul_flat(a, b, level)
+
+    print(f"// bf<{level}>: flat modulus f(y) = {hex(f)}; homomorphism and")
+    print(f"// inverse proven on all basis pairs; fold schedule checked.")
     dump(f"kTowerToFlat{n}", n, cols)
     dump(f"kFlatToTower{n}", n, inv)
     print()

--- a/tools/derive_tower_flat_basis.py
+++ b/tools/derive_tower_flat_basis.py
@@ -1,0 +1,264 @@
+# Derive the tower<->flat basis-change constants for SpecializeBinaryFieldToNVPTX.
+#
+# The Fan-Paar tower (BinaryFieldCodeGen.cpp) is GF(2^(2^k)) =
+# subfield[X_k]/(X_k^2 + X_{k-1}*X_k + 1) with X_0 = 1; storage bit i of a
+# bf<k> encodes the multilinear monomial prod_j X_{j+1}^{i_j}. A flat
+# GF(2^(2^k)) = GF(2)[y]/(f_k(y)) is isomorphic to it, and the isomorphism is
+# GF(2)-linear, so it is a (2^k x 2^k) bit matrix M_k: flat(a) = M_k * a.
+# With M_k in hand, tower mul specializes to
+#   from_flat(clmul_reduce(to_flat(a), to_flat(b)))
+# where clmul_reduce is one carry-less product + reduction mod f_k -- the
+# same shape as the existing GHASH clmad path.
+#
+# This script constructs M_k for k in {4, 5} (bf<4>, bf<5>), checks the
+# isomorphism (dense grid + corner sweep for bf<4>, random samples for
+# bf<5>), and prints the matrices as C++ column tables.
+#
+# Run: python3 tools/derive_tower_flat_basis.py
+
+import random
+
+# --- Tower arithmetic (mirrors BinaryFieldCodeGen::mulTower/mulXTower) ---
+
+
+def mul_x_tower(a: int, level: int) -> int:
+  """Multiply a (bf<level>) by the level generator X_level."""
+  if level == 0:
+    return a
+  half = 1 << (level - 1)
+  mask = (1 << half) - 1
+  a0, a1 = a & mask, a >> half
+  return a1 | ((a0 ^ mul_x_tower(a1, level - 1)) << half)
+
+
+def mul_tower(a: int, b: int, level: int) -> int:
+  if level == 0:
+    return a & b
+  half = 1 << (level - 1)
+  mask = (1 << half) - 1
+  a0, a1 = a & mask, a >> half
+  b0, b1 = b & mask, b >> half
+  m0 = mul_tower(a0, b0, level - 1)
+  m1 = mul_tower(a1, b1, level - 1)
+  m2 = mul_tower(a0 ^ a1, b0 ^ b1, level - 1)
+  lo = m0 ^ m1
+  hi = m2 ^ m0 ^ m1 ^ mul_x_tower(m1, level - 1)
+  return lo | (hi << half)
+
+
+# --- Flat arithmetic: GF(2)[y]/(f) with f given as an int bitmask ---
+
+# Low-weight irreducibles; is_irreducible() guards them in main().
+# Bit i = coefficient of y^i.
+FLAT_MODULUS = {
+    4: (1 << 16) | (1 << 5) | (1 << 3) | (1 << 1) | 1,  # y^16+y^5+y^3+y+1
+    5: (1 << 32) | (1 << 7) | (1 << 3) | (1 << 2) | 1,  # y^32+y^7+y^3+y^2+1
+}
+
+
+def clmul(a: int, b: int) -> int:
+  r = 0
+  while b:
+    if b & 1:
+      r ^= a
+    a <<= 1
+    b >>= 1
+  return r
+
+
+def flat_reduce(a: int, level: int) -> int:
+  f = FLAT_MODULUS[level]
+  n = 1 << level
+  for i in range(a.bit_length() - 1, n - 1, -1):
+    if a >> i & 1:
+      a ^= f << (i - n)
+  return a
+
+
+def mul_flat(a: int, b: int, level: int) -> int:
+  return flat_reduce(clmul(a, b), level)
+
+
+def pow_flat(a: int, e: int, level: int) -> int:
+  r = 1
+  while e:
+    if e & 1:
+      r = mul_flat(r, a, level)
+    a = mul_flat(a, a, level)
+    e >>= 1
+  return r
+
+
+def is_irreducible(f: int, n: int) -> bool:
+  """Degree-n f is irreducible over GF(2) iff y^(2^n) = y mod f and
+  gcd(y^(2^(n/p)) + y, f) = 1 for every prime p dividing n; n is a power
+  of two here, so p = 2 is the only case."""
+
+  def modmul(a, b):
+    r = clmul(a, b)
+    for i in range(r.bit_length() - 1, n - 1, -1):
+      if r >> i & 1:
+        r ^= f << (i - n)
+    return r
+
+  def y_pow_2exp(e):
+    r = 2  # y
+    for _ in range(e):
+      r = modmul(r, r)
+    return r
+
+  if y_pow_2exp(n) != 2:
+    return False
+  a, b = y_pow_2exp(n // 2) ^ 2, f
+  while a:
+    while a and a.bit_length() >= b.bit_length():
+      a ^= b << (a.bit_length() - b.bit_length())
+    a, b = b, a
+    if b.bit_length() <= 1:
+      break
+  return b == 1
+
+
+# --- Solve z^2 + z = c over the flat field (GF(2)-linear system) ---
+
+
+def solve_artin_schreier(c: int, level: int) -> int:
+  n = 1 << level
+  cols = [mul_flat(1 << i, 1 << i, level) ^ (1 << i) for i in range(n)]
+  basis = []  # (l, z) pairs, each l with a unique leading bit
+  for i in range(n):
+    l, z = cols[i], 1 << i
+    while l:
+      p = l.bit_length() - 1
+      hit = next(
+          (j for j, (bl, _) in enumerate(basis) if bl.bit_length() - 1 == p),
+          None,
+      )
+      if hit is None:
+        basis.append((l, z))
+        break
+      l ^= basis[hit][0]
+      z ^= basis[hit][1]
+  z = 0
+  while c:
+    p = c.bit_length() - 1
+    hit = next(
+        (j for j, (bl, _) in enumerate(basis) if bl.bit_length() - 1 == p), None
+    )
+    if hit is None:
+      raise ValueError("z^2+z=c has no solution (trace(c) != 0)")
+    c ^= basis[hit][0]
+    z ^= basis[hit][1]
+  return z
+
+
+# --- Embedding: images B_j of the tower generators X_j in the flat field ---
+
+
+def generator_images(level: int) -> list[int]:
+  """B[j] = flat image of X_{j+1}, satisfying B_1^2 + B_1 + 1 = 0 and
+  B_j^2 + B_{j-1}*B_j + 1 = 0. Substituting B = prev*z turns each
+  quadratic into Artin-Schreier form z^2 + z = 1/prev^2."""
+  images = []
+  prev = 1
+  for _ in range(level):
+    prev_sq = mul_flat(prev, prev, level)
+    inv_prev_sq = pow_flat(prev_sq, (1 << (1 << level)) - 2, level)
+    z = solve_artin_schreier(inv_prev_sq, level)
+    b = mul_flat(prev, z, level)
+    assert mul_flat(b, b, level) ^ mul_flat(prev, b, level) ^ 1 == 0
+    images.append(b)
+    prev = b
+  return images
+
+
+def basis_matrix(level: int) -> list[int]:
+  """Column i of M = flat image of tower basis monomial i."""
+  b = generator_images(level)
+  cols = []
+  for i in range(1 << level):
+    v = 1
+    for j in range(level):
+      if i >> j & 1:
+        v = mul_flat(v, b[j], level)
+    cols.append(v)
+  return cols
+
+
+def apply_matrix(cols: list[int], x: int) -> int:
+  r = 0
+  for i, c in enumerate(cols):
+    if x >> i & 1:
+      r ^= c
+  return r
+
+
+def invert_matrix(cols: list[int], n: int) -> list[int]:
+  basis = {}
+  for i in range(n):
+    l, z = cols[i], 1 << i
+    while l:
+      p = l.bit_length() - 1
+      if p not in basis:
+        basis[p] = (l, z)
+        break
+      l ^= basis[p][0]
+      z ^= basis[p][1]
+    else:
+      raise ValueError("matrix not invertible")
+  inv_cols = []
+  for i in range(n):
+    c, z = 1 << i, 0
+    while c:
+      p = c.bit_length() - 1
+      bl, bz = basis[p]
+      c ^= bl
+      z ^= bz
+    inv_cols.append(z)
+  return inv_cols
+
+
+def dump(name: str, n: int, cols: list[int]) -> None:
+  ctype = f"uint{n}_t"
+  print(f"static constexpr {ctype} {name}[{n}] = {{")
+  for i in range(0, n, 4):
+    print("    " + ", ".join(hex(c) for c in cols[i : i + 4]) + ",")
+  print("};")
+
+
+def main() -> None:
+  for level in (4, 5):
+    n = 1 << level
+    f = FLAT_MODULUS[level]
+    assert is_irreducible(f, n), f"modulus for level {level} not irreducible"
+    cols = basis_matrix(level)
+    inv = invert_matrix(cols, n)
+
+    if level == 4:
+      samples = [
+          (a, b) for a in range(0, 1 << 16, 251) for b in range(0, 1 << 16, 257)
+      ]
+      samples += [(a, b) for a in range(64) for b in range(64)]
+    else:
+      rng = random.Random(392)
+      samples = [
+          (rng.getrandbits(32), rng.getrandbits(32)) for _ in range(20000)
+      ]
+    for a, b in samples:
+      lhs = apply_matrix(cols, mul_tower(a, b, level))
+      rhs = mul_flat(apply_matrix(cols, a), apply_matrix(cols, b), level)
+      assert lhs == rhs, (level, a, b)
+    rng = random.Random(392 + level)
+    for _ in range(1000):
+      x = rng.getrandbits(n)
+      assert apply_matrix(inv, apply_matrix(cols, x)) == x
+
+    print(f"// bf<{level}>: flat modulus f(y) = {hex(f)}, homomorphism and")
+    print(f"// inverse checked over {len(samples)} products.")
+    dump(f"kTowerToFlat{n}", n, cols)
+    dump(f"kFlatToTower{n}", n, inv)
+    print()
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
## Description

fractalyze/xla#392 profiled the additive (LCH14) GPU NTT and found the
tower-field multiply is the entire cost: `mulTower` Karatsuba-recurses to
GF(2), so one `bf<5>` multiply bit-blasts to ~1,000 ALU ops and the NTT
saturates integer issue rate at ~2% of HBM bandwidth — 57x behind the
multiplicative NTT at equal element width, while GHASH (hardware clmad)
is 18x better per byte on the same benchmark.

A carryless product cannot compute a tower product directly (the reason
towers were excluded from the clmad path), but the tower is isomorphic to
a flat polynomial basis and the isomorphism is GF(2)-linear — so the
multiply becomes ladder-in, one `clmad.lo.u64` + two low-weight reduction
folds, ladder-out. The basis matrices are derived and checked
(irreducibility, homomorphism over exhaustive-grid bf<4> / randomized
bf<5>, inverse round-trip) by `tools/derive_tower_flat_basis.py`; GPU
execution correctness is covered end-to-end by xla's
`ntt_pass_fusion_gpu_test` (byte-compare vs the CPU thunk, 7/7 pass with
this branch overriding `@prime_ir`).

Measured on xla `BM_NttBinary*/24`, RTX 5090: bf<5> 13.32 ms → 2.56 ms
(5.2x), bf<4> 4.67 ms → 1.93 ms (2.4x); GHASH and koalabear unchanged.
Static SASS per NTT pass kernel drops ~21k → ~2.7k instructions with 3
CLMADs per butterfly. Consumers that keep whole kernels in the flat basis
(planned xla follow-up) can hoist the conversion ladders and take the
remaining ~10x headroom to the bandwidth floor.

Tower bf<6>/bf<7> stay portable: bf<6> needs a clmad.hi limb and a
degree-64 modulus, bf<7> a four-limb product.

## Related Issues/PRs

Refs fractalyze/xla#392, fractalyze/xla#239 (GHASH clmad path; same
CUDA >= 13.3 ptxas gate).

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline

🤖 Generated with [Claude Code](https://claude.com/claude-code)