### PR TITLE
perf(dialect/field): use Karatsuba for the NVPTX GHASH product

### DIFF
--- a/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.cpp
+++ b/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.cpp
@@ -45,8 +45,8 @@ namespace {
 // Emit a single PTX `clmad.{lo,hi}.u64` (carryless multiply-add, PTX ISA 9.3):
 //   dst = carryless_product_{lo|hi}(a, b) XOR c
 // `lo` selects bits 0..63 of the 64x64 carryless product, `hi` bits 64..127.
-// The `c` operand chains the XOR-accumulation for free, which the schoolbook
-// below uses to fold cross terms without extra XOR ops. Kept as opaque inline
+// The `c` operand chains one XOR into the multiply for free, which the
+// schedules below use to absorb fold terms. Kept as opaque inline
 // asm so `clmad` survives to PTX regardless of the LLVM NVPTX backend version;
 // only ptxas (CUDA 13.3+) needs to know the instruction.
 Value emitClmad(ImplicitLocOpBuilder &b, Value a, Value bv, Value c,
@@ -67,17 +67,16 @@ Value emitClmad(ImplicitLocOpBuilder &b, Value a, Value bv, Value c,
 // clmad-based GHASH Multiplication
 //===----------------------------------------------------------------------===//
 
-// Multiply two GHASH-basis i128 values using clmad. Eight clmad build the
-// 128x128 -> 256-bit carryless product as limbs r0..r3 (low to high), folding
-// the two cross terms via clmad's XOR-accumulate operand exactly as flock's
-// clmad kernel (optim/clmad/ghash_mul.ptx):
-//   r0 = ll_lo
-//   r1 = ll_hi ^ (a1·b0)_lo ^ (a0·b1)_lo   (= ll_hi ^ mid_lo)
-//   r2 = hh_lo ^ (a1·b0)_hi ^ (a0·b1)_hi   (= hh_lo ^ mid_hi)
-//   r3 = hh_hi
-// These are the same r0..r3 limbs the x86 PCLMULQDQ path produces, so the
-// reduction reuses the shared `reduceGhash` — the carryless-multiply backends
-// fold the high half identically and cannot drift.
+// Multiply two GHASH-basis i128 values using clmad. Karatsuba — 3 sub-products
+// instead of 4 (cross term a₀b₁ + a₁b₀ = (a₀+a₁)(b₀+b₁) + a₀b₀ + a₁b₁), which
+// trades two clmad for six XOR. Worth it because this multiply is
+// clmad-issue-bound on sm_120, so the XORs issue alongside for free; see the
+// pass's Performance notes for the measurement and when to re-check it.
+//
+// These are the same r0..r3 limbs the x86 PCLMULQDQ, ARM PMULL, and portable
+// `emitGhashMul` paths produce from the same identity, so the reduction reuses
+// the shared `reduceGhash` — the carryless-multiply backends fold the high half
+// identically and cannot drift.
 Value mulGhashClmad(ImplicitLocOpBuilder &b, Value lhsI128, Value rhsI128) {
   auto i64Ty = b.getI64Type();
   auto i128Ty = b.getIntegerType(128);
@@ -92,14 +91,25 @@ Value mulGhashClmad(ImplicitLocOpBuilder &b, Value lhsI128, Value rhsI128) {
 
   Value z = arith::ConstantIntOp::create(b, 0, 64);
 
-  Value r0 = emitClmad(b, a0, b0, z, /*isHi=*/false);
-  Value t1 = emitClmad(b, a1, b0, z, /*isHi=*/false);
-  t1 = emitClmad(b, a0, b1, t1, /*isHi=*/false);
-  Value r1 = emitClmad(b, a0, b0, t1, /*isHi=*/true);
-  Value t2 = emitClmad(b, a1, b0, z, /*isHi=*/true);
-  t2 = emitClmad(b, a0, b1, t2, /*isHi=*/true);
-  Value r2 = emitClmad(b, a1, b1, t2, /*isHi=*/false);
-  Value r3 = emitClmad(b, a1, b1, z, /*isHi=*/true);
+  Value aXor = arith::XOrIOp::create(b, a0, a1);
+  Value bXor = arith::XOrIOp::create(b, b0, b1);
+
+  Value llLo = emitClmad(b, a0, b0, z, /*isHi=*/false);
+  Value llHi = emitClmad(b, a0, b0, z, /*isHi=*/true);
+  Value hhLo = emitClmad(b, a1, b1, z, /*isHi=*/false);
+  Value hhHi = emitClmad(b, a1, b1, z, /*isHi=*/true);
+
+  // The `^ ll ^ hh` half of the cross term rides clmad's accumulate operand;
+  // the other half is these two XORs.
+  Value foldLo = arith::XOrIOp::create(b, llLo, hhLo);
+  Value foldHi = arith::XOrIOp::create(b, llHi, hhHi);
+  Value midLo = emitClmad(b, aXor, bXor, foldLo, /*isHi=*/false);
+  Value midHi = emitClmad(b, aXor, bXor, foldHi, /*isHi=*/true);
+
+  Value r0 = llLo;
+  Value r1 = arith::XOrIOp::create(b, llHi, midLo);
+  Value r2 = arith::XOrIOp::create(b, hhLo, midHi);
+  Value r3 = hhHi;
 
   // Fold the high half down via x¹²⁸ == x⁷ + x² + x + 1.
   auto [r3Red, r3Overflow] = reduceGhash(b, r3);
@@ -278,7 +288,8 @@ struct ConvertTowerMulToClmad : public OpRewritePattern<MulOp> {
 
       Value resultN;
       if (level == 7) {
-        // 128-bit: convert into the GHASH basis and reuse its 8-clmad product.
+        // 128-bit: route through the GHASH basis so level 7 shares
+        // mulGhashClmad instead of carrying a second product schedule.
         Value lhsFlat =
             emitBitMatrix128(b, lhsN, kTowerToFlat128Lo, kTowerToFlat128Hi);
         Value rhsFlat =

--- a/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.td
+++ b/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.td
@@ -27,7 +27,7 @@ def SpecializeBinaryFieldToNVPTX : Pass<"specialize-binary-field-to-nvptx", "Mod
 
     The GPU analog of `SpecializeBinaryFieldToX86` (PCLMULQDQ) and
 `SpecializeBinaryFieldToARM` (PMULL). Every flat multiply becomes a
-    clmad product: `bf<7, ghash>` a 128x128 schoolbook of eight
+    clmad product: `bf<7, ghash>` a 128x128 Karatsuba product of six
     `clmad.{lo,hi}.u64` plus the shared GHASH reduction, `bf<3, aes>` and
     every generic/custom `poly<...>` basis up to 32 bits a single
     `clmad.lo` plus two constant-tap folds (the modulus is read off the
@@ -56,6 +56,15 @@ def SpecializeBinaryFieldToNVPTX : Pass<"specialize-binary-field-to-nvptx", "Mod
 
     The emitted `clmad` requires a CUDA-13.3+ ptxas to assemble; on older
     toolchains leave this pass disabled and the portable path is used.
+
+    Performance notes:
+    - The GHASH product uses Karatsuba (3 sub-products, not 4), trading two
+      clmad for six XOR. Measured 1.27x on a GHASH mul-accumulate chain and
+      +2.7% on a whole GPU prove, because the multiply is clmad-issue-bound
+      on sm_120 and integer work issued alongside it is effectively free.
+      That premise is what makes the trade one-directional — re-measure
+      before assuming it holds on a target whose carryless-multiply pipe is
+      not the bottleneck.
   }];
 
   let dependentDialects = [

--- a/tests/Dialect/Field/specialize_binary_field_to_nvptx.mlir
+++ b/tests/Dialect/Field/specialize_binary_field_to_nvptx.mlir
@@ -15,7 +15,7 @@
 
 // Test clmad specialization for binary field multiplication.
 //
-// clmad computes a carryless product: flat bases multiply directly (ghash 8
+// clmad computes a carryless product: flat bases multiply directly (ghash 6
 // clmads, generic 3 or 5), and tower levels 4..7 convert through the
 // canonical flat basis of their width (TowerFlatBasis.h) around it.
 
@@ -40,11 +40,15 @@
 !F64 = !field.bf<6, flat>    // GF(2⁶⁴), canonical flat basis
 !RS8 = !field.bf<3, poly<0x11d>> // GF(2⁸), custom modulus
 
-// GHASH-basis scalar multiplication should use clmad: eight clmad.{lo,hi}.u64
-// build the 128×128 carryless product, then the shared GHASH reduction.
+// GHASH-basis scalar multiplication should use clmad: six clmad.{lo,hi}.u64
+// build the Karatsuba 128×128 carryless product, then the shared GHASH
+// reduction. The trailing NOT makes the count an exact bound rather than a
+// lower one — COUNT-6 alone still passes on a regression to the 4-sub-product
+// schedule, which is the thing worth catching (see `mulGhashClmad`).
 // CHECK-CLMAD-LABEL: @test_ghash_mul
 // CHECK-CLMAD: builtin.unrealized_conversion_cast
-// CHECK-CLMAD-COUNT-8: llvm.inline_asm{{.*}}clmad{{.*}}u64
+// CHECK-CLMAD-COUNT-6: llvm.inline_asm{{.*}}clmad{{.*}}u64
+// CHECK-CLMAD-NOT: llvm.inline_asm{{.*}}clmad{{.*}}u64
 // CHECK-CLMAD: builtin.unrealized_conversion_cast
 // CHECK-OFF-LABEL: @test_ghash_mul
 // CHECK-OFF: field.mul
@@ -97,9 +101,10 @@ func.func @test_aes_mul(%a: !AES, %b: !AES) -> !AES {
 }
 
 // BF128 (tower) converts into the GHASH basis (128-wide ladders) around the
-// 8-clmad GHASH product.
+// 6-clmad Karatsuba GHASH product.
 // CHECK-CLMAD-LABEL: @test_bf128_mul
-// CHECK-CLMAD-COUNT-8: llvm.inline_asm{{.*}}clmad{{.*}}u64
+// CHECK-CLMAD-COUNT-6: llvm.inline_asm{{.*}}clmad{{.*}}u64
+// CHECK-CLMAD-NOT: llvm.inline_asm{{.*}}clmad{{.*}}u64
 // CHECK-CLMAD-NOT: field.mul
 // CHECK-OFF-LABEL: @test_bf128_mul
 // CHECK-OFF: field.mul

--- a/tests/Dialect/Field/specialize_binary_field_to_nvptx_shaped_clmad.mlir
+++ b/tests/Dialect/Field/specialize_binary_field_to_nvptx_shaped_clmad.mlir
@@ -71,11 +71,12 @@ func.func @vector_aes_mul(%a: vector<2x!AES>, %b: vector<2x!AES>) -> vector<2x!A
   return %c : vector<2x!AES>
 }
 
-// Shaped GHASH (tensor): eight clmad.{lo,hi}.u64 build the 128×128 product per
-// lane, so 16 clmad across the 2 lanes.
+// Shaped GHASH (tensor): six clmad.{lo,hi}.u64 build the Karatsuba 128×128
+// product per lane, so 12 clmad across the 2 lanes.
 // CHECK-CLMAD-LABEL: @tensor_ghash_mul
 // CHECK-CLMAD: tensor.extract
-// CHECK-CLMAD-COUNT-16: llvm.inline_asm{{.*}}clmad{{.*}}u64
+// CHECK-CLMAD-COUNT-12: llvm.inline_asm{{.*}}clmad{{.*}}u64
+// CHECK-CLMAD-NOT: llvm.inline_asm{{.*}}clmad{{.*}}u64
 // CHECK-CLMAD: tensor.from_elements
 // CHECK-OFF-LABEL: @tensor_ghash_mul
 // CHECK-OFF: field.mul
@@ -144,10 +145,11 @@ func.func @vector_bf32_mul(%a: vector<2x!BF32>, %b: vector<2x!BF32>) -> vector<2
   return %c : vector<2x!BF32>
 }
 
-// Tower level 7 converts into the GHASH basis, so each lane is the 8-clmad
-// GHASH product between 128-wide ladders.
+// Tower level 7 converts into the GHASH basis, so each lane is the 6-clmad
+// Karatsuba GHASH product between 128-wide ladders.
 // CHECK-CLMAD-LABEL: @tensor_bf128_mul
-// CHECK-CLMAD-COUNT-16: llvm.inline_asm{{.*}}clmad{{.*}}u64
+// CHECK-CLMAD-COUNT-12: llvm.inline_asm{{.*}}clmad{{.*}}u64
+// CHECK-CLMAD-NOT: llvm.inline_asm{{.*}}clmad{{.*}}u64
 // CHECK-CLMAD-NOT: field.mul
 // CHECK-OFF-LABEL: @tensor_bf128_mul
 // CHECK-OFF: field.mul


### PR DESCRIPTION
## Description

NVPTX was the last carryless-multiply path still forming its 128x128 GHASH
product from four sub-products. x86 (PCLMULQDQ), ARM (PMULL), and the portable
`emitGhashMul` all already use Karatsuba's three — NVPTX diverged because it was
ported from flock's hand-written clmad PTX kernel rather than derived from its
siblings, and its own comment said so. This closes that gap; it is not a new
scheme, and the identity is already in-tree three times.

Karatsuba trades multiplies for adds, which is not automatically a win — on a
machine with cheap carryless multiplies it can lose. What makes it
one-directional here is that the multiply is **clmad-issue-bound on sm_120**, so
integer work issued alongside is effectively free. That was measured, not
assumed: on an isolated GHASH mul-accumulate chain, throughput tracks clmad
count to within 2.6% across four schedules, while deleting half the reduction's
ALU ops from the same loop moved 0.3% (noise). Dropping 8 -> 6 clmad gives 1.27x
there.

End to end on a blake3 m32 GPU prove (RTX 5090, idle card): **71.21 -> 69.35 ms,
+2.7%**. Four fresh processes per arm, alternating so drift cannot load onto one
arm; the distributions are non-overlapping, which matters because a whole-prove
wall spreads several percent run-to-run and a single-shot delta this size would
not be distinguishable from noise. Both plugins were built from the same tree and
config, differing only by this schedule, and the baseline arm reproduces the
project's recorded m32 number. Proof-level oracle gates stay byte-identical.

Back-solving those two figures puts GHASH multiply at ~12% of that prove's wall,
which is the useful ceiling for pricing future multiply-side work.

Scope is NVPTX only. The reduction is untouched and still shared with x86/ARM, so
all four paths keep producing the same r0..r3 limbs and cannot drift.

Two things a reviewer may want to push back on, flagged rather than buried:

- The comment now says the trade is two clmad for **six** XOR. That is the honest
  count — the previous schedule folded every cross term through clmad's
  accumulate operand and emitted none.
- Roughly two of those XORs are recoverable by folding more into the idle
  accumulate slots. Deliberately not done: it is worth ~0.05% by the calibration
  above, deepens the clmad->clmad chain, and would make this backend diverge
  further from the three that already share this shape.

## Related Issues/PRs

Follows #415 (shaped flat clmad) and #392 (GHASH clmad specialization), which
introduced the schedule this replaces. No tracking issue in this repo — the work
is tracked on the flock-zorch board, where the measurements and the refuted
alternative (deferring the modular reduction, +0.3%) are recorded.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline