### PR TITLE
fix(dialect/field): keep canonical constants >= 2^63 unsigned

### DIFF
--- a/prime_ir/Dialect/Field/IR/FieldTypes.cpp
+++ b/prime_ir/Dialect/Field/IR/FieldTypes.cpp
@@ -131,8 +131,40 @@ Attribute maybeToMontgomery(Type type, Attribute attr) {
 
 Value createFieldConstant(Type fieldType, ImplicitLocOpBuilder &builder,
                           uint64_t value) {
-  auto constantLike = cast<ConstantLikeInterface>(fieldType);
-  TypedAttr attr = constantLike.createConstantAttr(static_cast<int64_t>(value));
+  // `value` is a CANONICAL field element, so every bit of it is significant. It
+  // must NOT be routed through `createConstantAttr(int64_t)`: that path takes
+  // the magnitude and then field-negates (right for a caller passing a genuine
+  // negative, wrong here), so any `value >= 2^63` reads as negative and
+  // materializes `p - (2^64 - value)`. For Goldilocks that is
+  // `value - (2^32 - 1)` — silently wrong, with no verifier or assert to catch
+  // it, over roughly half the field range.
+  //
+  // Build from an APInt instead. This dispatches on the concrete type rather
+  // than going through ConstantLikeInterface because
+  // `createConstantAttrFromValues` is one-value-per-coefficient: an extension
+  // field expects `getDegreeOverPrime()` entries, so a scalar has to be
+  // embedded as [value, 0, ..., 0].
+  TypedAttr attr;
+  if (auto pfType = dyn_cast<PrimeFieldType>(fieldType)) {
+    attr = pfType.createConstantAttrFromValues(
+        {APInt(pfType.getTypeSizeInBits(), value)});
+  } else if (auto bfType = dyn_cast<BinaryFieldType>(fieldType)) {
+    attr = bfType.createConstantAttrFromValues(
+        {APInt(bfType.getBitWidth(), value)});
+  } else if (auto efType = dyn_cast<ExtensionFieldType>(fieldType)) {
+    PrimeFieldType pfType = efType.getBasePrimeField();
+    unsigned bitWidth = pfType.getTypeSizeInBits();
+    PrimeFieldOperation pfOp(APInt(bitWidth, value),
+                             pfType); // Handles Montgomery conversion
+    SmallVector<APInt> coeffs(efType.getDegreeOverPrime(),
+                              APInt::getZero(bitWidth));
+    coeffs[0] = static_cast<APInt>(pfOp);
+    attr = efType.createConstantAttrFromValues(coeffs);
+  } else {
+    // Any other ConstantLike type keeps the previous behavior.
+    attr = cast<ConstantLikeInterface>(fieldType).createConstantAttr(
+        static_cast<int64_t>(value));
+  }
   return ConstantOp::create(builder, fieldType, attr)->getResult(0);
 }
 

--- a/tests/Dialect/Field/BUILD.bazel
+++ b/tests/Dialect/Field/BUILD.bazel
@@ -106,3 +106,16 @@ prime_ir_cc_test(
         "@llvm-project//mlir:IR",
     ],
 )
+
+prime_ir_cc_test(
+    name = "CreateFieldConstantTest",
+    srcs = ["CreateFieldConstantTest.cpp"],
+    deps = [
+        "//prime_ir/Dialect/EllipticCurve/IR:EllipticCurve",
+        "//prime_ir/Dialect/Field/IR:Field",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+    ],
+)

