### PR TITLE
feat(dialect/poly): batch the NTT along the leading dimensions

### DIFF
--- a/prime_ir/Dialect/Poly/Conversions/PolyToField/PolyToField.cpp
+++ b/prime_ir/Dialect/Poly/Conversions/PolyToField/PolyToField.cpp
@@ -172,6 +172,25 @@ static Value buildPowerTable(ImplicitLocOpBuilder &b,
   return field::BitcastOp::create(b, fieldTensorType, table);
 }
 
+// Stretch a per-coefficient table across the batch axes of `type`, so it can
+// meet a batched tensor in an elementwise `field` op -- those are
+// `SameOperandsAndResultType` and do not broadcast. A no-op when there is no
+// batch.
+static Value broadcastOverBatch(ImplicitLocOpBuilder &b, Value table,
+                                RankedTensorType type) {
+  if (type.getRank() == 1)
+    return table;
+
+  SmallVector<int64_t> batchDims;
+  for (int64_t dim = 0; dim < type.getRank() - 1; ++dim)
+    batchDims.push_back(dim);
+  Value init =
+      tensor::EmptyOp::create(b, type.getShape(), type.getElementType());
+  return linalg::BroadcastOp::create(b, table, init, batchDims)
+      .getResults()
+      .front();
+}
+
 // Butterfly : Cooley-Tukey
 static std::pair<Value, Value> bflyCT(ImplicitLocOpBuilder &b, Value A, Value B,
                                       Value root) {
@@ -205,8 +224,11 @@ static Value fastNTT(ImplicitLocOpBuilder &b, NTTOpAdaptor adaptor,
   // -------------------------------------------------------------------------
   // Compute basic parameters and precompute the roots of unity.
   // -------------------------------------------------------------------------
-  // `degree` is the number of coefficients (assumed to be a power of 2).
-  unsigned degree = tensorType.getShape()[0];
+  // `degree` is the number of coefficients (assumed to be a power of 2). It is
+  // the minor dimension; every leading dimension is a batch axis, transformed
+  // independently by the same staged butterflies.
+  ArrayRef<int64_t> batchShape = tensorType.getShape().drop_back();
+  unsigned degree = tensorType.getShape().back();
   assert(llvm::has_single_bit(degree) &&
          "expected the number of coefficients to be a power of 2");
 
@@ -240,7 +262,8 @@ static Value fastNTT(ImplicitLocOpBuilder &b, NTTOpAdaptor adaptor,
                             b, rootsType, primitiveRootsAttr.getInvRoots());
 
     // Wrap the roots in a field encapsulation for further field operations.
-    roots = field::BitcastOp::create(b, tensorType, roots);
+    // Not `tensorType`: one table serves the whole batch.
+    roots = field::BitcastOp::create(b, rootsType.clone(coeffType), roots);
   }
 
   // -------------------------------------------------------------------------
@@ -341,10 +364,21 @@ static Value fastNTT(ImplicitLocOpBuilder &b, NTTOpAdaptor adaptor,
 
         // The inner loop processes groups of coefficients defined by the
         // current batchSize with a tile size of (tileX, tileY).
-        auto parallelLoop = scf::ParallelOp::create(
-            b, /*lowerBounds=*/ValueRange{c0, c0, c0, c0},
-            /*upperBounds=*/ValueRange{gridX, gridY, tileX, tileY},
-            /*steps=*/ValueRange{c1, c1, c1, c1});
+        //
+        // The batch axes lead, so one stage's parallel region spans every
+        // polynomial: `batch * degree/2` butterflies, and the stage barrier is
+        // paid once for the batch rather than once per polynomial. `row` names
+        // them because `batchSize`/`batchNum` above already mean the butterfly
+        // block within a single transform.
+        SmallVector<Value> lbs(batchShape.size(), c0);
+        SmallVector<Value> ubs;
+        for (int64_t rows : batchShape)
+          ubs.push_back(arith::ConstantIndexOp::create(b, rows));
+        lbs.append({c0, c0, c0, c0});
+        ubs.append({gridX, gridY, tileX, tileY});
+        SmallVector<Value> steps(lbs.size(), c1);
+
+        auto parallelLoop = scf::ParallelOp::create(b, lbs, ubs, steps);
 
         // Build the body of the parallel loop.
         {
@@ -353,10 +387,13 @@ static Value fastNTT(ImplicitLocOpBuilder &b, NTTOpAdaptor adaptor,
           ImplicitLocOpBuilder pb(parallelBlock.getArgument(0).getLoc(),
                                   parallelBuilder);
 
-          Value bx = parallelBlock.getArgument(0);
-          Value by = parallelBlock.getArgument(1);
-          Value tx = parallelBlock.getArgument(2);
-          Value ty = parallelBlock.getArgument(3);
+          unsigned rowRank = batchShape.size();
+          SmallVector<Value> rowIvs(
+              parallelBlock.getArguments().take_front(rowRank));
+          Value bx = parallelBlock.getArgument(rowRank + 0);
+          Value by = parallelBlock.getArgument(rowRank + 1);
+          Value tx = parallelBlock.getArgument(rowRank + 2);
+          Value ty = parallelBlock.getArgument(rowRank + 3);
 
           // Global indices:
           //   indexK = bx*tileY + ty
@@ -397,11 +434,16 @@ static Value fastNTT(ImplicitLocOpBuilder &b, NTTOpAdaptor adaptor,
                 Value halfBatch = arith::DivUIOp::create(t, batchSize, c2);
                 Value indexB = arith::AddIOp::create(t, indexA, halfBatch);
 
+                // The butterfly indices address the minor dimension; the row
+                // induction variables select the polynomial.
+                SmallVector<Value> subscriptA(rowIvs);
+                subscriptA.push_back(indexA);
+                SmallVector<Value> subscriptB(rowIvs);
+                subscriptB.push_back(indexB);
+
                 // Load values from previous stage output.
-                Value A =
-                    memref::LoadOp::create(t, stageMemref, ValueRange{indexA});
-                Value B =
-                    memref::LoadOp::create(t, stageMemref, ValueRange{indexB});
+                Value A = memref::LoadOp::create(t, stageMemref, subscriptA);
+                Value B = memref::LoadOp::create(t, stageMemref, subscriptB);
 
                 // ---------------------------------------------------------
                 // Compute the twiddle factor for the butterfly.
@@ -423,9 +465,9 @@ static Value fastNTT(ImplicitLocOpBuilder &b, NTTOpAdaptor adaptor,
                     kInverse ? bflyGS(t, A, B, root) : bflyCT(t, A, B, root);
 
                 memref::StoreOp::create(t, bflyResult.first, destMemref,
-                                        ValueRange{indexA});
+                                        subscriptA);
                 memref::StoreOp::create(t, bflyResult.second, destMemref,
-                                        ValueRange{indexB});
+                                        subscriptB);
 
                 scf::YieldOp::create(t, ValueRange{});
               });
@@ -495,7 +537,8 @@ struct ConvertNTT : public OpConversionPattern<NTTOp> {
     Value source = adaptor.getSource();
     auto tensorType = cast<RankedTensorType>(adaptor.getDest().getType());
     auto coeffType = cast<field::PrimeFieldType>(tensorType.getElementType());
-    unsigned degree = tensorType.getShape()[0];
+    const int64_t minorDim = tensorType.getRank() - 1;
+    unsigned degree = tensorType.getShape().back();
     const bool negacyclic = adaptor.getNegacyclic();
 
     // Negacyclic states its root as the 2n-th root `psi`; the staged
@@ -516,7 +559,8 @@ struct ConvertNTT : public OpConversionPattern<NTTOp> {
       if (!adaptor.getInverse()) {
         Value psiPowers = buildPowerTable(b, *adaptor.getRoot(), coeffType,
                                           degree, /*inverse=*/false);
-        source = field::MulOp::create(b, source, psiPowers);
+        source = field::MulOp::create(
+            b, source, broadcastOverBatch(b, psiPowers, tensorType));
       }
     }
 
@@ -526,7 +570,7 @@ struct ConvertNTT : public OpConversionPattern<NTTOp> {
     // forward NTT.
     if (!adaptor.getInverse() && adaptor.getBitReverse()) {
       auto bitReversed = tensor_ext::BitReverseOp::create(
-          b, source, adaptor.getDest(), /*dimension=*/0);
+          b, source, adaptor.getDest(), /*dimension=*/minorDim);
 
       // NOTE(batzor): We should not use `dest` operand for the destination
       // here. Otherwise, writable `ToBufferOp` will be called twice on the same
@@ -541,14 +585,15 @@ struct ConvertNTT : public OpConversionPattern<NTTOp> {
     // inverse NTT.
     if (adaptor.getInverse() && adaptor.getBitReverse()) {
       auto nttResultBitReversed = tensor_ext::BitReverseOp::create(
-          b, nttResult, nttResult, /*dimension=*/0);
+          b, nttResult, nttResult, /*dimension=*/minorDim);
       nttResult = nttResultBitReversed.getResult();
     }
 
     if (negacyclic && adaptor.getInverse()) {
       Value psiInvPowers = buildPowerTable(b, *adaptor.getRoot(), coeffType,
                                            degree, /*inverse=*/true);
-      nttResult = field::MulOp::create(b, nttResult, psiInvPowers);
+      nttResult = field::MulOp::create(
+          b, nttResult, broadcastOverBatch(b, psiInvPowers, tensorType));
     }
 
     rewriter.replaceOp(op, nttResult);

--- a/prime_ir/Dialect/Poly/IR/PolyOps.cpp
+++ b/prime_ir/Dialect/Poly/IR/PolyOps.cpp
@@ -41,6 +41,21 @@ void NTTOp::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 LogicalResult NTTOp::verify() {
+  auto tensorType = cast<RankedTensorType>(getOutput().getType());
+
+  // The transform runs along the minor dimension; leading dimensions are a
+  // batch. The staged butterflies assume a power-of-two length and read it off
+  // that dimension — an `assert` in the lowering, so an unchecked shape is a
+  // crash rather than a diagnostic.
+  if (tensorType.getRank() == 0)
+    return emitOpError("requires a tensor of rank 1 or higher");
+  if (tensorType.isDynamicDim(tensorType.getRank() - 1))
+    return emitOpError("requires a static transform length");
+  int64_t degree = tensorType.getShape().back();
+  if (degree <= 0 || !llvm::has_single_bit(static_cast<uint64_t>(degree)))
+    return emitOpError("requires a power-of-two transform length, got ")
+           << degree;
+
   if (!getNegacyclic())
     return success();
 
@@ -64,27 +79,14 @@ LogicalResult NTTOp::verify() {
   if (!rootOfUnity)
     return emitOpError("negacyclic requires `root`");
 
-  // The lowering reads the length off dimension zero and the staged butterflies
-  // assume it is a power of two — an `assert` there, so an unchecked shape is a
-  // crash rather than a diagnostic. Note `psi^n == -1` below does not imply it:
-  // a root of order 4 satisfies it at n = 6 as well as at n = 2.
-  auto tensorType = cast<RankedTensorType>(getOutput().getType());
-  if (tensorType.getRank() != 1)
-    return emitOpError("negacyclic requires a rank-1 tensor");
-  if (tensorType.isDynamicDim(0))
-    return emitOpError("negacyclic requires a static length");
-  int64_t degree = tensorType.getShape()[0];
-  if (degree <= 0 || !llvm::has_single_bit(static_cast<uint64_t>(degree)))
-    return emitOpError("negacyclic requires a power-of-two length, got ")
-           << degree;
-
   // `psi^n == -1` rather than a check on the *stated* degree. `RootOfUnityAttr`
   // verifies only `root^degree == 1`, which is divisibility and not order, so
   // an n-th root relabelled as a 2n-th one passes it, and would then drive
   // the core with `psi^2` of half the needed order, silently computing a
   // transform over the wrong ring. This is the defining property instead of a
   // proxy for it, and it is also what fails when `q - 1` lacks the 2-adicity
-  // for a 2n-th root at all.
+  // for a 2n-th root at all. It does not subsume the power-of-two check above:
+  // a root of order 4 satisfies it at n = 6 as well as at n = 2.
   auto coeffType = cast<field::PrimeFieldType>(tensorType.getElementType());
   auto psi = field::PrimeFieldOperation::fromUnchecked(rootOfUnity->getRoot(),
                                                        coeffType);

--- a/prime_ir/Dialect/Poly/IR/PolyOps.td
+++ b/prime_ir/Dialect/Poly/IR/PolyOps.td
@@ -74,7 +74,19 @@ def Poly_FromTensorOp : Poly_Op<"from_tensor"> {
   let hasCanonicalizer = 1;
 }
 
-def Poly_NTTOp : Poly_Op<"ntt", [DestinationStyleOpInterface, SameOperandsAndResultType]> {
+// A rank-1 table over the transform length, whatever the batch shape of the
+// transformed tensor is. Spelled as a type transform rather than by
+// `SameOperandsAndResultType` so the batch axes stay off the table, and so the
+// assembly format can still infer `$twiddles` from `type($output)` alone.
+class Poly_TwiddlesOverMinorDim<string src, string tw> : OptionalTypesMatchWith<
+  "twiddles is a rank-1 table over the transform length", src, tw,
+  "::mlir::RankedTensorType::get("
+      "{::llvm::cast<::mlir::ShapedType>($_self).getShape().back()}, "
+      "::llvm::cast<::mlir::ShapedType>($_self).getElementType())">;
+
+def Poly_NTTOp : Poly_Op<"ntt", [DestinationStyleOpInterface,
+                                 AllTypesMatch<["source", "dest", "output"]>,
+                                 Poly_TwiddlesOverMinorDim<"output", "twiddles">]> {
   let summary = "Compute the number theoretic transform.";
   let description = [{
     Computes the forward integer Number Theoretic Transform
@@ -91,6 +103,26 @@ def Poly_NTTOp : Poly_Op<"ntt", [DestinationStyleOpInterface, SameOperandsAndRes
     %coeffs = poly.to_tensor %poly : !poly_ty -> tensor<4x!pf>
     %evals = poly.ntt %coeffs {root=#root}: tensor<4x!pf>
     ```
+
+    The transform runs along the **minor** dimension; every leading dimension is
+    a batch axis, so one op transforms `64x11` independent length-256
+    polynomials:
+
+    ```
+    %evals = poly.ntt %coeffs into %dest {root=#root} : tensor<64x11x256x!pf>
+    ```
+
+    Batching belongs to the op rather than to the caller's loop because the
+    transform is `log2(n)` barrier-separated stages. A length-256 transform
+    offers 128 butterflies per stage, which does not fill a machine, and looping
+    the op pays those barriers once per polynomial. Carrying the batch inside
+    puts `batch * n/2` butterflies in every stage and leaves the barrier count
+    at `log2(n)` for the whole batch, which is what `tileX` / `gridSize` then
+    tile.
+
+    `twiddles` stays rank-1 of length `n` however the source is batched: the
+    table is indexed by position within a stage's block, which is the same for
+    every polynomial in the batch, so a batched table would only duplicate it.
 
     With `negacyclic`, the transform is over `Z_q[X]/(X^n + 1)` instead — the ring
     lattice cryptography multiplies in, where the wrap-around comes back negated.

--- a/tests/Dialect/Poly/ntt_invalid.mlir
+++ b/tests/Dialect/Poly/ntt_invalid.mlir
@@ -1,0 +1,93 @@
+// Copyright 2025 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// RUN: prime-ir-opt %s -split-input-file -verify-diagnostics
+
+// The shape contract `poly.ntt` shares between the cyclic and negacyclic paths:
+// the transform runs on the minor dimension and every leading dimension is a
+// batch. Each rejection below stands between a caller and the lowering's
+// power-of-two `assert`, which is a crash rather than a diagnostic.
+
+!coeff_ty = !field.pf<7681:i32, true>
+#omega = #field.root_of_unity<3383:i32, 4:i32> : !coeff_ty
+
+func.func @ntt_rejects_rank_zero(%t : tensor<!coeff_ty>) -> tensor<!coeff_ty> {
+  // expected-error @+1 {{requires a tensor of rank 1 or higher}}
+  %r = poly.ntt %t into %t {root=#omega} : tensor<!coeff_ty>
+  return %r : tensor<!coeff_ty>
+}
+
+// -----
+
+!coeff_ty = !field.pf<7681:i32, true>
+#omega = #field.root_of_unity<3383:i32, 4:i32> : !coeff_ty
+
+func.func @ntt_rejects_a_non_power_of_two(%t : tensor<6x!coeff_ty>) -> tensor<6x!coeff_ty> {
+  // expected-error @+1 {{requires a power-of-two transform length, got 6}}
+  %r = poly.ntt %t into %t {root=#omega} : tensor<6x!coeff_ty>
+  return %r : tensor<6x!coeff_ty>
+}
+
+// -----
+
+// The length is read off the *minor* dimension, so a batch axis is free to be
+// any size while the transform axis is not. The pair below and the positive
+// control that follows are what pin which axis is which — a reversed reading
+// would accept this one and reject that one.
+!coeff_ty = !field.pf<7681:i32, true>
+#omega = #field.root_of_unity<3383:i32, 4:i32> : !coeff_ty
+
+func.func @ntt_rejects_a_non_power_of_two_minor_dim(%t : tensor<4x6x!coeff_ty>) -> tensor<4x6x!coeff_ty> {
+  // expected-error @+1 {{requires a power-of-two transform length, got 6}}
+  %r = poly.ntt %t into %t {root=#omega} : tensor<4x6x!coeff_ty>
+  return %r : tensor<4x6x!coeff_ty>
+}
+
+// -----
+
+!coeff_ty = !field.pf<7681:i32, true>
+#omega = #field.root_of_unity<3383:i32, 4:i32> : !coeff_ty
+
+func.func @ntt_accepts_a_non_power_of_two_batch(%t : tensor<6x4x!coeff_ty>) -> tensor<6x4x!coeff_ty> {
+  %r = poly.ntt %t into %t {root=#omega} : tensor<6x4x!coeff_ty>
+  return %r : tensor<6x4x!coeff_ty>
+}
+
+// -----
+
+// One table serves the whole batch, so it stays rank-1 as the transformed
+// tensor grows leading dimensions. The assembly format derives its type from
+// `type($output)` rather than spelling it, so a batched table is not a verifier
+// rejection but an unwritable one — the parser resolves `%tw` to the rank-1
+// type and the mismatch lands on the prior use.
+!coeff_ty = !field.pf<7681:i32, true>
+
+// expected-note @+1 {{prior use here}}
+func.func @ntt_rejects_batched_twiddles(%t : tensor<2x4x!coeff_ty>, %tw : tensor<2x4x!coeff_ty>) -> tensor<2x4x!coeff_ty> {
+  // expected-error @+1 {{expects different type than prior uses: 'tensor<4x!field.pf<7681 : i32, true>>' vs 'tensor<2x4x!field.pf<7681 : i32, true>>'}}
+  %r = poly.ntt %t into %t with %tw : tensor<2x4x!coeff_ty>
+  return %r : tensor<2x4x!coeff_ty>
+}
+
+// -----
+
+!coeff_ty = !field.pf<7681:i32, true>
+
+// expected-note @+1 {{prior use here}}
+func.func @ntt_rejects_a_mismatched_twiddle_length(%t : tensor<2x4x!coeff_ty>, %tw : tensor<8x!coeff_ty>) -> tensor<2x4x!coeff_ty> {
+  // expected-error @+1 {{expects different type than prior uses: 'tensor<4x!field.pf<7681 : i32, true>>' vs 'tensor<8x!field.pf<7681 : i32, true>>'}}
+  %r = poly.ntt %t into %t with %tw : tensor<2x4x!coeff_ty>
+  return %r : tensor<2x4x!coeff_ty>
+}

--- a/tests/Dialect/Poly/ntt_negacyclic_invalid.mlir
+++ b/tests/Dialect/Poly/ntt_negacyclic_invalid.mlir
@@ -83,31 +83,6 @@ func.func @negacyclic_requires_bit_reverse(%t : tensor<4x!coeff_ty>) -> tensor<4
 
 // -----
 
-// `psi^n == -1` does not imply a power-of-two length: 3383 has order 4, so it
-// satisfies the equation at n = 6 as well. Unchecked, this reaches the
-// lowering's power-of-two assert — a crash rather than a diagnostic.
-!coeff_ty = !field.pf<7681:i32, true>
-#omega = #field.root_of_unity<3383:i32, 4:i32> : !coeff_ty
-
-func.func @negacyclic_rejects_a_non_power_of_two(%t : tensor<6x!coeff_ty>) -> tensor<6x!coeff_ty> {
-  // expected-error @+1 {{negacyclic requires a power-of-two length, got 6}}
-  %r = poly.ntt %t into %t {root=#omega} negacyclic=true : tensor<6x!coeff_ty>
-  return %r : tensor<6x!coeff_ty>
-}
-
-// -----
-
-!coeff_ty = !field.pf<7681:i32, true>
-#psi = #field.root_of_unity<1925:i32, 8:i32> : !coeff_ty
-
-func.func @negacyclic_rejects_rank_zero(%t : tensor<!coeff_ty>) -> tensor<!coeff_ty> {
-  // expected-error @+1 {{negacyclic requires a rank-1 tensor}}
-  %r = poly.ntt %t into %t {root=#psi} negacyclic=true : tensor<!coeff_ty>
-  return %r : tensor<!coeff_ty>
-}
-
-// -----
-
 // The positive control: a genuine 2n-th root is accepted, so the rejections above
 // are about the property and not about `negacyclic` itself.
 

--- a/tests/Dialect/Poly/ntt_runner.mlir
+++ b/tests/Dialect/Poly/ntt_runner.mlir
@@ -43,6 +43,16 @@
 // RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
 // RUN: FileCheck %s -check-prefix=CHECK_TEST_POLY_NEGACYCLIC_CONVOLUTION < %t
 
+// RUN: prime-ir-opt %s -poly-to-field -field-to-llvm \
+// RUN:   | mlir-runner -e test_poly_ntt_batched -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_TEST_POLY_NTT_BATCHED < %t
+
+// RUN: prime-ir-opt %s -poly-to-field -field-to-llvm \
+// RUN:   | mlir-runner -e test_poly_negacyclic_ntt_batched -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_TEST_POLY_NEGACYCLIC_NTT_BATCHED < %t
+
 !coeff_ty = !field.pf<7681:i32>
 !coeff_ty_mont = !field.pf<7681:i32, true>
 #root_of_unity = #field.root_of_unity<3383:i32, 4:i32> : !coeff_ty_mont
@@ -208,3 +218,67 @@ func.func @test_poly_negacyclic_convolution() {
   return
 }
 // CHECK_TEST_POLY_NEGACYCLIC_CONVOLUTION: [7625, 7645, 2, 60]
+
+// The rows below are the vectors the rank-1 cases above already pin, so a
+// batched transform that agreed with itself but not with the unbatched op would
+// still fail here. [0,1,0,0] is the polynomial X, whose evaluations are the
+// powers of the root themselves -- a row that shares no value with [1,2,3,4]'s,
+// so a batch axis folded into the wrong index cannot pass by coincidence.
+func.func @test_poly_ntt_batched() {
+  %coeffs_mont = field.constant dense<[[1, 2, 3, 4], [0, 1, 0, 0]]> : tensor<2x4x!coeff_ty_mont>
+  %tmp = bufferization.alloc_tensor() : tensor<2x4x!coeff_ty_mont>
+  %res = poly.ntt %coeffs_mont into %tmp {root=#root_of_unity} : tensor<2x4x!coeff_ty_mont>
+
+  %res_standard = field.from_mont %res : tensor<2x4x!coeff_ty>
+  %extract = field.bitcast %res_standard : tensor<2x4x!coeff_ty> -> tensor<2x4xi32>
+  %1 = bufferization.to_buffer %extract : tensor<2x4xi32> to memref<2x4xi32>
+  %U = memref.cast %1 : memref<2x4xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U) : (memref<*xi32>) -> ()
+
+  %tmp1 = bufferization.alloc_tensor() : tensor<2x4x!coeff_ty_mont>
+  %intt = poly.ntt %res into %tmp1 {root=#root_of_unity} inverse=true : tensor<2x4x!coeff_ty_mont>
+  %intt_standard = field.from_mont %intt : tensor<2x4x!coeff_ty>
+  %extract2 = field.bitcast %intt_standard : tensor<2x4x!coeff_ty> -> tensor<2x4xi32>
+  %2 = bufferization.to_buffer %extract2 : tensor<2x4xi32> to memref<2x4xi32>
+  %U2 = memref.cast %2 : memref<2x4xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U2) : (memref<*xi32>) -> ()
+  return
+}
+// CHECK_TEST_POLY_NTT_BATCHED: [10, 913, 7679, 6764]
+// CHECK_TEST_POLY_NTT_BATCHED: [1, 3383, 7680, 4298]
+// CHECK_TEST_POLY_NTT_BATCHED: [1, 2, 3, 4]
+// CHECK_TEST_POLY_NTT_BATCHED: [0, 1, 0, 0]
+
+// Rank 3, because that is the consumer's shape (a signature batch times a
+// polynomial count times the transform) and because two leading dimensions are
+// what distinguishes "the batch is one flattened axis" from "each leading axis
+// is its own loop dimension".
+func.func @test_poly_negacyclic_ntt_batched() {
+  %coeffs_mont = field.constant dense<[[[1, 2, 3, 4], [0, 1, 0, 0]],
+                                       [[5, 6, 7, 8], [1, 2, 3, 4]]]> : tensor<2x2x4x!coeff_ty_mont>
+  %tmp = bufferization.alloc_tensor() : tensor<2x2x4x!coeff_ty_mont>
+  %res = poly.ntt %coeffs_mont into %tmp {root=#psi} negacyclic=true : tensor<2x2x4x!coeff_ty_mont>
+
+  %res_standard = field.from_mont %res : tensor<2x2x4x!coeff_ty>
+  %extract = field.bitcast %res_standard : tensor<2x2x4x!coeff_ty> -> tensor<2x2x4xi32>
+  %1 = bufferization.to_buffer %extract : tensor<2x2x4xi32> to memref<2x2x4xi32>
+  %U = memref.cast %1 : memref<2x2x4xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U) : (memref<*xi32>) -> ()
+
+  %tmp1 = bufferization.alloc_tensor() : tensor<2x2x4x!coeff_ty_mont>
+  %intt = poly.ntt %res into %tmp1 {root=#psi} inverse=true negacyclic=true : tensor<2x2x4x!coeff_ty_mont>
+  %intt_standard = field.from_mont %intt : tensor<2x2x4x!coeff_ty>
+  %extract2 = field.bitcast %intt_standard : tensor<2x2x4x!coeff_ty> -> tensor<2x2x4xi32>
+  %2 = bufferization.to_buffer %extract2 : tensor<2x2x4xi32> to memref<2x2x4xi32>
+  %U2 = memref.cast %2 : memref<2x2x4xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U2) : (memref<*xi32>) -> ()
+  return
+}
+// CHECK_TEST_POLY_NEGACYCLIC_NTT_BATCHED: [1467, 2807, 3471, 7621]
+// CHECK_TEST_POLY_NEGACYCLIC_NTT_BATCHED: [1925, 6468, 5756, 1213]
+// CHECK_TEST_POLY_NEGACYCLIC_NTT_BATCHED: [2489, 7489, 6478, 6607]
+// CHECK_TEST_POLY_NEGACYCLIC_NTT_BATCHED: [1467, 2807, 3471, 7621]
+// CHECK_TEST_POLY_NEGACYCLIC_NTT_BATCHED: [1, 2, 3, 4]
+// CHECK_TEST_POLY_NEGACYCLIC_NTT_BATCHED: [0, 1, 0, 0]
+// CHECK_TEST_POLY_NEGACYCLIC_NTT_BATCHED: [5, 6, 7, 8]
+// CHECK_TEST_POLY_NEGACYCLIC_NTT_BATCHED: [1, 2, 3, 4]

--- a/tests/Dialect/Poly/poly_to_field.mlir
+++ b/tests/Dialect/Poly/poly_to_field.mlir
@@ -77,6 +77,34 @@ func.func @test_lower_intt_with_twiddles(%input : tensor<2x!PF1>, %twiddles : te
   return %res: tensor<2x!PF1>
 }
 
+// What the batch axis is for, and the one thing an execution test cannot see:
+// the stage loop stays singular and its parallel region grows to cover every
+// polynomial, so `log2(n)` barriers are paid once for the whole batch. A caller
+// that looped the rank-1 op would emit one stage loop per row instead.
+// CHECK-LABEL: @test_lower_batched_ntt
+func.func @test_lower_batched_ntt(%input : tensor<3x2x!PF1>) -> tensor<3x2x!PF1> {
+  // CHECK-NOT: poly.ntt
+  // CHECK: scf.for
+  // One induction variable per leading dimension, ahead of the four the
+  // (tileX, tileY) grid already had.
+  // CHECK: scf.parallel ({{[^,]*}}, {{[^,]*}}, {{[^,]*}}, {{[^,]*}}, {{[^,)]*}}) =
+  // CHECK-NOT: scf.parallel
+  %res = poly.ntt %input into %input {root=#root_of_unity} : tensor<3x2x!PF1>
+  return %res: tensor<3x2x!PF1>
+}
+
+// Each leading dimension is its own loop dimension rather than one flattened
+// axis, so the rank-3 shape a lattice consumer actually has (signatures x
+// polynomials x coefficients) needs no reshape to reach the op.
+// CHECK-LABEL: @test_lower_batched_ntt_rank3
+func.func @test_lower_batched_ntt_rank3(%input : tensor<3x5x2x!PF1>) -> tensor<3x5x2x!PF1> {
+  // CHECK-NOT: poly.ntt
+  // CHECK: scf.parallel ({{[^,]*}}, {{[^,]*}}, {{[^,]*}}, {{[^,]*}}, {{[^,]*}}, {{[^,)]*}}) =
+  // CHECK-NOT: scf.parallel
+  %res = poly.ntt %input into %input {root=#root_of_unity} : tensor<3x5x2x!PF1>
+  return %res: tensor<3x5x2x!PF1>
+}
+
 // The twist rides on the natural coefficient index, so on the forward transform
 // it lands *before* the bit-reversal permutation reorders anything.
 // CHECK-LABEL: @test_lower_negacyclic_ntt


### PR DESCRIPTION
## Description

`poly.ntt` transformed a rank-1 tensor, so a caller with many small polynomials
had to loop it. That is the wrong shape for this transform, and the cost is
structural rather than constant-factor.

The transform is `log2(n)` stages separated by barriers, and each stage's
`scf.parallel` covers `n/2` butterflies — 128 at `n = 256`, which does not fill a
machine. Looping the op pays those 8 barriers **once per polynomial** while never
giving any single one of them enough work. For ML-DSA-65 verification (64
signatures × 11 polynomials of length 256) that is 5632 barriers instead of 8.

So the minor dimension is now the transform and every leading dimension is a
batch, carried into the stage's parallel region:

```mlir
%evals = poly.ntt %coeffs into %dest {root=#root} : tensor<64x11x256x!pf>
```

`tileX` / `gridSize` then tile the combined domain rather than one polynomial's
butterflies.

## Shape of the change

- **One induction variable per leading dimension**, ahead of the four the
  `(tileX, tileY)` grid already had, rather than one flattened batch axis. Rank 1
  therefore emits exactly what it emitted before — `poly_to_field.mlir`'s existing
  checks pass untouched — and a rank-3 consumer needs no reshape to reach the op.
- The **roots table** was bitcast to the full tensor type, which was only ever
  correct because the tensor was rank-1. It is the stage's block-position table,
  identical for every polynomial, so it is now explicitly rank-1 and shared.
- The **negacyclic twist** is broadcast over the batch: `field` ops are
  `SameOperandsAndResultType` and do not broadcast, so a rank-1 `psi^j` table
  cannot meet a batched source on its own.

## Why `twiddles` stays rank-1, and the part worth reviewing closely

The butterfly indexes the table as `roots[indexJ * rootExp]` — a position within a
stage's block, with no polynomial index — so a batched table could only duplicate
itself.

`SameOperandsAndResultType` used to tie it to `source`, which batching rules out.
Two notes on the replacement:

- `TypesMatchWith` **cannot** be used for an optional operand: it expands to a
  bare `$twiddles.getType()` in `verifyInvariantsImpl` and segfaults on every op
  that omits it. `OptionalTypesMatchWith` is the same relation with an
  absence short-circuit.
- Deriving the type rather than spelling it means a mismatched table is now
  **unrepresentable in textual IR** — the parser resolves `%tw` to the derived
  type and the conflict lands on the prior use. The trait's own diagnostic is
  reachable only from programmatically-built IR, so `ntt_invalid.mlir` asserts the
  parse error instead.

## Verifier

The shape contract moved out of the `negacyclic` branch, so it now guards the
cyclic path too. Previously a rank-0 or non-power-of-two **cyclic** transform
passed the verifier and reached the lowering's power-of-two `assert` — a crash
rather than a diagnostic. Rank 0 is rejected explicitly, because reading the minor
dimension indexes off the end of the shape.

## Testing

- `ntt_runner.mlir` — a rank-2 cyclic and a rank-3 negacyclic case that **execute**
  through `mlir-runner`. Expected values were derived from the definition rather
  than from this implementation, and the same derivation reproduces the
  pre-existing rank-1 expectations, so the oracle is itself checked. One row is the
  polynomial `X`, whose evaluations are the powers of the root and share no value
  with `[1,2,3,4]`'s, so a batch axis folded into the wrong index cannot pass by
  coincidence. Both round-trip.
- `poly_to_field.mlir` — pins the loop structure, which is the performance claim
  and the one thing an execution test cannot see: the stage loop stays singular and
  its parallel region gains one induction variable per leading dimension (5 IVs at
  rank 2, 6 at rank 3).
- `ntt_invalid.mlir` — new; the shape contract now shared by both paths, including
  a pair that pins *which* axis is the transform (a non-power-of-two minor
  dimension is rejected, a non-power-of-two batch axis is accepted).

`bazel test //tests/...` is green apart from `//tests/Dialect/ArithExt:packed_arith_runner`,
which fails on any default invocation because `//:has_avx512` defaults false and
the `select()` falls through to `lit -h`; `.bazelrc.ci` passes the flag.

## Context

Prerequisite for fractalyze/xla#446, which adds a CPU NTT emitter that emits this
op. That issue's measurements are what motivate the batch axis: `lax.ntt` is
10-15× behind ordinary HLO at these shapes because its per-transform cost is flat.
