### PR TITLE
chore: remove Gemini Code Assist config

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,3 +1,0 @@
-have_fun: false
-code_review:
-  disable: true


### PR DESCRIPTION
Deletes the `.gemini/` Gemini Code Assist config (follow-up to #413, which merged the disable-config variant before the plan changed to full removal):

- `.gemini/config.yaml`

Note: reviews are driven by the org-wide gemini-code-assist app installation, not these files — with the app still installed, deleting the config alone reverts this repo to *default* review behavior. This PR is part of dropping Gemini review entirely; the app is being uninstalled by an org admin at https://github.com/organizations/fractalyze/settings/installations.