### PR TITLE
feat(dialect/poly): negacyclic NTT over Z_q[X]/(X^n + 1)

### DIFF
--- a/prime_ir/Dialect/Poly/Conversions/PolyToField/PolyToField.cpp
+++ b/prime_ir/Dialect/Poly/Conversions/PolyToField/PolyToField.cpp
@@ -134,6 +134,31 @@ struct ConvertFromTensor : public OpConversionPattern<FromTensorOp> {
   }
 };
 
+// A constant tensor of `count` consecutive powers of `root`, in the field's own
+// storage encoding.
+//
+// `PrimitiveRootAttr` holds the same loop but sizes its table by the root's
+// degree, and the negacyclic twist wants `psi^0 .. psi^(n-1)` from a root of
+// degree `2n` — so going through the attribute would materialize `2n` constants
+// to use half of them.
+static Value buildPowerTable(ImplicitLocOpBuilder &b, IntegerAttr rootAttr,
+                             field::PrimeFieldType coeffType, unsigned count) {
+  auto root = field::PrimeFieldOperation::fromUnchecked(rootAttr, coeffType);
+  SmallVector<APInt> powers;
+  powers.reserve(count);
+  field::PrimeFieldOperation cur = root.getOne();
+  for (unsigned i = 0; i < count; ++i) {
+    powers.push_back(cur);
+    cur *= root;
+  }
+  auto storageTensorType =
+      RankedTensorType::get({count}, coeffType.getStorageType());
+  auto fieldTensorType = RankedTensorType::get({count}, coeffType);
+  Value table = arith::ConstantOp::create(
+      b, storageTensorType, DenseElementsAttr::get(storageTensorType, powers));
+  return field::BitcastOp::create(b, fieldTensorType, table);
+}
+
 // Butterfly : Cooley-Tukey
 static std::pair<Value, Value> bflyCT(ImplicitLocOpBuilder &b, Value A, Value B,
                                       Value root) {
@@ -153,7 +178,8 @@ static std::pair<Value, Value> bflyGS(ImplicitLocOpBuilder &b, Value A, Value B,
 }
 
 static Value fastNTT(ImplicitLocOpBuilder &b, NTTOpAdaptor adaptor,
-                     Value source, Value dest) {
+                     field::RootOfUnityAttr coreRoot, Value source,
+                     Value dest) {
   auto tensorType = cast<RankedTensorType>(adaptor.getDest().getType());
   auto coeffType = cast<field::PrimeFieldType>(tensorType.getElementType());
 
@@ -181,11 +207,8 @@ static Value fastNTT(ImplicitLocOpBuilder &b, NTTOpAdaptor adaptor,
   if (adaptor.getTwiddles()) {
     roots = adaptor.getTwiddles();
   } else {
-    assert(adaptor.getRoot() &&
-           "Root of unity is required if no twiddles are provided");
-    field::RootOfUnityAttr rootAttr = adaptor.getRoot().value();
-    APInt cmod = coeffType.getModulus().getValue();
-    APInt root = rootAttr.getRoot().getValue();
+    assert(coreRoot && "Root of unity is required if no twiddles are provided");
+    field::RootOfUnityAttr rootAttr = coreRoot;
 
     mod_arith::MontgomeryAttr montAttr;
     if (coeffType.isMontgomery()) {
@@ -456,21 +479,49 @@ struct ConvertNTT : public OpConversionPattern<NTTOp> {
                   ConversionPatternRewriter &rewriter) const override {
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
 
+    Value source = adaptor.getSource();
+    auto tensorType = cast<RankedTensorType>(adaptor.getDest().getType());
+    auto coeffType = cast<field::PrimeFieldType>(tensorType.getElementType());
+    unsigned degree = tensorType.getShape()[0];
+    const bool negacyclic = adaptor.getNegacyclic();
+
+    // Negacyclic states its root as the 2n-th root `psi`; the staged
+    // butterflies are the cyclic transform, which runs on `omega = psi^2` of
+    // degree n. The verifier rejects negacyclic without a root, so the value is
+    // there.
+    field::RootOfUnityAttr coreRoot = adaptor.getRoot().value_or(nullptr);
+    if (negacyclic) {
+      auto psi = field::PrimeFieldOperation::fromUnchecked(coreRoot.getRoot(),
+                                                           coeffType);
+      coreRoot = field::RootOfUnityAttr::get(
+          b.getContext(), coeffType, psi.square().getIntegerAttr(),
+          b.getIntegerAttr(coreRoot.getDegree().getType(), degree));
+
+      // `psi^j` on the *natural* coefficient index, so the forward twist goes
+      // on before the bit-reversal permutation reorders anything and the
+      // inverse one after the output is back in natural order.
+      if (!adaptor.getInverse()) {
+        Value psiPowers =
+            buildPowerTable(b, psi.getIntegerAttr(), coeffType, degree);
+        source = field::MulOp::create(b, source, psiPowers);
+      }
+    }
+
     Value nttResult;
 
     // Transform the input tensor to bit-reversed order at first if performing
     // forward NTT.
     if (!adaptor.getInverse() && adaptor.getBitReverse()) {
       auto bitReversed = tensor_ext::BitReverseOp::create(
-          b, adaptor.getSource(), adaptor.getDest(), /*dimension=*/0);
+          b, source, adaptor.getDest(), /*dimension=*/0);
 
       // NOTE(batzor): We should not use `dest` operand for the destination
       // here. Otherwise, writable `ToBufferOp` will be called twice on the same
       // `dest` SSA Value causing conflict and force memory copy.
-      nttResult =
-          fastNTT(b, adaptor, bitReversed.getResult(), bitReversed.getResult());
+      nttResult = fastNTT(b, adaptor, coreRoot, bitReversed.getResult(),
+                          bitReversed.getResult());
     } else {
-      nttResult = fastNTT(b, adaptor, adaptor.getSource(), adaptor.getDest());
+      nttResult = fastNTT(b, adaptor, coreRoot, source, adaptor.getDest());
     }
 
     // Transform the input tensor to bit-reversed order at last if performing
@@ -478,11 +529,18 @@ struct ConvertNTT : public OpConversionPattern<NTTOp> {
     if (adaptor.getInverse() && adaptor.getBitReverse()) {
       auto nttResultBitReversed = tensor_ext::BitReverseOp::create(
           b, nttResult, nttResult, /*dimension=*/0);
-
-      rewriter.replaceOp(op, nttResultBitReversed);
-    } else {
-      rewriter.replaceOp(op, nttResult);
+      nttResult = nttResultBitReversed.getResult();
     }
+
+    if (negacyclic && adaptor.getInverse()) {
+      auto psi = field::PrimeFieldOperation::fromUnchecked(
+          adaptor.getRoot()->getRoot(), coeffType);
+      Value psiInvPowers =
+          buildPowerTable(b, psi.inverse().getIntegerAttr(), coeffType, degree);
+      nttResult = field::MulOp::create(b, nttResult, psiInvPowers);
+    }
+
+    rewriter.replaceOp(op, nttResult);
 
     return success();
   }

--- a/prime_ir/Dialect/Poly/Conversions/PolyToField/PolyToField.cpp
+++ b/prime_ir/Dialect/Poly/Conversions/PolyToField/PolyToField.cpp
@@ -134,23 +134,36 @@ struct ConvertFromTensor : public OpConversionPattern<FromTensorOp> {
   }
 };
 
-// A constant tensor of `count` consecutive powers of `root`, in the field's own
+// The first `count` powers of `root`, as a constant tensor in the field's own
 // storage encoding.
 //
-// `PrimitiveRootAttr` holds the same loop but sizes its table by the root's
+// The powers come from `PrimitiveRootAttr`, which is uniqued on the
+// MLIRContext, so the modular exponentiation runs once per distinct root for
+// the whole module rather than once per op — the cyclic path gets that for free
+// and computing the table locally would not. Its table is sized by the root's
 // degree, and the negacyclic twist wants `psi^0 .. psi^(n-1)` from a root of
-// degree `2n` — so going through the attribute would materialize `2n` constants
-// to use half of them.
-static Value buildPowerTable(ImplicitLocOpBuilder &b, IntegerAttr rootAttr,
-                             field::PrimeFieldType coeffType, unsigned count) {
-  auto root = field::PrimeFieldOperation::fromUnchecked(rootAttr, coeffType);
+// degree `2n`, hence the prefix.
+static Value buildPowerTable(ImplicitLocOpBuilder &b,
+                             field::RootOfUnityAttr rootAttr,
+                             field::PrimeFieldType coeffType, unsigned count,
+                             bool inverse) {
+  mod_arith::MontgomeryAttr montAttr;
+  if (coeffType.isMontgomery())
+    montAttr =
+        mod_arith::MontgomeryAttr::get(b.getContext(), coeffType.getModulus());
+  auto primitiveRoots =
+      PrimitiveRootAttr::get(b.getContext(), rootAttr, montAttr);
+  DenseElementsAttr full =
+      inverse ? primitiveRoots.getInvRoots() : primitiveRoots.getRoots();
+
   SmallVector<APInt> powers;
   powers.reserve(count);
-  field::PrimeFieldOperation cur = root.getOne();
-  for (unsigned i = 0; i < count; ++i) {
-    powers.push_back(cur);
-    cur *= root;
+  for (const APInt &value : full.getValues<APInt>()) {
+    if (powers.size() == count)
+      break;
+    powers.push_back(value);
   }
+
   auto storageTensorType =
       RankedTensorType::get({count}, coeffType.getStorageType());
   auto fieldTensorType = RankedTensorType::get({count}, coeffType);
@@ -501,8 +514,8 @@ struct ConvertNTT : public OpConversionPattern<NTTOp> {
       // on before the bit-reversal permutation reorders anything and the
       // inverse one after the output is back in natural order.
       if (!adaptor.getInverse()) {
-        Value psiPowers =
-            buildPowerTable(b, psi.getIntegerAttr(), coeffType, degree);
+        Value psiPowers = buildPowerTable(b, *adaptor.getRoot(), coeffType,
+                                          degree, /*inverse=*/false);
         source = field::MulOp::create(b, source, psiPowers);
       }
     }
@@ -533,10 +546,8 @@ struct ConvertNTT : public OpConversionPattern<NTTOp> {
     }
 
     if (negacyclic && adaptor.getInverse()) {
-      auto psi = field::PrimeFieldOperation::fromUnchecked(
-          adaptor.getRoot()->getRoot(), coeffType);
-      Value psiInvPowers =
-          buildPowerTable(b, psi.inverse().getIntegerAttr(), coeffType, degree);
+      Value psiInvPowers = buildPowerTable(b, *adaptor.getRoot(), coeffType,
+                                           degree, /*inverse=*/true);
       nttResult = field::MulOp::create(b, nttResult, psiInvPowers);
     }
 

--- a/prime_ir/Dialect/Poly/IR/PolyCanonicalization.td
+++ b/prime_ir/Dialect/Poly/IR/PolyCanonicalization.td
@@ -24,10 +24,14 @@ def Equal : Constraint<CPred<"$0 == $1">>;
 def BoolNotEqual : Constraint<CPred<"$0.getValue() != $1.getValue()">, "not equal">;
 def BoolEqual : Constraint<CPred<"$0.getValue() == $1.getValue()">, "equal">;
 
+// `negacyclic` must match on both sides. A cyclic transform undone by a
+// negacyclic one is not the identity — they are transforms over different rings
+// — and folding the pair away would be silently wrong rather than merely
+// suboptimal.
 def INTTAfterNTT : Pat<
-  (Poly_NTTOp (Poly_NTTOp $tensor, $dest1, $twiddles1, $r1, $tileCap1, $gridSize1, $bitReverse1, $inverse1), $dest2, $twiddles2, $r2, $tileCap2, $gridSize2, $bitReverse2, $inverse2),
+  (Poly_NTTOp (Poly_NTTOp $tensor, $dest1, $twiddles1, $r1, $tileCap1, $gridSize1, $bitReverse1, $inverse1, $negacyclic1), $dest2, $twiddles2, $r2, $tileCap2, $gridSize2, $bitReverse2, $inverse2, $negacyclic2),
   (replaceWithValue $tensor),
-  [(Equal $twiddles1, $twiddles2), (Equal $r1, $r2), (BoolNotEqual $inverse1, $inverse2), (BoolEqual $bitReverse1, $bitReverse2)]
+  [(Equal $twiddles1, $twiddles2), (Equal $r1, $r2), (BoolNotEqual $inverse1, $inverse2), (BoolEqual $bitReverse1, $bitReverse2), (BoolEqual $negacyclic1, $negacyclic2)]
 >;
 
 def FromToTensor : Pat<

--- a/prime_ir/Dialect/Poly/IR/PolyOps.cpp
+++ b/prime_ir/Dialect/Poly/IR/PolyOps.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "prime_ir/Dialect/Poly/IR/PolyOps.h"
 
+#include "llvm/ADT/bit.h"
 #include "mlir/include/mlir/IR/PatternMatch.h"
 #include "prime_ir/Dialect/Field/IR/FieldOperation.h"
 
@@ -63,10 +64,19 @@ LogicalResult NTTOp::verify() {
   if (!rootOfUnity)
     return emitOpError("negacyclic requires `root`");
 
+  // The lowering reads the length off dimension zero and the staged butterflies
+  // assume it is a power of two — an `assert` there, so an unchecked shape is a
+  // crash rather than a diagnostic. Note `psi^n == -1` below does not imply it:
+  // a root of order 4 satisfies it at n = 6 as well as at n = 2.
   auto tensorType = cast<RankedTensorType>(getOutput().getType());
+  if (tensorType.getRank() != 1)
+    return emitOpError("negacyclic requires a rank-1 tensor");
   if (tensorType.isDynamicDim(0))
     return emitOpError("negacyclic requires a static length");
   int64_t degree = tensorType.getShape()[0];
+  if (degree <= 0 || !llvm::has_single_bit(static_cast<uint64_t>(degree)))
+    return emitOpError("negacyclic requires a power-of-two length, got ")
+           << degree;
 
   // `psi^n == -1` rather than a check on the *stated* degree. `RootOfUnityAttr`
   // verifies only `root^degree == 1`, which is divisibility and not order, so

--- a/prime_ir/Dialect/Poly/IR/PolyOps.cpp
+++ b/prime_ir/Dialect/Poly/IR/PolyOps.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 #include "prime_ir/Dialect/Poly/IR/PolyOps.h"
 
 #include "mlir/include/mlir/IR/PatternMatch.h"
+#include "prime_ir/Dialect/Field/IR/FieldOperation.h"
 
 namespace mlir::prime_ir::poly {
 
@@ -36,6 +37,55 @@ void ToTensorOp::getCanonicalizationPatterns(RewritePatternSet &results,
 void NTTOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                         MLIRContext *context) {
   results.add<INTTAfterNTT>(context);
+}
+
+LogicalResult NTTOp::verify() {
+  if (!getNegacyclic())
+    return success();
+
+  // The twist is `psi^j` on the *natural* coefficient index. Without the
+  // bit-reversal the caller owns the ordering, so slot `j` need not hold
+  // coefficient `j` and the factor would land on the wrong one. The round
+  // trip still closes but the pointwise product stops being a negacyclic
+  // convolution, which is the whole reason for the transform.
+  if (!getBitReverse())
+    return emitOpError("negacyclic requires `bit_reverse`");
+
+  // Supplied twiddles cannot carry the twist: the butterfly indexes them as
+  // `roots[indexJ * rootExp]`, with no block index, so one table entry is
+  // shared across every block of a stage — a per-coefficient diagonal is not
+  // expressible. Accepting the pair would silently lower to a cyclic
+  // transform.
+  if (getTwiddles())
+    return emitOpError("negacyclic is not supported with `twiddles`");
+
+  auto rootOfUnity = getRoot();
+  if (!rootOfUnity)
+    return emitOpError("negacyclic requires `root`");
+
+  auto tensorType = cast<RankedTensorType>(getOutput().getType());
+  if (tensorType.isDynamicDim(0))
+    return emitOpError("negacyclic requires a static length");
+  int64_t degree = tensorType.getShape()[0];
+
+  // `psi^n == -1` rather than a check on the *stated* degree. `RootOfUnityAttr`
+  // verifies only `root^degree == 1`, which is divisibility and not order, so
+  // an n-th root relabelled as a 2n-th one passes it, and would then drive
+  // the core with `psi^2` of half the needed order, silently computing a
+  // transform over the wrong ring. This is the defining property instead of a
+  // proxy for it, and it is also what fails when `q - 1` lacks the 2-adicity
+  // for a 2n-th root at all.
+  auto coeffType = cast<field::PrimeFieldType>(tensorType.getElementType());
+  auto psi = field::PrimeFieldOperation::fromUnchecked(rootOfUnity->getRoot(),
+                                                       coeffType);
+  unsigned bits = coeffType.getModulus().getValue().getBitWidth();
+  if (!(psi.power(APInt(bits, degree)) + psi.getOne()).isZero())
+    return emitOpError("negacyclic over ")
+           << degree << " coefficients needs `root^" << degree
+           << " == -1`, i.e. a primitive root of unity of degree "
+           << 2 * degree;
+
+  return success();
 }
 
 } // namespace mlir::prime_ir::poly

--- a/prime_ir/Dialect/Poly/IR/PolyOps.td
+++ b/prime_ir/Dialect/Poly/IR/PolyOps.td
@@ -91,6 +91,28 @@ def Poly_NTTOp : Poly_Op<"ntt", [DestinationStyleOpInterface, SameOperandsAndRes
     %coeffs = poly.to_tensor %poly : !poly_ty -> tensor<4x!pf>
     %evals = poly.ntt %coeffs {root=#root}: tensor<4x!pf>
     ```
+
+    With `negacyclic`, the transform is over `Z_q[X]/(X^n + 1)` instead — the ring
+    lattice cryptography multiplies in, where the wrap-around comes back negated.
+    `root` then carries a primitive `2n`-th root `psi` rather than an `n`-th root,
+    and the cyclic core runs on `omega = psi^2`. Taking `psi` rather than deriving
+    it is deliberate: a square root of `omega` is not unique, so `omega` alone does
+    not determine the transform.
+
+    It reduces to the cyclic transform with a twist on each side — forward
+    pre-twists `a[j]` by `psi^j` on the natural index, inverse post-untwists by
+    `psi^-j` — so the staged butterflies are shared, and `bit_reverse` is
+    required because that is what puts slot `j` on coefficient `j`.
+
+    `twiddles` cannot carry the twist and is rejected with `negacyclic`: the
+    butterflies index one table by the position within a block, so a
+    per-coefficient diagonal has nowhere to live.
+
+    A length-`n` negacyclic transform exists only where the field has a primitive
+    `2n`-th root, which the 2-adicity of `q - 1` decides. That is why FIPS 203's
+    ML-KEM (`q = 3329`, 2-adicity 8) has no length-256 negacyclic transform and
+    uses two length-128 ones, while FIPS 204's ML-DSA (`q = 8380417`, 2-adicity 13)
+    has one.
   }];
   let arguments = (ins
     RankedTensorOf<[Field_PrimeFieldType]>:$source,
@@ -100,11 +122,13 @@ def Poly_NTTOp : Poly_Op<"ntt", [DestinationStyleOpInterface, SameOperandsAndRes
     OptionalAttr<Builtin_IntegerAttr>:$tileX,
     OptionalAttr<Builtin_IntegerAttr>:$gridSize,
     DefaultValuedAttr<BoolAttr, "true">:$bitReverse,
-    DefaultValuedAttr<BoolAttr, "false">:$inverse
+    DefaultValuedAttr<BoolAttr, "false">:$inverse,
+    DefaultValuedAttr<BoolAttr, "false">:$negacyclic
   );
   let results = (outs RankedTensorOf<[Field_PrimeFieldType]>:$output);
-  let assemblyFormat = "$source `into` $dest (`with` $twiddles^)? attr-dict (`inverse` `=` $inverse^)? (`bit_reverse` `=` $bitReverse^)? `:` type($output)";
+  let assemblyFormat = "$source `into` $dest (`with` $twiddles^)? attr-dict (`inverse` `=` $inverse^)? (`bit_reverse` `=` $bitReverse^)? (`negacyclic` `=` $negacyclic^)? `:` type($output)";
   let hasCanonicalizer = 1;
+  let hasVerifier = 1;
   let extraClassDeclaration = [{
     MutableOperandRange getDpsInitsMutable() { return getDestMutable(); }
   }];

--- a/tests/Dialect/Poly/canonicalize.mlir
+++ b/tests/Dialect/Poly/canonicalize.mlir
@@ -17,6 +17,7 @@
 
 !coeff_ty = !field.pf<7681:i32>
 #root_of_unity = #field.root_of_unity<3383:i32, 4:i32> : !coeff_ty
+#psi = #field.root_of_unity<1925:i32, 8:i32> : !coeff_ty
 !poly_ty = !poly.polynomial<!coeff_ty, 3>
 !tensor_ty = tensor<4x!coeff_ty>
 
@@ -46,4 +47,27 @@ func.func @test_canonicalize_ntt_after_intt(%t0 : !tensor_ty) -> !tensor_ty {
   %evals3 = field.add %evals2, %evals2 : !tensor_ty
   // CHECK: return %[[RESULT]] : [[T]]
   return %evals3 : !tensor_ty
+}
+
+// A negacyclic pair folds like the cyclic one.
+// CHECK-LABEL: @test_canonicalize_negacyclic_pair
+// CHECK: (%[[X:.*]]: [[T:.*]]) -> [[T]]
+func.func @test_canonicalize_negacyclic_pair(%t0 : !tensor_ty) -> !tensor_ty {
+  // CHECK-NOT: poly.ntt
+  %evals = poly.ntt %t0 into %t0 {root=#psi} negacyclic=true : !tensor_ty
+  %coeffs = poly.ntt %evals into %evals {root=#psi} inverse=true negacyclic=true : !tensor_ty
+  // CHECK: return %[[X]] : [[T]]
+  return %coeffs : !tensor_ty
+}
+
+// A cyclic transform undone by a negacyclic one is NOT the identity — they are
+// transforms over different rings — so the pair must survive canonicalization.
+// Without the `negacyclic` equality constraint this folds away silently and the
+// program computes something else entirely.
+// CHECK-LABEL: @test_no_fold_across_negacyclic_mismatch
+func.func @test_no_fold_across_negacyclic_mismatch(%t0 : !tensor_ty) -> !tensor_ty {
+  // CHECK-COUNT-2: poly.ntt
+  %evals = poly.ntt %t0 into %t0 {root=#psi} : !tensor_ty
+  %coeffs = poly.ntt %evals into %evals {root=#psi} inverse=true negacyclic=true : !tensor_ty
+  return %coeffs : !tensor_ty
 }

--- a/tests/Dialect/Poly/ntt_negacyclic_invalid.mlir
+++ b/tests/Dialect/Poly/ntt_negacyclic_invalid.mlir
@@ -83,6 +83,31 @@ func.func @negacyclic_requires_bit_reverse(%t : tensor<4x!coeff_ty>) -> tensor<4
 
 // -----
 
+// `psi^n == -1` does not imply a power-of-two length: 3383 has order 4, so it
+// satisfies the equation at n = 6 as well. Unchecked, this reaches the
+// lowering's power-of-two assert — a crash rather than a diagnostic.
+!coeff_ty = !field.pf<7681:i32, true>
+#omega = #field.root_of_unity<3383:i32, 4:i32> : !coeff_ty
+
+func.func @negacyclic_rejects_a_non_power_of_two(%t : tensor<6x!coeff_ty>) -> tensor<6x!coeff_ty> {
+  // expected-error @+1 {{negacyclic requires a power-of-two length, got 6}}
+  %r = poly.ntt %t into %t {root=#omega} negacyclic=true : tensor<6x!coeff_ty>
+  return %r : tensor<6x!coeff_ty>
+}
+
+// -----
+
+!coeff_ty = !field.pf<7681:i32, true>
+#psi = #field.root_of_unity<1925:i32, 8:i32> : !coeff_ty
+
+func.func @negacyclic_rejects_rank_zero(%t : tensor<!coeff_ty>) -> tensor<!coeff_ty> {
+  // expected-error @+1 {{negacyclic requires a rank-1 tensor}}
+  %r = poly.ntt %t into %t {root=#psi} negacyclic=true : tensor<!coeff_ty>
+  return %r : tensor<!coeff_ty>
+}
+
+// -----
+
 // The positive control: a genuine 2n-th root is accepted, so the rejections above
 // are about the property and not about `negacyclic` itself.
 

--- a/tests/Dialect/Poly/ntt_negacyclic_invalid.mlir
+++ b/tests/Dialect/Poly/ntt_negacyclic_invalid.mlir
@@ -1,0 +1,95 @@
+// Copyright 2025 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// RUN: prime-ir-opt %s -split-input-file -verify-diagnostics
+
+// A negacyclic transform over `n` coefficients evaluates at odd powers of a
+// `2n`-th root, so an `n`-th root is the wrong one. Caught at the op rather than
+// producing a transform over the wrong ring.
+
+!coeff_ty = !field.pf<7681:i32, true>
+// 3383 has order 4 — correct for the cyclic transform, half of what negacyclic
+// over 4 coefficients needs.
+#omega = #field.root_of_unity<3383:i32, 4:i32> : !coeff_ty
+
+func.func @negacyclic_rejects_an_nth_root(%t : tensor<4x!coeff_ty>) -> tensor<4x!coeff_ty> {
+  // expected-error @+1 {{needs `root^4 == -1`}}
+  %r = poly.ntt %t into %t {root=#omega} negacyclic=true : tensor<4x!coeff_ty>
+  return %r : tensor<4x!coeff_ty>
+}
+
+// -----
+
+// The same order-4 root *relabelled* as degree 8. `RootOfUnityAttr` verifies only
+// `root^degree == 1`, which is divisibility and not order, so 3383^8 = 1 passes
+// it — a check on the stated degree would wave this through and then drive the
+// core with a root of half the needed order. Rejecting on `psi^n == -1` is what
+// makes the claim a checked value.
+!coeff_ty = !field.pf<7681:i32, true>
+#mislabelled = #field.root_of_unity<3383:i32, 8:i32> : !coeff_ty
+
+func.func @negacyclic_rejects_a_mislabelled_root(%t : tensor<4x!coeff_ty>) -> tensor<4x!coeff_ty> {
+  // expected-error @+1 {{needs `root^4 == -1`}}
+  %r = poly.ntt %t into %t {root=#mislabelled} negacyclic=true : tensor<4x!coeff_ty>
+  return %r : tensor<4x!coeff_ty>
+}
+
+// -----
+
+!coeff_ty = !field.pf<7681:i32, true>
+
+func.func @negacyclic_requires_a_root(%t : tensor<4x!coeff_ty>) -> tensor<4x!coeff_ty> {
+  // expected-error @+1 {{negacyclic requires `root`}}
+  %r = poly.ntt %t into %t negacyclic=true : tensor<4x!coeff_ty>
+  return %r : tensor<4x!coeff_ty>
+}
+
+// -----
+
+// `twiddles` cannot encode the per-coefficient twist, so the pair is rejected
+// rather than silently lowering to a cyclic transform.
+!coeff_ty = !field.pf<7681:i32, true>
+#psi = #field.root_of_unity<1925:i32, 8:i32> : !coeff_ty
+
+func.func @negacyclic_rejects_twiddles(%t : tensor<4x!coeff_ty>, %tw : tensor<4x!coeff_ty>) -> tensor<4x!coeff_ty> {
+  // expected-error @+1 {{negacyclic is not supported with `twiddles`}}
+  %r = poly.ntt %t into %t with %tw {root=#psi} negacyclic=true : tensor<4x!coeff_ty>
+  return %r : tensor<4x!coeff_ty>
+}
+
+// -----
+
+// The twist rides the natural index, which only `bit_reverse` establishes.
+!coeff_ty = !field.pf<7681:i32, true>
+#psi = #field.root_of_unity<1925:i32, 8:i32> : !coeff_ty
+
+func.func @negacyclic_requires_bit_reverse(%t : tensor<4x!coeff_ty>) -> tensor<4x!coeff_ty> {
+  // expected-error @+1 {{negacyclic requires `bit_reverse`}}
+  %r = poly.ntt %t into %t {root=#psi} bit_reverse=false negacyclic=true : tensor<4x!coeff_ty>
+  return %r : tensor<4x!coeff_ty>
+}
+
+// -----
+
+// The positive control: a genuine 2n-th root is accepted, so the rejections above
+// are about the property and not about `negacyclic` itself.
+
+!coeff_ty = !field.pf<7681:i32, true>
+#psi = #field.root_of_unity<1925:i32, 8:i32> : !coeff_ty
+
+func.func @negacyclic_accepts_a_2nth_root(%t : tensor<4x!coeff_ty>) -> tensor<4x!coeff_ty> {
+  %r = poly.ntt %t into %t {root=#psi} negacyclic=true : tensor<4x!coeff_ty>
+  return %r : tensor<4x!coeff_ty>
+}

--- a/tests/Dialect/Poly/ntt_runner.mlir
+++ b/tests/Dialect/Poly/ntt_runner.mlir
@@ -33,9 +33,23 @@
 // RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
 // RUN: FileCheck %s -check-prefix=CHECK_TEST_POLY_NTT_OUT_OF_PLACE_NO_BIT_REVERSAL < %t
 
+// RUN: prime-ir-opt %s -poly-to-field -field-to-llvm \
+// RUN:   | mlir-runner -e test_poly_negacyclic_ntt -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_TEST_POLY_NEGACYCLIC_NTT < %t
+
+// RUN: prime-ir-opt %s -poly-to-field -field-to-llvm \
+// RUN:   | mlir-runner -e test_poly_negacyclic_convolution -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_TEST_POLY_NEGACYCLIC_CONVOLUTION < %t
+
 !coeff_ty = !field.pf<7681:i32>
 !coeff_ty_mont = !field.pf<7681:i32, true>
 #root_of_unity = #field.root_of_unity<3383:i32, 4:i32> : !coeff_ty_mont
+// psi is a primitive 8th root with psi^2 = 3383, the omega above: a length-4
+// negacyclic transform evaluates at the roots of X^4 + 1, which are the odd
+// powers of a 2n-th root.
+#psi = #field.root_of_unity<1925:i32, 8:i32> : !coeff_ty_mont
 !poly_ty = !poly.polynomial<!coeff_ty_mont, 3>
 
 func.func private @printMemrefI32(memref<*xi32>) attributes { llvm.emit_c_interface }
@@ -142,3 +156,55 @@ func.func @test_poly_ntt_out_of_place_no_bit_reversal() {
 
 // CHECK_TEST_POLY_NTT_OUT_OF_PLACE_NO_BIT_REVERSAL: [10, 4297, 7677, 3382]
 // CHECK_TEST_POLY_NTT_OUT_OF_PLACE_NO_BIT_REVERSAL: [1, 2, 3, 4]
+
+// A negacyclic transform is not the cyclic one: evaluating [1,2,3,4] at the odd
+// powers of psi gives values the cyclic case above never produces, and the round
+// trip returns the input.
+func.func @test_poly_negacyclic_ntt() {
+  %coeffs_mont = field.constant dense<[1, 2, 3, 4]> : tensor<4x!coeff_ty_mont>
+  %tmp = bufferization.alloc_tensor() : tensor<4x!coeff_ty_mont>
+  %res = poly.ntt %coeffs_mont into %tmp {root=#psi} negacyclic=true : tensor<4x!coeff_ty_mont>
+
+  %res_standard = field.from_mont %res : tensor<4x!coeff_ty>
+  %extract = field.bitcast %res_standard : tensor<4x!coeff_ty> -> tensor<4xi32>
+  %1 = bufferization.to_buffer %extract : tensor<4xi32> to memref<4xi32>
+  %U = memref.cast %1 : memref<4xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U) : (memref<*xi32>) -> ()
+
+  %tmp1 = bufferization.alloc_tensor() : tensor<4x!coeff_ty_mont>
+  %intt = poly.ntt %res into %tmp1 {root=#psi} inverse=true negacyclic=true : tensor<4x!coeff_ty_mont>
+  %intt_standard = field.from_mont %intt : tensor<4x!coeff_ty>
+  %extract2 = field.bitcast %intt_standard : tensor<4x!coeff_ty> -> tensor<4xi32>
+  %2 = bufferization.to_buffer %extract2 : tensor<4xi32> to memref<4xi32>
+  %U2 = memref.cast %2 : memref<4xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U2) : (memref<*xi32>) -> ()
+  return
+}
+// CHECK_TEST_POLY_NEGACYCLIC_NTT: [1467, 2807, 3471, 7621]
+// CHECK_TEST_POLY_NEGACYCLIC_NTT: [1, 2, 3, 4]
+
+// The property the transform exists for, and the one a round trip cannot see: a
+// pointwise product in the evaluation domain is multiplication in
+// Z_q[X]/(X^4 + 1), where the wrap-around comes back negated. [1,2,3,4]*[5,6,7,8]
+// has full product [5,16,34,60,61,52,32]; cyclic folds it as c_i + c_{i+4} =
+// [66,68,66,60], negacyclic as c_i - c_{i+4} = [-56,-36,2,60].
+func.func @test_poly_negacyclic_convolution() {
+  %a = field.constant dense<[1, 2, 3, 4]> : tensor<4x!coeff_ty_mont>
+  %b = field.constant dense<[5, 6, 7, 8]> : tensor<4x!coeff_ty_mont>
+  %ta = bufferization.alloc_tensor() : tensor<4x!coeff_ty_mont>
+  %tb = bufferization.alloc_tensor() : tensor<4x!coeff_ty_mont>
+  %fa = poly.ntt %a into %ta {root=#psi} negacyclic=true : tensor<4x!coeff_ty_mont>
+  %fb = poly.ntt %b into %tb {root=#psi} negacyclic=true : tensor<4x!coeff_ty_mont>
+
+  %prod = field.mul %fa, %fb : tensor<4x!coeff_ty_mont>
+
+  %tc = bufferization.alloc_tensor() : tensor<4x!coeff_ty_mont>
+  %conv = poly.ntt %prod into %tc {root=#psi} inverse=true negacyclic=true : tensor<4x!coeff_ty_mont>
+  %conv_standard = field.from_mont %conv : tensor<4x!coeff_ty>
+  %extract = field.bitcast %conv_standard : tensor<4x!coeff_ty> -> tensor<4xi32>
+  %1 = bufferization.to_buffer %extract : tensor<4xi32> to memref<4xi32>
+  %U = memref.cast %1 : memref<4xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U) : (memref<*xi32>) -> ()
+  return
+}
+// CHECK_TEST_POLY_NEGACYCLIC_CONVOLUTION: [7625, 7645, 2, 60]

--- a/tests/Dialect/Poly/poly_to_field.mlir
+++ b/tests/Dialect/Poly/poly_to_field.mlir
@@ -19,6 +19,11 @@
 !poly_ty1 = !poly.polynomial<!PF1, 3>
 !poly_ty2 = !poly.polynomial<!PF1, 4>
 #root_of_unity = #field.root_of_unity<6:i255, 2:i255> : !PF1
+// A separate field for the negacyclic cases because F_7's `q - 1 = 6` has
+// 2-adicity 1: it has no 4th root of unity, so a length-2 negacyclic transform
+// does not exist over !PF1 at all. 7681 has 2-adicity 9.
+!PFN = !field.pf<7681:i32, true>
+#psi = #field.root_of_unity<1925:i32, 8:i32> : !PFN
 
 // CHECK-LABEL: @test_lower_to_tensor
 // CHECK-SAME: (%[[ARG0:.*]]: [[T:.*]]) -> [[T]] {
@@ -70,4 +75,26 @@ func.func @test_lower_intt_with_twiddles(%input : tensor<2x!PF1>, %twiddles : te
   // CHECK-NOT: arith.constant dense
   %res = poly.ntt %input into %input with %twiddles inverse=true: tensor<2x!PF1>
   return %res: tensor<2x!PF1>
+}
+
+// The twist rides on the natural coefficient index, so on the forward transform
+// it lands *before* the bit-reversal permutation reorders anything.
+// CHECK-LABEL: @test_lower_negacyclic_ntt
+func.func @test_lower_negacyclic_ntt(%input : tensor<4x!PFN>) -> tensor<4x!PFN> {
+  // The check is about twist *position*, not the opcode.
+  // CHECK-NOT: poly.ntt
+  // CHECK: field.mul
+  // CHECK: tensor_ext.bit_reverse
+  %res = poly.ntt %input into %input {root=#psi} negacyclic=true : tensor<4x!PFN>
+  return %res: tensor<4x!PFN>
+}
+
+// And on the inverse it lands after, once the output is back in natural order.
+// CHECK-LABEL: @test_lower_negacyclic_intt
+func.func @test_lower_negacyclic_intt(%input : tensor<4x!PFN>) -> tensor<4x!PFN> {
+  // CHECK-NOT: poly.ntt
+  // CHECK: tensor_ext.bit_reverse
+  // CHECK: field.mul
+  %res = poly.ntt %input into %input {root=#psi} inverse=true negacyclic=true : tensor<4x!PFN>
+  return %res: tensor<4x!PFN>
 }


### PR DESCRIPTION
## Description

`poly.ntt` computes only the cyclic transform. Lattice cryptography multiplies in
`Z_q[X]/(X^n + 1)` — the **negacyclic** ring — so neither ML-DSA (FIPS 204) nor
ML-KEM (FIPS 203) can use this op today. The word "negacyclic" did not appear
anywhere in the repository.

A `negacyclic` attribute (default `false`, so no existing IR changes meaning) plus
its lowering. Negacyclic reduces to the cyclic core with a twist on each side:
forward pre-twists `a[j]` by `psi^j`, inverse post-untwists by `psi^-j`, and the
staged butterflies run on `omega = psi^2`.

**Root convention.** With `negacyclic`, `root` carries the `2n`-th root `psi`
rather than an `n`-th root. Taking `psi` rather than deriving it matters: a square
root of `omega` is not unique, so `omega` alone does not determine the transform.
This also matches `xla/backends/cpu/runtime/ntt_thunk.cc`, so a consumer moving
across does not have to change which root it computes.

## What the verifier rejects, and why each one is a silent-wrong-answer path

This is the part worth reviewing closely — every rejection below replaced
something that previously produced a wrong transform with no diagnostic.

- **`root^n != -1`.** The natural check is "the stated degree is `2n`", and it is
  a proxy that does not hold: `RootOfUnityAttr::verify` checks only
  `root^degree == 1`, which is divisibility and not order. So `3383` — which has
  order 4 over `F_7681` — relabelled as `#root_of_unity<3383, 8>` passes both the
  attribute verifier and a degree comparison, then drives the core with
  `omega = 3383^2 = -1`, emitting the roots table `[1,-1,1,-1]` for a length-4
  transform. Checking the defining property instead of a proxy for it catches
  that, and it is also what fails when `q - 1` lacks the 2-adicity for a `2n`-th
  root at all.
- **`negacyclic` with `twiddles`.** Not merely unenforced — unachievable. The
  butterflies index the table as `roots[indexJ * rootExp]`, with no block index,
  so one entry is shared across every block of a stage and a per-coefficient
  diagonal has nowhere to live. Accepting the pair lowered to a byte-identical
  *cyclic* transform while still advertising itself as negacyclic to
  `INTTAfterNTT`.
- **`negacyclic` with `bit_reverse=false`.** The twist rides the natural
  coefficient index, which only the bit-reversal establishes. Without it the round
  trip still closes — so a round-trip test would not notice — but the pointwise
  product stops being a negacyclic convolution, which is the entire reason for the
  transform.
- **Dynamic leading dimension**, which otherwise produced
  `negacyclic over -9223372036854775808 coefficients`.

## The canonicalization constraint is load-bearing

`INTTAfterNTT` matches its operands positionally, so the new attribute had to be
threaded through it. It also needed `BoolEqual $negacyclic1, $negacyclic2`: a
cyclic transform undone by a negacyclic one is **not** the identity — they are
transforms over different rings — and without the constraint the pair folds away
silently. `test_no_fold_across_negacyclic_mismatch` pins it, deliberately using
the *same* root on both sides so that only the negacyclic constraint can be what
prevents the fold.

## Tests

`ntt_runner.mlir` executes the lowered code through `mlir-runner`, so these are
values rather than structure:

- forward `[1,2,3,4]` → `[1467, 2807, 3471, 7621]`, the evaluations at the odd
  powers of `psi`
- round trip returns the input
- `intt(ntt(a) ∘ ntt(b))` = `[7625, 7645, 2, 60]` = schoolbook multiplication in
  `Z_q[X]/(X^4 + 1)`. This is the property a round trip cannot see, and the one a
  cyclic transform fails: the same inputs fold cyclically to `[66,68,66,60]`.

Expected values were computed independently before the tests were written, not
read back out of the implementation.

`ntt_negacyclic_invalid.mlir` covers each rejection plus a positive control, so
the rejections are demonstrably about the property rather than about `negacyclic`
itself. `poly_to_field.mlir` pins the twist's *position* relative to the
bit-reversal. It needs its own field because `F_7`'s `q - 1 = 6` has 2-adicity 1 —
a length-2 negacyclic transform does not exist over the field the rest of that
file uses, which is the 2-adicity constraint showing up in practice.

Full suite green (129 tests).

## Known follow-up, deliberately not in this PR

The inverse path makes two elementwise passes over the data — `fastNTT`'s `1/n`
normalization and then the untwist — and they do not fuse (the scale is on
memrefs, a permutation sits between them). Folding `1/n` into the untwist table
would remove roughly 17% of the inverse transform's multiplies at `n = 256`. Left
out because it is a performance change in a correctness PR, it puts negacyclic
knowledge back inside `fastNTT` which this PR deliberately keeps cyclic-only, and
the two constants are in different encodings (the tables are Montgomery-raw, the
`invDegree` constant is standard-form) so the fold has a real trap in it. Worth
doing with its own measurement.

## Related Issues/PRs

Closes #421

Requested by `fractalyze/xla#446` (a CPU NTT emitter over this dialect — CPU
currently runs a routine that describes itself as mirroring
`ComputeReferenceNtt`). The consumers are `fractalyze/sig-frx#18` (ML-DSA, landed
hand-written for want of this) and `fractalyze/enc-frx#17` (ML-KEM).

Binary-tower fields are out of scope: `Poly_NTTOp` takes
`Field_PrimeFieldType`, and char-2 fields use the LCH14 additive transform.
