### PR TITLE
feat(dialect/arith_ext): add AVX2 (2x ymm) flavor to SpecializeArithToAVX

### DIFF
--- a/benchmarks/ArithExt/packed_mont_chain.mlir
+++ b/benchmarks/ArithExt/packed_mont_chain.mlir
@@ -1,0 +1,174 @@
+// Copyright 2025 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// Microbenchmark for SpecializeArithToAVX (see run_bench.sh for how to run).
+//
+// Each round is one packed Montgomery multiply-accumulate step over BabyBear
+// (q = 2013265921, q^-1 mod 2^32 = 2281701377): the
+// mului_extended/muli/subi/addi mix and low/high gather chaining that the
+// field-to-llvm pipeline emits for absorb-style kernels, on vector<16xi32>.
+//
+// Two kernels:
+// - @chain:  one loop-carried vector, latency-bound (absorb-chain analog).
+// - @sweep:  independent rounds over a buffer, throughput-bound. The buffer
+//   size selects the cache level (see run_bench.sh).
+
+func.func private @rtclock() -> f64
+
+// One Montgomery REDC round: x <- REDC(x * y) + q (kept unreduced; the
+// values wrap mod 2^32, which is fine for measurement purposes).
+func.func @round(%x: vector<16xi32>, %y: vector<16xi32>) -> vector<16xi32> {
+  // q^-1 mod 2^32 (= 2281701377) as signed i32; the subtraction form of REDC
+  // below pairs with q^-1, not -q^-1.
+  %qInv = arith.constant dense<-2013265919> : vector<16xi32>
+  %q = arith.constant dense<2013265921> : vector<16xi32>
+  %t:2 = arith.mului_extended %x, %y : vector<16xi32>
+  %m = arith.muli %t#0, %qInv : vector<16xi32>
+  %u:2 = arith.mului_extended %m, %q : vector<16xi32>
+  %r = arith.subi %t#1, %u#1 : vector<16xi32>
+  %x1 = arith.addi %r, %q : vector<16xi32>
+  return %x1 : vector<16xi32>
+}
+
+func.func @chain(%x0: vector<16xi32>, %y: vector<16xi32>, %reps: index)
+    -> vector<16xi32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %res = scf.for %i = %c0 to %reps step %c1
+      iter_args(%x = %x0) -> (vector<16xi32>) {
+    %x1 = func.call @round(%x, %y) : (vector<16xi32>, vector<16xi32>)
+        -> vector<16xi32>
+    scf.yield %x1 : vector<16xi32>
+  }
+  return %res : vector<16xi32>
+}
+
+func.func @sweep(%buf: memref<?xvector<16xi32>>, %y: vector<16xi32>,
+                 %outer: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %n = memref.dim %buf, %c0 : memref<?xvector<16xi32>>
+  scf.for %t = %c0 to %outer step %c1 {
+    scf.for %j = %c0 to %n step %c1 {
+      %x = memref.load %buf[%j] : memref<?xvector<16xi32>>
+      %x1 = func.call @round(%x, %y) : (vector<16xi32>, vector<16xi32>)
+          -> vector<16xi32>
+      %x2 = func.call @round(%x1, %y) : (vector<16xi32>, vector<16xi32>)
+          -> vector<16xi32>
+      %x3 = func.call @round(%x2, %y) : (vector<16xi32>, vector<16xi32>)
+          -> vector<16xi32>
+      %x4 = func.call @round(%x3, %y) : (vector<16xi32>, vector<16xi32>)
+          -> vector<16xi32>
+      memref.store %x4, %buf[%j] : memref<?xvector<16xi32>>
+    }
+  }
+  return
+}
+
+func.func @init(%buf: memref<?xvector<16xi32>>, %x0: vector<16xi32>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %n = memref.dim %buf, %c0 : memref<?xvector<16xi32>>
+  scf.for %j = %c0 to %n step %c1 {
+    memref.store %x0, %buf[%j] : memref<?xvector<16xi32>>
+  }
+  return
+}
+
+// Times @sweep over a buffer of %n vectors; returns seconds per round.
+func.func @timed_sweep(%n: index, %outer: index, %x0: vector<16xi32>,
+                       %y: vector<16xi32>) -> f64 {
+  %c0 = arith.constant 0 : index
+  %buf = memref.alloc(%n) : memref<?xvector<16xi32>>
+  func.call @init(%buf, %x0)
+      : (memref<?xvector<16xi32>>, vector<16xi32>) -> ()
+  // Warm-up pass.
+  %c1 = arith.constant 1 : index
+  func.call @sweep(%buf, %y, %c1)
+      : (memref<?xvector<16xi32>>, vector<16xi32>, index) -> ()
+  %t0 = func.call @rtclock() : () -> f64
+  func.call @sweep(%buf, %y, %outer)
+      : (memref<?xvector<16xi32>>, vector<16xi32>, index) -> ()
+  %t1 = func.call @rtclock() : () -> f64
+  // Keep the result observable; the reductions also let the harness diff
+  // results across configs.
+  %x = memref.load %buf[%c0] : memref<?xvector<16xi32>>
+  %xXor = vector.reduction <xor>, %x : vector<16xi32> into i32
+  vector.print %xXor : i32
+  %xAdd = vector.reduction <add>, %x : vector<16xi32> into i32
+  vector.print %xAdd : i32
+  %dt = arith.subf %t1, %t0 : f64
+  %nI64 = arith.index_cast %n : index to i64
+  %outerI64 = arith.index_cast %outer : index to i64
+  %c4 = arith.constant 4 : i64
+  %roundsA = arith.muli %nI64, %outerI64 : i64
+  %rounds = arith.muli %roundsA, %c4 : i64
+  %roundsF = arith.sitofp %rounds : i64 to f64
+  %perRound = arith.divf %dt, %roundsF : f64
+  memref.dealloc %buf : memref<?xvector<16xi32>>
+  return %perRound : f64
+}
+
+func.func @main() {
+  %x0 = arith.constant dense<[1, 2, 3, 4, 5, 6, 7, 8,
+                              9, 10, 11, 12, 13, 14, 15, 16]> : vector<16xi32>
+  %y = arith.constant dense<[901943132, 447872240, 1755702243, 917797396,
+                             1663489668, 977253245, 473039071, 100480371,
+                             1524823050, 933205805, 67650069, 1893806164,
+                             225804680, 1911871336, 1189862080,
+                             688018430]> : vector<16xi32>
+
+  // Latency-bound chain: 1<<22 dependent rounds.
+  %chain_reps = arith.constant 4194304 : index
+  // Warm-up.
+  %warm_reps = arith.constant 16384 : index
+  %w = func.call @chain(%x0, %y, %warm_reps)
+      : (vector<16xi32>, vector<16xi32>, index) -> vector<16xi32>
+  %wXor = vector.reduction <xor>, %w : vector<16xi32> into i32
+  vector.print %wXor : i32
+  %t0 = func.call @rtclock() : () -> f64
+  %r = func.call @chain(%x0, %y, %chain_reps)
+      : (vector<16xi32>, vector<16xi32>, index) -> vector<16xi32>
+  %t1 = func.call @rtclock() : () -> f64
+  %rXor = vector.reduction <xor>, %r : vector<16xi32> into i32
+  vector.print %rXor : i32
+  %rAdd = vector.reduction <add>, %r : vector<16xi32> into i32
+  vector.print %rAdd : i32
+  %dt = arith.subf %t1, %t0 : f64
+  %repsI64 = arith.index_cast %chain_reps : index to i64
+  %repsF = arith.sitofp %repsI64 : i64 to f64
+  %perRound = arith.divf %dt, %repsF : f64
+  // ns per round.
+  %c1e9 = arith.constant 1.0e9 : f64
+  %chainNs = arith.mulf %perRound, %c1e9 : f64
+  vector.print %chainNs : f64
+
+  // Throughput-bound sweeps: 16 KiB (L1-resident) and 1 MiB (L2-resident)
+  // buffers, ~21M rounds each.
+  %l1_n = arith.constant 256 : index
+  %l1_outer = arith.constant 20000 : index
+  %l1_per = func.call @timed_sweep(%l1_n, %l1_outer, %x0, %y)
+      : (index, index, vector<16xi32>, vector<16xi32>) -> f64
+  %l1_ns = arith.mulf %l1_per, %c1e9 : f64
+  vector.print %l1_ns : f64
+
+  %l2_n = arith.constant 16384 : index
+  %l2_outer = arith.constant 320 : index
+  %l2_per = func.call @timed_sweep(%l2_n, %l2_outer, %x0, %y)
+      : (index, index, vector<16xi32>, vector<16xi32>) -> f64
+  %l2_ns = arith.mulf %l2_per, %c1e9 : f64
+  vector.print %l2_ns : f64
+  return
+}