--- a/tests/Dialect/Field/CreateFieldConstantTest.cpp
+++ b/tests/Dialect/Field/CreateFieldConstantTest.cpp
@@ -1,0 +1,144 @@
+/* Copyright 2026 The PrimeIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// `createFieldConstant(Type, ImplicitLocOpBuilder &, uint64_t)` takes a
+// CANONICAL field element, so every bit of the argument is significant.
+//
+// It used to forward through `createConstantAttr(int64_t)`, whose
+// magnitude-then-negate path reads any value with bit 63 set as negative and
+// materializes `p - (2^64 - v)` — for Goldilocks, `v - (2^32 - 1)`. Nothing
+// caught it: the internal `assert(value.ult(modulus))` is satisfied by the
+// magnitude, and small-modulus fields (BabyBear, KoalaBear, Mersenne31) can
+// never set bit 63, so no pre-existing test could observe it.
+//
+// These cases pin the top half of a 64-bit field's value range for each field
+// flavor the helper dispatches over.
+
+#include "gtest/gtest.h"
+#include "llvm/ADT/APInt.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "prime_ir/Dialect/Field/IR/FieldDialect.h"
+#include "prime_ir/Dialect/Field/IR/FieldOps.h"
+#include "prime_ir/Dialect/Field/IR/FieldTypes.h"
+
+namespace mlir::prime_ir::field {
+namespace {
+
+// Goldilocks: p = 2^64 - 2^32 + 1. Roughly half its canonical range has bit 63
+// set, which is what makes it the first field to expose this.
+constexpr uint64_t kGoldilocksModulus = UINT64_C(18446744069414584321);
+
+// Canonical Goldilocks values: four with bit 63 set (including both boundary
+// cases p-1 and exactly 2^63), and two small ones that must be unaffected.
+constexpr uint64_t kValues[] = {
+    kGoldilocksModulus - 1,       // 0xFFFFFFFF00000000
+    UINT64_C(0x8000000000000000), // exactly 2^63, the first bad value
+    UINT64_C(0x9E3779B97F4A7C15),
+    UINT64_C(0xABCDEF0123456789),
+    UINT64_C(7),
+    UINT64_C(11),
+};
+
+class CreateFieldConstantTest : public testing::Test {
+protected:
+  void SetUp() override {
+    context.loadDialect<FieldDialect>();
+    module = ModuleOp::create(UnknownLoc::get(&context));
+  }
+
+  // A builder anchored in the module body, so created ops have somewhere to go.
+  ImplicitLocOpBuilder createBodyBuilder() {
+    ImplicitLocOpBuilder b(UnknownLoc::get(&context), &context);
+    b.setInsertionPointToStart(module->getBody());
+    return b;
+  }
+
+  IntegerAttr getGoldilocksModulusAttr() {
+    return IntegerAttr::get(IntegerType::get(&context, 64),
+                            APInt(64, kGoldilocksModulus));
+  }
+
+  MLIRContext context;
+  OwningOpRef<ModuleOp> module;
+};
+
+// Standard (non-Montgomery) form: the stored attribute IS the canonical value,
+// so this asserts the exact bit pattern survives.
+TEST_F(CreateFieldConstantTest, PrimeFieldStandardFormKeepsWideValues) {
+  auto pfType = PrimeFieldType::get(&context, getGoldilocksModulusAttr(),
+                                    /*isMontgomery=*/false);
+  ImplicitLocOpBuilder b = createBodyBuilder();
+
+  for (uint64_t v : kValues) {
+    Value c = createFieldConstant(pfType, b, v);
+    auto constOp = c.getDefiningOp<ConstantOp>();
+    ASSERT_TRUE(constOp) << "value " << v;
+    auto attr = dyn_cast<IntegerAttr>(constOp.getValue());
+    ASSERT_TRUE(attr) << "value " << v;
+    EXPECT_EQ(attr.getValue().getZExtValue(), v)
+        << "wrong constant for " << v << " (delta "
+        << (v - attr.getValue().getZExtValue()) << ")";
+  }
+}
+
+// Montgomery form: the stored attribute is v·R, so compare after converting
+// back to standard form rather than against the raw value.
+TEST_F(CreateFieldConstantTest, PrimeFieldMontgomeryFormKeepsWideValues) {
+  auto pfType = PrimeFieldType::get(&context, getGoldilocksModulusAttr(),
+                                    /*isMontgomery=*/true);
+  ImplicitLocOpBuilder b = createBodyBuilder();
+
+  for (uint64_t v : kValues) {
+    Value c = createFieldConstant(pfType, b, v);
+    auto constOp = c.getDefiningOp<ConstantOp>();
+    ASSERT_TRUE(constOp) << "value " << v;
+    auto standard =
+        dyn_cast<IntegerAttr>(maybeToStandard(pfType, constOp.getValue()));
+    ASSERT_TRUE(standard) << "value " << v;
+    EXPECT_EQ(standard.getValue().getZExtValue(), v)
+        << "wrong constant for " << v;
+  }
+}
+
+// Extension field: the scalar must land in coefficient 0 with the rest zero,
+// and must not be mangled on the way in.
+TEST_F(CreateFieldConstantTest, ExtensionFieldEmbedsWideScalarInCoeffZero) {
+  auto pfType = PrimeFieldType::get(&context, getGoldilocksModulusAttr(),
+                                    /*isMontgomery=*/false);
+  auto nonResidue = IntegerAttr::get(IntegerType::get(&context, 64), 7);
+  auto efType =
+      ExtensionFieldType::get(&context, /*degree=*/3, pfType, nonResidue);
+  ImplicitLocOpBuilder b = createBodyBuilder();
+
+  for (uint64_t v : kValues) {
+    Value c = createFieldConstant(efType, b, v);
+    auto constOp = c.getDefiningOp<ConstantOp>();
+    ASSERT_TRUE(constOp) << "value " << v;
+    auto dense = dyn_cast<DenseIntElementsAttr>(constOp.getValue());
+    ASSERT_TRUE(dense) << "value " << v;
+
+    SmallVector<APInt> coeffs(dense.value_begin<APInt>(),
+                              dense.value_end<APInt>());
+    ASSERT_EQ(coeffs.size(), efType.getDegreeOverPrime());
+    EXPECT_EQ(coeffs[0].getZExtValue(), v) << "wrong coeff 0 for " << v;
+    for (size_t i = 1; i < coeffs.size(); ++i) {
+      EXPECT_TRUE(coeffs[i].isZero()) << "coeff " << i << " nonzero for " << v;
+    }
+  }
+}
+
+} // namespace
+} // namespace mlir::prime_ir::field


