### PR TITLE
feat: specialize AES gf8 field.mul to NVPTX clmad

### DIFF
--- a/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.cpp
+++ b/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.cpp
@@ -249,6 +249,44 @@ struct ConvertTowerMulToClmad : public OpRewritePattern<MulOp> {
   }
 };
 
+// AES-basis bf<3, aes> multiply via one clmad product. The AES basis is
+// already the flat monomial basis GF(2)[x]/(x⁸ + x⁴ + x³ + x + 1) (0x11B), so
+// -- unlike the tower path -- no toFlat/fromFlat bit-matrix is needed. The 8×8
+// product is 15-bit, so one clmad.lo covers it and two folds finish. Result is
+// byte-identical to BinaryFieldToArith's emitAesMul (the software fallback).
+struct ConvertAesMulToClmad : public OpRewritePattern<MulOp> {
+  using OpRewritePattern<MulOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(MulOp op,
+                                PatternRewriter &rewriter) const override {
+    Type aesType = op.getResult().getType();
+    auto bfType = dyn_cast<BinaryFieldType>(aesType);
+    if (!bfType || !bfType.isAes())
+      return failure();
+
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+    auto i8Type = b.getI8Type();
+    auto i64Type = b.getI64Type();
+
+    // Cast aes -> i8; BinaryFieldToArith later reconciles these casts.
+    Value lhs8 =
+        UnrealizedConversionCastOp::create(b, i8Type, op.getLhs()).getResult(0);
+    Value rhs8 =
+        UnrealizedConversionCastOp::create(b, i8Type, op.getRhs()).getResult(0);
+
+    // 0x1b = x⁴ + x³ + x + 1, the low half of the AES modulus x⁸ + 0x1b.
+    Value prodFlat64 = mulFlatClmad(b, arith::ExtUIOp::create(b, i64Type, lhs8),
+                                    arith::ExtUIOp::create(b, i64Type, rhs8),
+                                    /*n=*/8, /*fLow=*/0x1b);
+    Value prod8 = arith::TruncIOp::create(b, i8Type, prodFlat64);
+
+    Value resultAes =
+        UnrealizedConversionCastOp::create(b, aesType, prod8).getResult(0);
+    rewriter.replaceOp(op, resultAes);
+    return success();
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // Pass Implementation
 //===----------------------------------------------------------------------===//
@@ -263,7 +301,8 @@ struct SpecializeBinaryFieldToNVPTX
 
     RewritePatternSet patterns(context);
     if (useClmad) {
-      patterns.add<ConvertGhashMulToClmad, ConvertTowerMulToClmad>(context);
+      patterns.add<ConvertGhashMulToClmad, ConvertTowerMulToClmad,
+                   ConvertAesMulToClmad>(context);
     }
 
     // Greedy rewriting (not partial conversion) so unmatched field.mul ops

--- a/tests/Dialect/Field/specialize_binary_field_to_nvptx.mlir
+++ b/tests/Dialect/Field/specialize_binary_field_to_nvptx.mlir
@@ -15,9 +15,10 @@
 
 // Test clmad specialization for binary field multiplication.
 //
-// clmad computes a carryless product: `bf<7, ghash>` multiplies directly,
-// tower bf<4>/bf<5> go through the flat-basis conversion (TowerFlatBasis.h),
-// and tower bf<6>/bf<7> stay portable (`field.mul`).
+// clmad computes a carryless product: `bf<7, ghash>` and `bf<3, aes>` are
+// already flat so they multiply directly, tower bf<4>/bf<5> go through the
+// flat-basis conversion (TowerFlatBasis.h), and tower bf<6>/bf<7> stay
+// portable (`field.mul`).
 
 // RUN: prime-ir-opt --specialize-binary-field-to-nvptx %s | FileCheck %s --check-prefix=CHECK-CLMAD
 
@@ -35,6 +36,7 @@
 !BF64 = !field.bf<6>         // GF(2⁶⁴), tower basis
 !BF128 = !field.bf<7>        // GF(2¹²⁸), tower basis
 !GHASH = !field.bf<7, ghash> // GF(2¹²⁸), flat GHASH polynomial basis
+!AES = !field.bf<3, aes>     // GF(2⁸), flat AES polynomial basis
 
 // GHASH-basis scalar multiplication should use clmad: eight clmad.{lo,hi}.u64
 // build the 128×128 carryless product, then the shared GHASH reduction.
@@ -75,6 +77,21 @@ func.func @test_bf32_mul(%a: !BF32, %b: !BF32) -> !BF32 {
 func.func @test_bf16_mul(%a: !BF16, %b: !BF16) -> !BF16 {
   %c = field.mul %a, %b : !BF16
   return %c : !BF16
+}
+
+// AES (flat) multiplies directly like GHASH, but the 8×8 product is 15-bit so
+// it needs no Karatsuba limbs: one clmad.lo product + two reduction folds =
+// three clmad.lo.u64, and no toFlat/fromFlat conversion.
+// CHECK-CLMAD-LABEL: @test_aes_mul
+// CHECK-CLMAD: builtin.unrealized_conversion_cast
+// CHECK-CLMAD-COUNT-3: llvm.inline_asm{{.*}}clmad.lo{{.*}}u64
+// CHECK-CLMAD: builtin.unrealized_conversion_cast
+// CHECK-OFF-LABEL: @test_aes_mul
+// CHECK-OFF: field.mul
+// CHECK-OFF-NOT: clmad
+func.func @test_aes_mul(%a: !AES, %b: !AES) -> !AES {
+  %c = field.mul %a, %b : !AES
+  return %c : !AES
 }
 
 // BF128 (tower) scalar multiplication stays portable — no carryless fast path.


### PR DESCRIPTION
## Description

flock's zerocheck round-1 additive NTT multiplies in the flat-AES GF(2⁸)
basis (`bf<3, aes>`). Unlike GHASH (`bf<7, ghash>`) and tower `bf<4>/bf<5>`,
that `field.mul` had no NVPTX specialization, so it fell through to the ~90-op
software carryless multiply — leaving the fused `ntt_pass_fusion` kernel
compute-bound (~52% of flock's zerocheck at m=28, ALU-bound, ~17% peak BW).

AES is already the flat monomial basis, so — unlike the tower path — no
tower↔flat bit-matrix is needed: the 8-bit operands feed one `clmad.lo`
product, and two folds mod x⁸+x⁴+x³+x+1 (`0x1b`) finish the reduction via the
shared `mulFlatClmad`. The result reduces the same GF(2)[x] product as the
`emitAesMul` software fallback, so it is byte-identical — confirmed equal on
all 2⁸×2⁸ inputs.

This is the prime-ir half; the GPU speedup reaches flock only after the
stablehlo/xla pin bumps + zkx PJRT plugin rebuild (clmad needs CUDA≥13.3
ptxas, the same gate as GHASH/#410).

## Related Issues/PRs

Part of fractalyze/xla#396. Follows #410 (tower `bf<4>/bf<5>` clmad) and the
earlier GHASH clmad specialization.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline