### PR TITLE
fix(mod_arith): splat reducer constants over shaped operand types

### DIFF
--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -1185,8 +1185,13 @@ struct ConvertMul : public BoundMapPattern<MulOp> {
       // Logic: A * B = H * 2ᵏ + L == H + L (mod 2ᵏ - 1)
 
       // 1. Reduce
-      Value kConst =
-          arith::ConstantOp::create(b, wideType, b.getIntegerAttr(wideType, k));
+      // Build the attr on the element type and splat: wideType is shaped for
+      // shaped operands, and getIntegerAttr on a shaped type crashes (same
+      // fix as SolinasReducer's konst).
+      TypedAttr kAttr = b.getIntegerAttr(getElementTypeOrSelf(wideType), k);
+      if (auto shaped = dyn_cast<ShapedType>(wideType))
+        kAttr = SplatElementsAttr::get(shaped, kAttr);
+      Value kConst = arith::ConstantOp::create(b, wideType, kAttr);
 
       // hi = mul >> k
       Value hi = arith::ShRUIOp::create(b, mul, kConst);

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -1184,14 +1184,8 @@ struct ConvertMul : public BoundMapPattern<MulOp> {
       // === Mersenne Reduction Strategy ===
       // Logic: A * B = H * 2ᵏ + L == H + L (mod 2ᵏ - 1)
 
-      // 1. Reduce
-      // Build the attr on the element type and splat: wideType is shaped for
-      // shaped operands, and getIntegerAttr on a shaped type crashes (same
-      // fix as SolinasReducer's konst).
-      TypedAttr kAttr = b.getIntegerAttr(getElementTypeOrSelf(wideType), k);
-      if (auto shaped = dyn_cast<ShapedType>(wideType))
-        kAttr = SplatElementsAttr::get(shaped, kAttr);
-      Value kConst = arith::ConstantOp::create(b, wideType, kAttr);
+      // 1. Reduce (wideType may be shaped, so splat)
+      Value kConst = createScalarOrSplatConstant(b, b.getLoc(), wideType, k);
 
       // hi = mul >> k
       Value hi = arith::ShRUIOp::create(b, mul, kConst);

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/BUILD.bazel
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/BUILD.bazel
@@ -55,6 +55,7 @@ prime_ir_cc_library(
         "//prime_ir/Dialect/ModArith/IR:ModArith",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:ArithUtils",
         "@llvm-project//mlir:IR",
         "@zk_dtypes//zk_dtypes:goldilocks",
     ],

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/SolinasReducer.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/SolinasReducer.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/TypeUtilities.h"
 #include "prime_ir/Dialect/ModArith/IR/ModArithTypes.h" // IWYU pragma: keep
 #include "zk_dtypes/include/field/goldilocks/goldilocks.h"
 
@@ -37,8 +38,15 @@ SolinasReducer::SolinasReducer(ImplicitLocOpBuilder &b,
 
 Value SolinasReducer::reduce(Value lo, Value hi, bool lazy) {
   Type t = lo.getType();
+  // `t` may be a shaped (vector/tensor) i64 on the CPU pipeline;
+  // getIntegerAttr on a shaped type walks into FloatType::getWidth and
+  // crashes, so build the scalar attr on the element type and splat it
+  // (same idiom as MontReducer's shaped-type constants).
   auto konst = [&](uint64_t v) {
-    return arith::ConstantOp::create(b, t, b.getIntegerAttr(t, v));
+    TypedAttr attr = b.getIntegerAttr(getElementTypeOrSelf(t), v);
+    if (auto shaped = dyn_cast<ShapedType>(t))
+      attr = SplatElementsAttr::get(shaped, attr);
+    return arith::ConstantOp::create(b, t, attr);
   };
   // ε = 2^32 - 1 = 2^64 mod p. With hi = hi_hi·2^32 + hi_lo and the
   // congruences 2^64 ≡ ε, 2^96 ≡ -1 (mod p):

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/SolinasReducer.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/SolinasReducer.cpp
@@ -17,9 +17,9 @@ limitations under the License.
 
 #include "llvm/ADT/APInt.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/TypeUtilities.h"
 #include "prime_ir/Dialect/ModArith/IR/ModArithTypes.h" // IWYU pragma: keep
 #include "zk_dtypes/include/field/goldilocks/goldilocks.h"
 
@@ -37,16 +37,11 @@ SolinasReducer::SolinasReducer(ImplicitLocOpBuilder &b,
 }
 
 Value SolinasReducer::reduce(Value lo, Value hi, bool lazy) {
+  // `t` may be shaped (the CPU pipeline hands the reducer vector/tensor i64).
+  // The APInt overload keeps p > INT64_MAX exact.
   Type t = lo.getType();
-  // `t` may be a shaped (vector/tensor) i64 on the CPU pipeline;
-  // getIntegerAttr on a shaped type walks into FloatType::getWidth and
-  // crashes, so build the scalar attr on the element type and splat it
-  // (same idiom as MontReducer's shaped-type constants).
   auto konst = [&](uint64_t v) {
-    TypedAttr attr = b.getIntegerAttr(getElementTypeOrSelf(t), v);
-    if (auto shaped = dyn_cast<ShapedType>(t))
-      attr = SplatElementsAttr::get(shaped, attr);
-    return arith::ConstantOp::create(b, t, attr);
+    return createScalarOrSplatConstant(b, b.getLoc(), t, APInt(64, v));
   };
   // ε = 2^32 - 1 = 2^64 mod p. With hi = hi_hi·2^32 + hi_lo and the
   // congruences 2^64 ≡ ε, 2^96 ≡ -1 (mod p):

--- a/tests/Dialect/ModArith/mod_arith_to_arith.mlir
+++ b/tests/Dialect/ModArith/mod_arith_to_arith.mlir
@@ -413,3 +413,22 @@ func.func @test_lower_sub_goldilocks_feeds_mul(%a: !Gsub, %b: !Gsub, %c: !Gsub) 
   %r = mod_arith.mul %s, %c : !Gsub
   return %r : !Gsub
 }
+
+// -----
+
+// Regression: the Solinas reducer's constants must splat over a shaped
+// operand. A tensor-typed Goldilocks square used to crash the lowering:
+// getIntegerAttr received the shaped type itself and walked into
+// FloatType::getWidth (the CPU fusion pipeline hands the reducer shaped
+// i64 values; the GPU pipeline scalarizes first, which hid the crash).
+!Gv = !mod_arith.int<18446744069414584321 : i64>
+!Gvec = tensor<4x!Gv>
+// CHECK-LABEL: @test_lower_square_goldilocks_shaped
+func.func @test_lower_square_goldilocks_shaped(%lhs : !Gvec) -> !Gvec {
+  // CHECK-NOT: mod_arith.square
+  // CHECK:      arith.mului_extended %{{.*}}, %{{.*}} : tensor<4xi64>
+  // CHECK:      %[[RES:.*]] = arith.minui %{{.*}}, %{{.*}} : tensor<4xi64>
+  // CHECK:      return %[[RES]] : tensor<4xi64>
+  %res = mod_arith.square %lhs : !Gvec
+  return %res : !Gvec
+}

--- a/tests/Dialect/ModArith/mod_arith_to_arith.mlir
+++ b/tests/Dialect/ModArith/mod_arith_to_arith.mlir
@@ -417,18 +417,34 @@ func.func @test_lower_sub_goldilocks_feeds_mul(%a: !Gsub, %b: !Gsub, %c: !Gsub) 
 // -----
 
 // Regression: the Solinas reducer's constants must splat over a shaped
-// operand. A tensor-typed Goldilocks square used to crash the lowering:
-// getIntegerAttr received the shaped type itself and walked into
-// FloatType::getWidth (the CPU fusion pipeline hands the reducer shaped
-// i64 values; the GPU pipeline scalarizes first, which hid the crash).
-!Gv = !mod_arith.int<18446744069414584321 : i64>
-!Gvec = tensor<4x!Gv>
+// operand — a tensor-typed Goldilocks square used to crash the lowering
+// (the CPU fusion pipeline hands the reducer shaped i64; the GPU pipeline
+// scalarizes first, which hid it).
+!Gsq = !mod_arith.int<18446744069414584321 : i64>
+!Gsqv = tensor<4x!Gsq>
 // CHECK-LABEL: @test_lower_square_goldilocks_shaped
-func.func @test_lower_square_goldilocks_shaped(%lhs : !Gvec) -> !Gvec {
+func.func @test_lower_square_goldilocks_shaped(%lhs : !Gsqv) -> !Gsqv {
   // CHECK-NOT: mod_arith.square
   // CHECK:      arith.mului_extended %{{.*}}, %{{.*}} : tensor<4xi64>
   // CHECK:      %[[RES:.*]] = arith.minui %{{.*}}, %{{.*}} : tensor<4xi64>
   // CHECK:      return %[[RES]] : tensor<4xi64>
-  %res = mod_arith.square %lhs : !Gvec
-  return %res : !Gvec
+  %res = mod_arith.square %lhs : !Gsqv
+  return %res : !Gsqv
+}
+
+// -----
+
+// Regression: the Mersenne fast path's shift-amount constant must also
+// splat over a shaped operand (same crash class as the Solinas reducer).
+!M31 = !mod_arith.int<2147483647 : i32>
+!M31v = tensor<4x!M31>
+// CHECK-LABEL: @test_lower_mul_mersenne_shaped
+func.func @test_lower_mul_mersenne_shaped(%lhs : !M31v, %rhs : !M31v) -> !M31v {
+  // CHECK-NOT: mod_arith.mul
+  // CHECK:      arith.muli %{{.*}}, %{{.*}} : tensor<4xi64>
+  // CHECK:      arith.shrui %{{.*}}, %{{.*}} : tensor<4xi64>
+  // CHECK:      %[[RES:.*]] = arith.trunci %{{.*}} : tensor<4xi64> to tensor<4xi32>
+  // CHECK:      return %[[RES]] : tensor<4xi32>
+  %res = mod_arith.mul %lhs, %rhs : !M31v
+  return %res : !M31v
 }


### PR DESCRIPTION
## What

`SolinasReducer::reduce` built its chain constants with
`getIntegerAttr(t, v)` where `t` is the operand type. On a shaped
(vector/tensor) operand — what the CPU fusion pipeline hands the
`ModArithToArith` lowering — `getIntegerAttr` walks into
`FloatType::getWidth()` on the shaped type and segfaults the compiler.
The GPU pipeline scalarizes before this lowering, which is why device
compiles never hit it.

Fix: build the attr on `getElementTypeOrSelf` and splat for shaped
types — the idiom `MontReducer`'s shaped-type constants already use.
The Mersenne fast path's shift-amount constant had the identical
pattern (its `wideType` clones the shaped container via `modulusAttr`);
hardened the same way.

## Impact

This is the crash behind the XLA **CPU** backend segfaulting on every
Goldilocks width-8 Poseidon2 permute compile across the frx dev-wheel
lineage (observed since at least `0.10.1.dev20260729`; device always
fine). Downstream it is exactly fractalyze/zisk-zorch#89's ten CPU CI
segfaults, and one of the two wheel-side blockers on
fractalyze/zisk-zorch#136. gdb stack from the wheel:
`ConvertSquare` → `SolinasReducer::reduce` → `Builder::getIntegerAttr`
→ `Type::getIntOrFloatBitWidth` → `FloatType::getWidth` → SIGSEGV.

## Test

New shaped-square regression in `mod_arith_to_arith.mlir`
(`tensor<4x!Goldilocks>` `mod_arith.square` through
`-mod-arith-to-arith` — crashed before, lowers to the elementwise
Solinas chain now). Full `//tests/Dialect/ModArith/...` suite: 23/23.