### PR DESCRIPTION
`createFieldConstant(Type, ImplicitLocOpBuilder &, uint64_t)` accepts a
`uint64_t` but cannot represent half of its own domain: it forwards through
`createConstantAttr(int64_t)`, whose magnitude-then-negate path reads any
canonical value with bit 63 set as negative and emits `p - (2^64 - v)`. For
Goldilocks that is exactly `v - (2^32 - 1)`.

Silent — the internal `assert(value.ult(modulus))` is satisfied by the
magnitude, and asserts are off in opt builds.

Found downstream in fractalyze/xla: a fused Goldilocks Poseidon1 emitter had
every commit root mismatch deterministically. 387 of 1194 matrix constants in
a W16 config have bit 63 set. Full analysis and the bit-exact device
reproduction are in #419.

## Approach

Build the attribute from an `APInt`. Not a single generic interface call:
`createConstantAttrFromValues` is one-value-per-coefficient, so an
`ExtensionFieldType` expects `getDegreeOverPrime()` entries and a scalar has to
be embedded as `[v, 0, ..., 0]`. `ConstantLikeInterface` is upstream MLIR's, so
adding an unsigned entry point there is out of scope; this dispatches on the
concrete field type instead.

`BinaryFieldType::createConstantAttr(int64_t)` is already bit-preserving, so
only the prime and extension paths change behavior.

`createConstantAttr(int64_t)` is deliberately left as-is — callers legitimately
pass small negatives and rely on the field-negation semantics. The bug is only
that an explicitly unsigned API routed through it.

## Testing

New `CreateFieldConstantTest` covers all three dispatch paths — prime standard
form (exact bit pattern), prime Montgomery (round-trip via `maybeToStandard`),
and extension (scalar in coefficient 0, rest zero) — over four wide values
including both boundaries (`p-1` and exactly `2^63`) plus small controls.

Verified to FAIL on the parent commit and PASS with the fix. Full
`//tests/Dialect/Field/... //tests/Dialect/ModArith/...` suite green (93/93).

Small-modulus fields (BabyBear, KoalaBear, Mersenne31) cannot set bit 63, which
is why no pre-existing test could observe this.

Fixes #419