--- a/benchmarks/ArithExt/run_bench.sh
+++ b/benchmarks/ArithExt/run_bench.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Copyright 2025 The PrimeIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# Microbenchmark harness for SpecializeArithToAVX (not wired into CI; run
+# manually). Measures the packed Montgomery chain kernel in three configs:
+#
+#   generic-avx2      LLVM generic legalization, JIT capped to AVX2
+#   flavor-avx2       -specialize-arith-to-avx=flavor=avx2, JIT capped to AVX2
+#   flavor-avx512     -specialize-arith-to-avx (default), native host ISA
+#                     (reference; requires an AVX-512 host)
+#
+# The AVX2 cap is applied with mlir-runner --mattr=-avx512f (JitRunner adds
+# -mattr on top of the detected host features, and clearing avx512f also
+# clears everything that implies it). The script verifies the cap from the
+# dumped JIT object: no zmm registers or opmask merges may appear, and the
+# flavor-avx2 config must actually contain ymm vpmuludq.
+#
+# Each config runs RUNS times (default 5); the per-round minimum is reported.
+# Printed result vectors must be identical across configs (bit-exactness).
+#
+# Usage: benchmarks/ArithExt/run_bench.sh
+#   RUNS=<n>           number of repetitions per config
+#   BENCH_CPU=<core>   core to pin to (default: last core)
+#   BENCH_OUT_DIR=<d>  keep lowered IR, JIT objects, and raw runs there
+#   SKIP_AVX512=1      skip the native AVX-512 reference config
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+RUNS="${RUNS:-5}"
+# Default to the highest CPU this process may run on; nproc is a count and
+# breaks in sparse or non-zero-based cpusets.
+CPU="${BENCH_CPU:-$(awk '/Cpus_allowed_list/ {
+  count = split($2, ranges, ",")
+  bounds = split(ranges[count], range, "-")
+  print range[bounds]
+}' /proc/self/status)}"
+SRC=benchmarks/ArithExt/packed_mont_chain.mlir
+if [[ -n "${BENCH_OUT_DIR:-}" ]]; then
+  OUT=$BENCH_OUT_DIR
+  mkdir -p "$OUT"
+else
+  OUT=$(mktemp -d)
+  trap 'rm -rf "$OUT"' EXIT
+fi
+
+echo "== load average: $(cat /proc/loadavg) (benchmarking wants an idle box)"
+echo "== building tools"
+nice -n 10 bazel build //tools:prime-ir-opt \
+  @llvm-project//mlir:mlir-runner \
+  @llvm-project//mlir:libmlir_c_runner_utils.so
+
+OPT=bazel-bin/tools/prime-ir-opt
+RUNNER=bazel-bin/external/llvm-project/mlir/mlir-runner
+LIBS=$(readlink -f bazel-bin/external/llvm-project/mlir/libmlir_c_runner_utils.so)
+
+# lower <pass-flags...>
+lower() {
+  # -convert-vector-to-llvm handles vector.print, which the generic
+  # -convert-to-llvm interface does not lower.
+  "$OPT" "$SRC" "$@" -convert-scf-to-cf -convert-vector-to-llvm \
+    -convert-to-llvm
+}
+
+# run_config <name> <mattr-flags> — expects $OUT/<name>.mlir to exist.
+# Prints "chain l1 l2" minima; dumps the JIT object on the first run.
+run_config() {
+  local name=$1 mattr=$2
+  local best_chain= best_l1= best_l2=
+  for i in $(seq "$RUNS"); do
+    local dump=()
+    if [[ $i == 1 ]]; then
+      dump=(--dump-object-file --object-filename="$OUT/$name.o")
+    fi
+    # shellcheck disable=SC2086
+    taskset -c "$CPU" nice -n -0 "$RUNNER" "$OUT/$name.mlir" \
+      -e main -entry-point-result=void -O3 $mattr \
+      -shared-libs="$LIBS" "${dump[@]}" > "$OUT/$name.run$i.txt"
+    mapfile -t ns < <(grep -E '^[0-9]+\.[0-9]+(e[-+]?[0-9]+)?$' \
+      "$OUT/$name.run$i.txt")
+    if [[ ${#ns[@]} -ne 3 ]]; then
+      echo "unexpected output in $OUT/$name.run$i.txt" >&2
+      exit 1
+    fi
+    grep -E '^-?[0-9]+$' "$OUT/$name.run$i.txt" > "$OUT/$name.vectors.txt"
+    best_chain=$(printf '%s\n' "${best_chain:-inf}" "${ns[0]}" | sort -g | head -1)
+    best_l1=$(printf '%s\n' "${best_l1:-inf}" "${ns[1]}" | sort -g | head -1)
+    best_l2=$(printf '%s\n' "${best_l2:-inf}" "${ns[2]}" | sort -g | head -1)
+  done
+  echo "$best_chain $best_l1 $best_l2"
+}
+
+echo "== lowering"
+lower > "$OUT/generic-avx2.mlir"
+lower -specialize-arith-to-avx=flavor=avx2 > "$OUT/flavor-avx2.mlir"
+lower -specialize-arith-to-avx > "$OUT/flavor-avx512.mlir"
+
+echo "== running generic-avx2 (baseline)"
+GEN=$(run_config generic-avx2 --mattr=-avx512f)
+echo "== running flavor-avx2"
+AVX2=$(run_config flavor-avx2 --mattr=-avx512f)
+if [[ "${SKIP_AVX512:-}" != 1 ]]; then
+  echo "== running flavor-avx512 (native reference)"
+  AVX512=$(run_config flavor-avx512 "")
+fi
+
+echo "== verifying the AVX2 cap from the dumped JIT objects"
+# grep -q would SIGPIPE objdump on first match, which pipefail turns into a
+# failure — disassemble to a file instead.
+for name in generic-avx2 flavor-avx2; do
+  objdump -d "$OUT/$name.o" > "$OUT/$name.disasm"
+  if grep -qE 'zmm|\{%k[0-7]\}' "$OUT/$name.disasm"; then
+    echo "FAIL: $name object uses zmm/opmask; the AVX2 cap did not hold" >&2
+    exit 1
+  fi
+done
+if ! grep -qE 'vpmuludq.*ymm' "$OUT/flavor-avx2.disasm"; then
+  echo "FAIL: flavor-avx2 object contains no ymm vpmuludq" >&2
+  exit 1
+fi
+echo "   ok: no zmm/opmask in capped objects; ymm vpmuludq present"
+
+echo "== verifying bit-exact results across configs"
+if ! diff -q "$OUT/generic-avx2.vectors.txt" "$OUT/flavor-avx2.vectors.txt"; then
+  echo "FAIL: flavor-avx2 results differ from generic" >&2
+  exit 1
+fi
+if [[ "${SKIP_AVX512:-}" != 1 ]] && \
+   ! diff -q "$OUT/generic-avx2.vectors.txt" "$OUT/flavor-avx512.vectors.txt"; then
+  echo "FAIL: flavor-avx512 results differ from generic" >&2
+  exit 1
+fi
+echo "   ok"
+
+echo
+echo "ns/round (min of $RUNS runs)      chain      sweep-16KiB  sweep-1MiB"
+printf 'generic-avx2 (baseline)    %10s %12s %12s\n' $GEN
+printf 'flavor-avx2                %10s %12s %12s\n' $AVX2
+if [[ "${SKIP_AVX512:-}" != 1 ]]; then
+  printf 'flavor-avx512 (native)     %10s %12s %12s\n' $AVX512
+fi

--- a/prime_ir/Dialect/ArithExt/Conversions/SpecializeArithToAVX/SpecializeArithToAVX.cpp
+++ b/prime_ir/Dialect/ArithExt/Conversions/SpecializeArithToAVX/SpecializeArithToAVX.cpp
@@ -231,11 +231,214 @@ extractEvenOdd(ImplicitLocOpBuilder &b, Value value,
   return std::nullopt;
 }
 
+//===----------------------------------------------------------------------===//
+// AVX2 (2x ymm) helpers
+//===----------------------------------------------------------------------===//
+//
+// On AVX2, vector<16xi32> occupies two ymm registers and there are no opmask
+// registers, so the zmm inline asm above is not encodable. The same dual-lane
+// dataflow is expressed as target-independent IR instead:
+// - Extended products use the masked 64-bit multiply idiom that the X86
+//   backend selects to vpmuludq/vpmuldq (combineMulToPMULDQ; the
+//   llvm.x86.*.pmul[u].dq intrinsics were removed in LLVM 7 in favor of this
+//   form, which is also what clang emits for _mm256_mul_ep[iu]32).
+// - Low/high interleaves are vector.shuffle ops; LLVM lowers each to a short
+//   ymm sequence (e.g. vmovs[lh]dup + vpblendd) per half.
+// - Adds/subs on dual-lane values stay as plain integer ops; they legalize
+//   to vpaddd/vpsubd ymm pairs without help.
+// Keeping the ops transparent (no asm) lets LLVM schedule them freely.
+//
+// The arithmetic is emitted in the LLVM dialect rather than arith: the
+// conversion target only marks the LLVM and vector dialects legal, and ops
+// created by a conversion pattern must be legal or the whole rewrite is
+// rolled back. (arith.addi on vector<16xi32> also could not be marked legal
+// without disabling the dual-lane chain pattern that matches that very form.)
+
+// vector.shuffle masks implementing the interleaves documented on
+// gatherLowsInterleaved/gatherHighsInterleaved above, as 2-input shuffles of
+// (even, odd).
+inline constexpr int64_t kGatherLowsMask[16] = {0, 16, 2,  18, 4,  20, 6,  22,
+                                                8, 24, 10, 26, 12, 28, 14, 30};
+inline constexpr int64_t kGatherHighsMask[16] = {1, 17, 3,  19, 5,  21, 7,  23,
+                                                 9, 25, 11, 27, 13, 29, 15, 31};
+
+// Multiplies the even 32-bit lanes of the given vector<16xi32> operands into
+// 64-bit products, like mulExtendedByOddEven, but as the pmuludq/pmuldq IR
+// idiom instead of zmm inline asm.
+std::pair<Value, Value> mulExtendedByOddEvenAVX2(ImplicitLocOpBuilder &b,
+                                                 Value lhsEven, Value lhsOdd,
+                                                 Value rhsEven, Value rhsOdd,
+                                                 bool isSigned = false) {
+  auto vecI32Type = VectorType::get(16, b.getI32Type());
+  auto vecI64Type = VectorType::get(8, b.getI64Type());
+
+  // Reinterprets the vector as vector<8xi64> and extends each even i32 lane
+  // (the low half of every i64 lane) to the full 64 bits.
+  auto extendEvenLanes = [&](Value vec) -> Value {
+    Value vec64 = vector::BitCastOp::create(b, vecI64Type, vec);
+    if (isSigned) {
+      // sext_inreg as shifts; matched to vpmuldq.
+      Value c32 = LLVM::ConstantOp::create(
+          b, vecI64Type,
+          DenseElementsAttr::get(vecI64Type, b.getI64IntegerAttr(32)));
+      Value shifted = LLVM::ShlOp::create(b, vec64, c32);
+      return LLVM::AShrOp::create(b, shifted, c32);
+    }
+    // Zero-extend by masking; matched to vpmuludq.
+    Value mask = LLVM::ConstantOp::create(
+        b, vecI64Type,
+        DenseElementsAttr::get(vecI64Type, b.getI64IntegerAttr(0xFFFFFFFF)));
+    return LLVM::AndOp::create(b, vec64, mask);
+  };
+
+  Value prodEven64 = LLVM::MulOp::create(b, extendEvenLanes(lhsEven),
+                                         extendEvenLanes(rhsEven));
+  Value prodOdd64 =
+      LLVM::MulOp::create(b, extendEvenLanes(lhsOdd), extendEvenLanes(rhsOdd));
+
+  // cast them to vector<16xi32> so even lanes are the low parts and odd
+  // lanes are the high parts
+  auto prodEven32 = vector::BitCastOp::create(b, vecI32Type, prodEven64);
+  auto prodOdd32 = vector::BitCastOp::create(b, vecI32Type, prodOdd64);
+  return {prodEven32, prodOdd32};
+}
+
+// Shuffle-based equivalent of gatherLowsInterleaved.
+Value gatherLowsInterleavedAVX2(ImplicitLocOpBuilder &b, Value even,
+                                Value odd) {
+  auto vecI32Type = VectorType::get(16, b.getI32Type());
+  return vector::ShuffleOp::create(b, vecI32Type, even, odd,
+                                   b.getDenseI64ArrayAttr(kGatherLowsMask));
+}
+
+inline bool isGatherLowsResultAVX2(Value value) {
+  auto shuffleOp = value.getDefiningOp<vector::ShuffleOp>();
+  return shuffleOp && shuffleOp.getMask() == ArrayRef<int64_t>(kGatherLowsMask);
+}
+
+// Shuffle-based equivalent of gatherHighsInterleaved.
+Value gatherHighsInterleavedAVX2(ImplicitLocOpBuilder &b, Value even,
+                                 Value odd) {
+  auto vecI32Type = VectorType::get(16, b.getI32Type());
+  return vector::ShuffleOp::create(b, vecI32Type, even, odd,
+                                   b.getDenseI64ArrayAttr(kGatherHighsMask));
+}
+
+inline bool isGatherHighsResultAVX2(Value value) {
+  auto shuffleOp = value.getDefiningOp<vector::ShuffleOp>();
+  return shuffleOp &&
+         shuffleOp.getMask() == ArrayRef<int64_t>(kGatherHighsMask);
+}
+
+// Shuffle-based equivalent of extractEvenOdd.
+std::optional<std::pair<Value, Value>>
+extractEvenOddAVX2(ImplicitLocOpBuilder &b, Value value,
+                   bool duplicateForHighs = false,
+                   bool duplicateForDefault = true) {
+  if (isGatherLowsResultAVX2(value)) {
+    auto shuffleOp = value.getDefiningOp<vector::ShuffleOp>();
+    return {{shuffleOp.getV1(), shuffleOp.getV2()}};
+  }
+  if (isGatherHighsResultAVX2(value)) {
+    auto shuffleOp = value.getDefiningOp<vector::ShuffleOp>();
+    Value even = shuffleOp.getV1();
+    Value odd = shuffleOp.getV2();
+    if (duplicateForHighs) {
+      even = duplicateOddLanesToEven(b, even);
+      odd = duplicateOddLanesToEven(b, odd);
+    }
+    return {{even, odd}};
+  }
+  if (isConstantSplat(value)) {
+    return {{value, value}};
+  }
+  // Default case
+  if (duplicateForDefault) {
+    return {{value, duplicateOddLanesToEven(b, value)}};
+  }
+  return std::nullopt;
+}
+
+//===----------------------------------------------------------------------===//
+// Flavor traits
+//===----------------------------------------------------------------------===//
+
+// Dispatch tables between the AVX-512 and AVX2 lowerings of the dual-lane
+// building blocks. The conversion patterns below are templated over these.
+struct Avx512Flavor {
+  static bool matchGatherLows(Value value) { return isGatherLowsResult(value); }
+  static bool matchGatherHighs(Value value) {
+    return isGatherHighsResult(value);
+  }
+  static Value emitGatherLows(ImplicitLocOpBuilder &b, Value even, Value odd) {
+    return gatherLowsInterleaved(b, even, odd);
+  }
+  static Value emitGatherHighs(ImplicitLocOpBuilder &b, Value even, Value odd) {
+    return gatherHighsInterleaved(b, even, odd);
+  }
+  static std::optional<std::pair<Value, Value>>
+  splitEvenOdd(ImplicitLocOpBuilder &b, Value value, bool duplicateForHighs,
+               bool duplicateForDefault) {
+    return extractEvenOdd(b, value, duplicateForHighs, duplicateForDefault);
+  }
+  static std::pair<Value, Value> emitMulExtended(ImplicitLocOpBuilder &b,
+                                                 Value lhsEven, Value lhsOdd,
+                                                 Value rhsEven, Value rhsOdd,
+                                                 bool isSigned) {
+    return mulExtendedByOddEven(b, lhsEven, lhsOdd, rhsEven, rhsOdd, isSigned);
+  }
+  template <typename OpType>
+  static std::pair<Value, Value> emitAddSub(ImplicitLocOpBuilder &b,
+                                            Value lhsEven, Value lhsOdd,
+                                            Value rhsEven, Value rhsOdd) {
+    return addSubByOddEven<OpType>(b, lhsEven, lhsOdd, rhsEven, rhsOdd);
+  }
+};
+
+struct Avx2Flavor {
+  static bool matchGatherLows(Value value) {
+    return isGatherLowsResultAVX2(value);
+  }
+  static bool matchGatherHighs(Value value) {
+    return isGatherHighsResultAVX2(value);
+  }
+  static Value emitGatherLows(ImplicitLocOpBuilder &b, Value even, Value odd) {
+    return gatherLowsInterleavedAVX2(b, even, odd);
+  }
+  static Value emitGatherHighs(ImplicitLocOpBuilder &b, Value even, Value odd) {
+    return gatherHighsInterleavedAVX2(b, even, odd);
+  }
+  static std::optional<std::pair<Value, Value>>
+  splitEvenOdd(ImplicitLocOpBuilder &b, Value value, bool duplicateForHighs,
+               bool duplicateForDefault) {
+    return extractEvenOddAVX2(b, value, duplicateForHighs, duplicateForDefault);
+  }
+  static std::pair<Value, Value> emitMulExtended(ImplicitLocOpBuilder &b,
+                                                 Value lhsEven, Value lhsOdd,
+                                                 Value rhsEven, Value rhsOdd,
+                                                 bool isSigned) {
+    return mulExtendedByOddEvenAVX2(b, lhsEven, lhsOdd, rhsEven, rhsOdd,
+                                    isSigned);
+  }
+  // Adds/subs on dual-lane values need no special instruction on AVX2;
+  // vector<16xi32> integer add/sub legalizes to vpaddd/vpsubd ymm pairs.
+  template <typename OpType>
+  static std::pair<Value, Value> emitAddSub(ImplicitLocOpBuilder &b,
+                                            Value lhsEven, Value lhsOdd,
+                                            Value rhsEven, Value rhsOdd) {
+    using LLVMOp = std::conditional_t<std::is_same_v<OpType, arith::AddIOp>,
+                                      LLVM::AddOp, LLVM::SubOp>;
+    Value resEven = LLVMOp::create(b, lhsEven, rhsEven);
+    Value resOdd = LLVMOp::create(b, lhsOdd, rhsOdd);
+    return {resEven, resOdd};
+  }
+};
+
 } // namespace
 
-template <typename OpType>
-struct SpecializeAddSubIOpToAVX512 : public OpConversionPattern<OpType> {
-  explicit SpecializeAddSubIOpToAVX512(MLIRContext *context)
+template <typename OpType, typename Flavor>
+struct SpecializeAddSubIOp : public OpConversionPattern<OpType> {
+  explicit SpecializeAddSubIOp(MLIRContext *context)
       : OpConversionPattern<OpType>(context) {}
 
   using OpConversionPattern<OpType>::OpConversionPattern;
@@ -274,12 +477,12 @@ struct SpecializeAddSubIOpToAVX512 : public OpConversionPattern<OpType> {
           }
         }
 
-        bool isLhsLow = isGatherLowsResult(adaptor.getLhs());
-        bool isLhsHigh = isGatherHighsResult(adaptor.getLhs());
+        bool isLhsLow = Flavor::matchGatherLows(adaptor.getLhs());
+        bool isLhsHigh = Flavor::matchGatherHighs(adaptor.getLhs());
         // In the case of SubIOp, LHS can be a constant.
         bool isLhsConst = isConstantSplat(adaptor.getLhs());
-        bool isRhsLow = isGatherLowsResult(adaptor.getRhs());
-        bool isRhsHigh = isGatherHighsResult(adaptor.getRhs());
+        bool isRhsLow = Flavor::matchGatherLows(adaptor.getRhs());
+        bool isRhsHigh = Flavor::matchGatherHighs(adaptor.getRhs());
         bool isRhsConst = isConstantSplat(adaptor.getRhs());
 
         bool onLowPath = (isLhsLow || isLhsConst) && (isRhsLow || isRhsConst);
@@ -292,22 +495,23 @@ struct SpecializeAddSubIOpToAVX512 : public OpConversionPattern<OpType> {
         }
 
         auto [lhsEven, lhsOdd] =
-            extractEvenOdd(b, adaptor.getLhs(), false, false).value();
+            Flavor::splitEvenOdd(b, adaptor.getLhs(), false, false).value();
         auto [rhsEven, rhsOdd] =
-            extractEvenOdd(b, adaptor.getRhs(), false, false).value();
+            Flavor::splitEvenOdd(b, adaptor.getRhs(), false, false).value();
 
-        auto [resultEven32, resultOdd32] =
-            addSubByOddEven<OpType>(b, lhsEven, lhsOdd, rhsEven, rhsOdd);
+        auto [resultEven32, resultOdd32] = Flavor::template emitAddSub<OpType>(
+            b, lhsEven, lhsOdd, rhsEven, rhsOdd);
 
         if (onLowPath) {
-          Value gatherLow = gatherLowsInterleaved(b, resultEven32, resultOdd32);
+          Value gatherLow =
+              Flavor::emitGatherLows(b, resultEven32, resultOdd32);
           rewriter.replaceOp(op, {gatherLow});
           return success();
         }
 
         if (onHighPath) {
           Value gatherHigh =
-              gatherHighsInterleaved(b, resultEven32, resultOdd32);
+              Flavor::emitGatherHighs(b, resultEven32, resultOdd32);
           rewriter.replaceOp(op, {gatherHigh});
           return success();
         }
@@ -319,12 +523,16 @@ struct SpecializeAddSubIOpToAVX512 : public OpConversionPattern<OpType> {
   }
 };
 
-using SpecializeAddIOpToAVX512 = SpecializeAddSubIOpToAVX512<arith::AddIOp>;
-using SpecializeSubIOpToAVX512 = SpecializeAddSubIOpToAVX512<arith::SubIOp>;
+using SpecializeAddIOpToAVX512 =
+    SpecializeAddSubIOp<arith::AddIOp, Avx512Flavor>;
+using SpecializeSubIOpToAVX512 =
+    SpecializeAddSubIOp<arith::SubIOp, Avx512Flavor>;
+using SpecializeAddIOpToAVX2 = SpecializeAddSubIOp<arith::AddIOp, Avx2Flavor>;
+using SpecializeSubIOpToAVX2 = SpecializeAddSubIOp<arith::SubIOp, Avx2Flavor>;
 
-template <typename OpType>
-struct SpecializeMulIOpToAVX512Impl : public OpConversionPattern<OpType> {
-  explicit SpecializeMulIOpToAVX512Impl(MLIRContext *context)
+template <typename OpType, typename Flavor>
+struct SpecializeMulIOpImpl : public OpConversionPattern<OpType> {
+  explicit SpecializeMulIOpImpl(MLIRContext *context)
       : OpConversionPattern<OpType>(context) {}
 
   using OpConversionPattern<OpType>::OpConversionPattern;
@@ -340,25 +548,20 @@ struct SpecializeMulIOpToAVX512Impl : public OpConversionPattern<OpType> {
         ImplicitLocOpBuilder b(op.getLoc(), rewriter);
 
         auto [lhsEven, lhsOdd] =
-            *extractEvenOdd(b, adaptor.getLhs(), true, true);
+            *Flavor::splitEvenOdd(b, adaptor.getLhs(), true, true);
         auto [rhsEven, rhsOdd] =
-            *extractEvenOdd(b, adaptor.getRhs(), true, true);
+            *Flavor::splitEvenOdd(b, adaptor.getRhs(), true, true);
 
-        Value prodEven32, prodOdd32;
-        if constexpr (std::is_same_v<OpType, arith::MulSIExtendedOp>) {
-          std::tie(prodEven32, prodOdd32) =
-              mulExtendedByOddEven(b, lhsEven, lhsOdd, rhsEven, rhsOdd, true);
-        } else {
-          std::tie(prodEven32, prodOdd32) =
-              mulExtendedByOddEven(b, lhsEven, lhsOdd, rhsEven, rhsOdd);
-        }
+        bool isSigned = std::is_same_v<OpType, arith::MulSIExtendedOp>;
+        auto [prodEven32, prodOdd32] = Flavor::emitMulExtended(
+            b, lhsEven, lhsOdd, rhsEven, rhsOdd, isSigned);
 
         if constexpr (std::is_same_v<OpType, arith::MulIOp>) {
-          Value prodLow = gatherLowsInterleaved(b, prodEven32, prodOdd32);
+          Value prodLow = Flavor::emitGatherLows(b, prodEven32, prodOdd32);
           rewriter.replaceOp(op, prodLow);
         } else {
-          Value prodLow = gatherLowsInterleaved(b, prodEven32, prodOdd32);
-          Value prodHi = gatherHighsInterleaved(b, prodEven32, prodOdd32);
+          Value prodLow = Flavor::emitGatherLows(b, prodEven32, prodOdd32);
+          Value prodHi = Flavor::emitGatherHighs(b, prodEven32, prodOdd32);
           rewriter.replaceOp(op, {prodLow, prodHi});
         }
         return success();
@@ -369,10 +572,16 @@ struct SpecializeMulIOpToAVX512Impl : public OpConversionPattern<OpType> {
 };
 
 using SpecializeMulUIExtendedToAVX512 =
-    SpecializeMulIOpToAVX512Impl<arith::MulUIExtendedOp>;
+    SpecializeMulIOpImpl<arith::MulUIExtendedOp, Avx512Flavor>;
 using SpecializeMulSIExtendedToAVX512 =
-    SpecializeMulIOpToAVX512Impl<arith::MulSIExtendedOp>;
-using SpecializeMulIOpToAVX512 = SpecializeMulIOpToAVX512Impl<arith::MulIOp>;
+    SpecializeMulIOpImpl<arith::MulSIExtendedOp, Avx512Flavor>;
+using SpecializeMulIOpToAVX512 =
+    SpecializeMulIOpImpl<arith::MulIOp, Avx512Flavor>;
+using SpecializeMulUIExtendedToAVX2 =
+    SpecializeMulIOpImpl<arith::MulUIExtendedOp, Avx2Flavor>;
+using SpecializeMulSIExtendedToAVX2 =
+    SpecializeMulIOpImpl<arith::MulSIExtendedOp, Avx2Flavor>;
+using SpecializeMulIOpToAVX2 = SpecializeMulIOpImpl<arith::MulIOp, Avx2Flavor>;
 
 namespace {
 #include "prime_ir/Dialect/ArithExt/Conversions/SpecializeArithToAVX/SpecializeArithToAVX.cpp.inc"
@@ -395,15 +604,30 @@ void SpecializeArithToAVX::runOnOperation() {
 
   RewritePatternSet patterns(context);
   populateWithGenerated(patterns);
-  patterns.add<
-      // clang-format off
-      SpecializeAddIOpToAVX512,
-      SpecializeMulIOpToAVX512,
-      SpecializeMulSIExtendedToAVX512,
-      SpecializeMulUIExtendedToAVX512,
-      SpecializeSubIOpToAVX512
-      // clang-format on
-      >(context);
+  switch (flavor) {
+  case AVXFlavor::kAVX512:
+    patterns.add<
+        // clang-format off
+        SpecializeAddIOpToAVX512,
+        SpecializeMulIOpToAVX512,
+        SpecializeMulSIExtendedToAVX512,
+        SpecializeMulUIExtendedToAVX512,
+        SpecializeSubIOpToAVX512
+        // clang-format on
+        >(context);
+    break;
+  case AVXFlavor::kAVX2:
+    patterns.add<
+        // clang-format off
+        SpecializeAddIOpToAVX2,
+        SpecializeMulIOpToAVX2,
+        SpecializeMulSIExtendedToAVX2,
+        SpecializeMulUIExtendedToAVX2,
+        SpecializeSubIOpToAVX2
+        // clang-format on
+        >(context);
+    break;
+  }
   if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
     signalPassFailure();
   }

--- a/prime_ir/Dialect/ArithExt/Conversions/SpecializeArithToAVX/SpecializeArithToAVX.h
+++ b/prime_ir/Dialect/ArithExt/Conversions/SpecializeArithToAVX/SpecializeArithToAVX.h
@@ -18,12 +18,20 @@ limitations under the License.
 
 // IWYU pragma: begin_keep
 // Headers needed for SpecializeArithToAVX.h.inc
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Pass/Pass.h"
 // IWYU pragma: end_keep
 
 namespace mlir::prime_ir::arith_ext {
+
+// Instruction-set flavor emitted by SpecializeArithToAVX. See the pass
+// description in SpecializeArithToAVX.td.
+enum class AVXFlavor {
+  kAVX512 = 0,
+  kAVX2 = 1,
+};
 
 #define GEN_PASS_DECL
 #include "prime_ir/Dialect/ArithExt/Conversions/SpecializeArithToAVX/SpecializeArithToAVX.h.inc"

--- a/prime_ir/Dialect/ArithExt/Conversions/SpecializeArithToAVX/SpecializeArithToAVX.td
+++ b/prime_ir/Dialect/ArithExt/Conversions/SpecializeArithToAVX/SpecializeArithToAVX.td
@@ -23,9 +23,33 @@ include "mlir/Pass/PassBase.td"
 def SpecializeArithToAVX : Pass<"specialize-arith-to-avx", "ModuleOp"> {
   let summary = "Specialize some `arith` ops to assembly";
   let description = [{
-    This pass specializes some `arith` ops to assembly.
+    This pass specializes some `arith` ops on `vector<16xi32>` to dual-lane
+    (even/odd) sequences. The `flavor` option selects the target ISA:
+
+    - `avx512` (default): 512-bit zmm inline asm using opmask-merged
+      `vmovsldup`/`vmovshdup` interleaves. Requires AVX-512F at runtime.
+    - `avx2`: the same dual-lane dataflow expressed as target-independent IR
+      that legalizes to 2x ymm on AVX2-only targets: extended products are
+      emitted as the masked 64-bit multiply idiom X86 selects to
+      `vpmuludq`/`vpmuldq`, and interleaves as `vector.shuffle`.
+
+    The caller is responsible for matching the flavor to the JIT/AOT target
+    features; the pass itself does not inspect the host CPU.
   }];
+  let options = [
+    Option<"flavor", "flavor", "mlir::prime_ir::arith_ext::AVXFlavor",
+           /*default=*/"mlir::prime_ir::arith_ext::AVXFlavor::kAVX512",
+           "Instruction-set flavor to specialize for",
+           [{::llvm::cl::values(
+             clEnumValN(mlir::prime_ir::arith_ext::AVXFlavor::kAVX512,
+                        "avx512",
+                        "512-bit zmm inline asm with opmask interleaves"),
+             clEnumValN(mlir::prime_ir::arith_ext::AVXFlavor::kAVX2, "avx2",
+                        "2x 256-bit ymm via pmuludq idiom and shuffles")
+           )}]>
+  ];
   let dependentDialects = [
+    "arith::ArithDialect",
     "LLVM::LLVMDialect",
     "vector::VectorDialect",
   ];

--- a/tests/Dialect/ArithExt/packed_arith_runner.mlir
+++ b/tests/Dialect/ArithExt/packed_arith_runner.mlir
@@ -20,6 +20,15 @@
 // RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
 // RUN: FileCheck %s < %t
 
+// RUN: prime-ir-opt %s -specialize-arith-to-avx=flavor=avx2 \
+// RUN:   | FileCheck %s --check-prefix=CHECK-AVX2
+
+// The AVX2 flavor must produce bit-identical results (same CHECK lines).
+// RUN: prime-ir-opt %s -specialize-arith-to-avx=flavor=avx2 -convert-to-llvm \
+// RUN:   | mlir-runner -e main -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t.avx2
+// RUN: FileCheck %s < %t.avx2
+
 
 func.func private @printMemrefI32(memref<*xi32>) attributes { llvm.emit_c_interface }
 
@@ -28,6 +37,10 @@ func.func @packed_mului_extended() {
   %b = arith.constant dense<[1,10,100,1000,10000,100000,100000,10000000,1,10,100,1000,10000,100000,100000,10000000]> : vector<16xi32>
 
   // CHECK-LOWERING-NOT: arith.mului_extended
+  // CHECK-AVX2-NOT: arith.mului_extended
+  // CHECK-AVX2: llvm.mul {{.*}} : vector<8xi64>
+  // CHECK-AVX2: vector.shuffle {{.*}} [0, 16, 2, 18, 4, 20, 6, 22, 8, 24, 10, 26, 12, 28, 14, 30] : vector<16xi32>, vector<16xi32>
+  // CHECK-AVX2: vector.shuffle {{.*}} [1, 17, 3, 19, 5, 21, 7, 23, 9, 25, 11, 27, 13, 29, 15, 31] : vector<16xi32>, vector<16xi32>
   %c:2 = arith.mului_extended %a, %b : vector<16xi32>
 
   %mem = memref.alloc() : memref<32xi32>
@@ -46,6 +59,10 @@ func.func @packed_mulsi_extended() {
   %b = arith.constant dense<[1,10,100,1000,10000,100000,100000,10000000,1,10,100,1000,10000,100000,100000,10000000]> : vector<16xi32>
 
   // CHECK-LOWERING-NOT: arith.mulsi_extended
+  // CHECK-AVX2-NOT: arith.mulsi_extended
+  // CHECK-AVX2: llvm.shl {{.*}} : vector<8xi64>
+  // CHECK-AVX2: llvm.ashr {{.*}} : vector<8xi64>
+  // CHECK-AVX2: llvm.mul {{.*}} : vector<8xi64>
   %c:2 = arith.mulsi_extended %a, %b : vector<16xi32>
 
   %mem = memref.alloc() : memref<32xi32>
@@ -65,6 +82,8 @@ func.func @packed_muli() {
   %b = arith.constant dense<[2, 3, 4, 5, 6, 2, 3, 4, 5, 6, 2, 3, 4, 5, 6, 2]> : vector<16xi32>
 
   // CHECK-LOWERING-NOT: arith.muli
+  // CHECK-AVX2-NOT: arith.muli {{.*}} : vector<16xi32>
+  // CHECK-AVX2: llvm.mul {{.*}} : vector<8xi64>
   %c = arith.muli %a, %b : vector<16xi32>
 
   %mem = memref.alloc() : memref<16xi32>
@@ -88,6 +107,8 @@ func.func @packed_addi() {
 
   // Chain addi operations on the low results (gather low path)
   // CHECK-LOWERING-NOT: arith.addi
+  // CHECK-AVX2-NOT: arith.addi
+  // CHECK-AVX2: llvm.add {{.*}} : vector<16xi32>
   %low = arith.addi %mul#0, %mul1#0 : vector<16xi32>
   %high = arith.addi %mul#1, %mul1#1 : vector<16xi32>
 
@@ -116,7 +137,9 @@ func.func @packed_subi() {
   %mul:2 = arith.mului_extended %a, %b : vector<16xi32>
   %mul1:2 = arith.mului_extended %mul#0, %mul#1 : vector<16xi32>
 
-  // CHECK-LOWERING-NOT: arith.addi
+  // CHECK-LOWERING-NOT: arith.subi
+  // CHECK-AVX2-NOT: arith.subi
+  // CHECK-AVX2: llvm.sub {{.*}} : vector<16xi32>
   %low = arith.subi %mul#0, %mul1#0 : vector<16xi32>
   %high = arith.subi %mul#1, %mul1#1 : vector<16xi32>
 


### PR DESCRIPTION
## Description

The dual-lane specialization is unusable on AVX2-only prover fleets today: its zmm inline asm and `^Yk` opmask constraints require AVX-512F, so since fractalyze/xla#412 the XLA pipeline simply skips the pass on such targets and eats LLVM's generic legalization. This adds the `flavor=avx2` pass option sketched in the issue so those targets get the specialization back. The flavor is a pass option (not runtime dispatch) because the caller (XLA's fusion compiler) already knows the JIT target features; the default remains `avx512`, so nothing changes for existing consumers (riscv-witness et al.) until they opt in.

**Why the AVX2 flavor emits no inline asm.** The AVX-512 asm exists for two reasons that both disappear on AVX2: `vpmuludq` was unrepresentable in arith (solved instead by emitting the masked 64-bit-multiply idiom that X86's `combineMulToPMULDQ` selects to `vpmuludq`/`vpmuldq` — the `llvm.x86.*.pmul[u].dq` intrinsics were removed in LLVM 7 in favor of exactly this form, which is also what clang emits for `_mm256_mul_epu32`), and the opmask-merged `vmovs[lh]dup` single-instruction interleave has no AVX2 equivalent (so interleaves become `vector.shuffle`, which LLVM lowers to a 2-instruction ymm sequence anyway). Transparent IR additionally lets LLVM schedule and CSE across chained rounds, which inline asm blocks. Correctness does not depend on the `vpmuludq` pattern-match firing; only performance does, and that is verified from disassembly (below).

One non-obvious implementation constraint: the helpers emit LLVM-dialect arithmetic (`llvm.mul`/`llvm.and`/…) rather than arith, because ops created by a conversion pattern must be legal for the `ConversionTarget` or the whole rewrite silently rolls back — and `arith.addi` on `vector<16xi32>` could not be marked legal without disabling the chain pattern that matches that exact form.

## Benchmark (acceptance: land only if it beats generic legalization)

`benchmarks/ArithExt/run_bench.sh`, BabyBear packed-Montgomery REDC round on `vector<16xi32>` (the `mului_extended`/`muli`/`subi`/`addi` mix with low/high gather chaining), ns/round, min of 7 runs:

| config | chain (latency) | sweep 16 KiB | sweep 1 MiB |
|---|---|---|---|
| generic legalization, AVX2-capped | 5.67 | 3.40 | 3.43 |
| **flavor=avx2, AVX2-capped** | **3.04 (-46%)** | **1.86 (-45%)** | **1.87 (-46%)** |
| flavor=avx512, native (reference) | 3.22 | 1.01 | 1.01 |

Environment: AMD Ryzen 9 9950X3D (AVX2+AVX-512 host), core-pinned, performance governor, `mlir-runner -O3 --mattr=-avx512f` for the capped rows. The harness verifies the AVX2 path is genuinely exercised — it dumps the JIT object and asserts no `zmm`/opmask usage plus the presence of ymm `vpmuludq` — and asserts xor/add lane reductions match bit-exactly across all three configs. (The AVX-512 reference row is native-ISA and included for context only; the acceptance comparison is between the two capped rows.)

## Verification

- `tests/Dialect/ArithExt/packed_arith_runner.mlir` now also runs the `flavor=avx2` lowering + execution against the same hardcoded expected outputs as the AVX-512 path (integer ops, so bit-exactness is the only correct answer). Passes under `bazel test --//:has_avx512`.
- `//tests/... //prime_ir/...`: 123/124 pass; the one failure is `//tests/Dialect/EllipticCurve:pairing_check_4pairs_runner` hitting its 900s timeout, pre-existing and unreachable by this change (the `field-to-llvm` `specialize-avx` option defaults to off) — flagged on #405.

## Related Issues/PRs

Part of #416 (PR1 of its plan; PR2 — XLA-side flavor plumbing — is tracked there and lives in fractalyze/xla).

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline