### PR TITLE
perf(dialect/field): specialize GHASH square on NVPTX and x86

### DIFF
--- a/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.cpp
+++ b/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToNVPTX/SpecializeBinaryFieldToNVPTX.cpp
@@ -67,6 +67,28 @@ Value emitClmad(ImplicitLocOpBuilder &b, Value a, Value bv, Value c,
 // clmad-based GHASH Multiplication
 //===----------------------------------------------------------------------===//
 
+// Fold the 256-bit carryless product limbs r0..r3 (low to high) down to a GHASH
+// field element via x¹²⁸ == x⁷ + x² + x + 1, then repack as i128. Shared by the
+// multiply and the square so the two cannot drift in how they reduce.
+Value reduceGhashProduct(ImplicitLocOpBuilder &b, Value r0, Value r1, Value r2,
+                         Value r3) {
+  auto i128Ty = b.getIntegerType(128);
+  Value sh64 = arith::ConstantIntOp::create(b, 64, 128);
+
+  auto [r3Red, r3Overflow] = reduceGhash(b, r3);
+  r1 = arith::XOrIOp::create(b, r1, r3Red);
+  r2 = arith::XOrIOp::create(b, r2, r3Overflow);
+
+  auto [r2Red, r2Overflow] = reduceGhash(b, r2);
+  r0 = arith::XOrIOp::create(b, r0, r2Red);
+  r1 = arith::XOrIOp::create(b, r1, r2Overflow);
+
+  Value r0Ext = arith::ExtUIOp::create(b, i128Ty, r0);
+  Value r1Ext = arith::ExtUIOp::create(b, i128Ty, r1);
+  Value r1Hi = arith::ShLIOp::create(b, r1Ext, sh64);
+  return arith::OrIOp::create(b, r0Ext, r1Hi);
+}
+
 // Multiply two GHASH-basis i128 values using clmad. Karatsuba — 3 sub-products
 // instead of 4 (cross term a₀b₁ + a₁b₀ = (a₀+a₁)(b₀+b₁) + a₀b₀ + a₁b₁), which
 // trades two clmad for six XOR. Worth it because this multiply is
@@ -79,7 +101,6 @@ Value emitClmad(ImplicitLocOpBuilder &b, Value a, Value bv, Value c,
 // identically and cannot drift.
 Value mulGhashClmad(ImplicitLocOpBuilder &b, Value lhsI128, Value rhsI128) {
   auto i64Ty = b.getI64Type();
-  auto i128Ty = b.getIntegerType(128);
   Value sh64 = arith::ConstantIntOp::create(b, 64, 128);
 
   Value a0 = arith::TruncIOp::create(b, i64Ty, lhsI128);
@@ -106,25 +127,30 @@ Value mulGhashClmad(ImplicitLocOpBuilder &b, Value lhsI128, Value rhsI128) {
   Value midLo = emitClmad(b, aXor, bXor, foldLo, /*isHi=*/false);
   Value midHi = emitClmad(b, aXor, bXor, foldHi, /*isHi=*/true);
 
-  Value r0 = llLo;
-  Value r1 = arith::XOrIOp::create(b, llHi, midLo);
-  Value r2 = arith::XOrIOp::create(b, hhLo, midHi);
-  Value r3 = hhHi;
+  return reduceGhashProduct(b, llLo, arith::XOrIOp::create(b, llHi, midLo),
+                            arith::XOrIOp::create(b, hhLo, midHi), hhHi);
+}
 
-  // Fold the high half down via x¹²⁸ == x⁷ + x² + x + 1.
-  auto [r3Red, r3Overflow] = reduceGhash(b, r3);
-  r1 = arith::XOrIOp::create(b, r1, r3Red);
-  r2 = arith::XOrIOp::create(b, r2, r3Overflow);
+// Square a GHASH-basis i128 value. In characteristic 2 the cross term vanishes
+// — a₀·a₁ + a₁·a₀ = 0 — so only the two diagonal sub-products survive: four
+// clmad against the multiply's six.
+//
+// Routing a square through mulGhashClmad would still emit the cross-term clmads
+// and then XOR their result to zero. `clmad` is opaque inline asm, so nothing
+// downstream can prove that and delete them.
+Value squareGhashClmad(ImplicitLocOpBuilder &b, Value valI128) {
+  auto i64Ty = b.getI64Type();
+  Value sh64 = arith::ConstantIntOp::create(b, 64, 128);
 
-  auto [r2Red, r2Overflow] = reduceGhash(b, r2);
-  r0 = arith::XOrIOp::create(b, r0, r2Red);
-  r1 = arith::XOrIOp::create(b, r1, r2Overflow);
+  Value a0 = arith::TruncIOp::create(b, i64Ty, valI128);
+  Value a1 = arith::TruncIOp::create(b, i64Ty,
+                                     arith::ShRUIOp::create(b, valI128, sh64));
+  Value z = arith::ConstantIntOp::create(b, 0, 64);
 
-  // Reassemble the 128-bit result: r0 | (r1 << 64).
-  Value r0Ext = arith::ExtUIOp::create(b, i128Ty, r0);
-  Value r1Ext = arith::ExtUIOp::create(b, i128Ty, r1);
-  Value r1Hi = arith::ShLIOp::create(b, r1Ext, sh64);
-  return arith::OrIOp::create(b, r0Ext, r1Hi);
+  return reduceGhashProduct(b, emitClmad(b, a0, a0, z, /*isHi=*/false),
+                            emitClmad(b, a0, a0, z, /*isHi=*/true),
+                            emitClmad(b, a1, a1, z, /*isHi=*/false),
+                            emitClmad(b, a1, a1, z, /*isHi=*/true));
 }
 
 //===----------------------------------------------------------------------===//
@@ -253,6 +279,35 @@ struct ConvertGhashMulToClmad : public OpRewritePattern<MulOp> {
     };
     return replaceFlatFieldMul(rewriter, op, op.getLhs(), op.getRhs(),
                                mulScalar);
+  }
+};
+
+// `field.square` on a GHASH value gets its own pattern rather than being routed
+// through the multiply with both operands equal, so it can drop the cross-term
+// products (see squareGhashClmad). replaceFlatFieldMul is op-agnostic and takes
+// the input twice; only the scalar callback differs.
+struct ConvertGhashSquareToClmad : public OpRewritePattern<SquareOp> {
+  using OpRewritePattern<SquareOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(SquareOp op,
+                                PatternRewriter &rewriter) const override {
+    auto bfType = dyn_cast<BinaryFieldType>(
+        getElementTypeOrSelf(op.getResult().getType()));
+    if (!bfType || !bfType.isGhash())
+      return failure();
+    Type ghashType = bfType;
+
+    auto squareScalar = [ghashType](ImplicitLocOpBuilder &b, Value val,
+                                    Value) -> Value {
+      auto i128Type = b.getIntegerType(128);
+      Value valI128 =
+          UnrealizedConversionCastOp::create(b, i128Type, val).getResult(0);
+      Value resultI128 = squareGhashClmad(b, valI128);
+      return UnrealizedConversionCastOp::create(b, ghashType, resultI128)
+          .getResult(0);
+    };
+    return replaceFlatFieldMul(rewriter, op, op.getInput(), op.getInput(),
+                               squareScalar);
   }
 };
 
@@ -404,8 +459,9 @@ struct SpecializeBinaryFieldToNVPTX
 
     RewritePatternSet patterns(context);
     if (useClmad) {
-      patterns.add<ConvertGhashMulToClmad, ConvertTowerMulToClmad,
-                   ConvertFlatGenericMulToClmad>(context);
+      patterns.add<ConvertGhashMulToClmad, ConvertGhashSquareToClmad,
+                   ConvertTowerMulToClmad, ConvertFlatGenericMulToClmad>(
+          context);
     }
 
     // Greedy rewriting (not partial conversion) so unmatched field.mul ops

--- a/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToX86/SpecializeBinaryFieldToX86.cpp
+++ b/prime_ir/Dialect/Field/Conversions/SpecializeBinaryFieldToX86/SpecializeBinaryFieldToX86.cpp
@@ -159,13 +159,28 @@ Value mulBF8PackedGFNI(ImplicitLocOpBuilder &b, Value lhs, Value rhs,
 // PCLMULQDQ-based Binary Field Multiplication
 //===----------------------------------------------------------------------===//
 
+// Fold the 256-bit carryless product limbs r0..r3 (low to high) down to a GHASH
+// field element via x¹²⁸ == x⁷ + x² + x + 1, then repack as vec2i64. Shared by
+// the multiply and the square so the two cannot drift in how they reduce.
+Value reduceGhashProduct(ImplicitLocOpBuilder &b, Value r0, Value r1, Value r2,
+                         Value r3) {
+  auto vec2i64Type = VectorType::get(2, b.getI64Type());
+
+  auto [r3_red, r3_overflow] = reduceGhash(b, r3);
+  r1 = arith::XOrIOp::create(b, r1, r3_red);
+  r2 = arith::XOrIOp::create(b, r2, r3_overflow);
+
+  auto [r2_red, r2_overflow] = reduceGhash(b, r2);
+  r0 = arith::XOrIOp::create(b, r0, r2_red);
+  r1 = arith::XOrIOp::create(b, r1, r2_overflow);
+
+  return vector::FromElementsOp::create(b, vec2i64Type, ValueRange{r0, r1});
+}
+
 // Multiply two GHASH-basis i128 values (as vector<2xi64>) using PCLMULQDQ.
 // Karatsuba — 3 PCLMULQDQ (the cross term a₀b₁ + a₁b₀ = (a₀+a₁)(b₀+b₁) + ll +
 // hh), then reduce mod x¹²⁸ + x⁷ + x² + x + 1.
 Value mulGhashPCLMULQDQ(ImplicitLocOpBuilder &b, Value lhs, Value rhs) {
-  auto i64Type = b.getI64Type();
-  auto vec2i64Type = VectorType::get(2, i64Type);
-
   // Swap the two 64-bit lanes so each lane of *Xor holds (lo ^ hi).
   Value lhsSwapped =
       vector::ShuffleOp::create(b, lhs, lhs, ArrayRef<int64_t>{1, 0});
@@ -187,22 +202,27 @@ Value mulGhashPCLMULQDQ(ImplicitLocOpBuilder &b, Value lhs, Value rhs) {
   Value midLow = vector::ExtractOp::create(b, mid, ArrayRef<int64_t>{0});
   Value midHigh = vector::ExtractOp::create(b, mid, ArrayRef<int64_t>{1});
 
-  // 256-bit product as limbs r0..r3 (low to high).
-  Value r0 = llLow;
-  Value r1 = arith::XOrIOp::create(b, llHigh, midLow);
-  Value r2 = arith::XOrIOp::create(b, hhLow, midHigh);
-  Value r3 = hhHigh;
+  return reduceGhashProduct(b, llLow, arith::XOrIOp::create(b, llHigh, midLow),
+                            arith::XOrIOp::create(b, hhLow, midHigh), hhHigh);
+}
 
-  // Fold the high half down via x¹²⁸ == x⁷ + x² + x + 1.
-  auto [r3_red, r3_overflow] = reduceGhash(b, r3);
-  r1 = arith::XOrIOp::create(b, r1, r3_red);
-  r2 = arith::XOrIOp::create(b, r2, r3_overflow);
+// Square a GHASH-basis vec2i64. In characteristic 2 the cross term vanishes —
+// a₀·a₁ + a₁·a₀ = 0 — so only the two diagonal sub-products survive: two
+// PCLMULQDQ against the multiply's three, and no lane-swap XORs to build the
+// Karatsuba operands.
+//
+// Routing a square through mulGhashPCLMULQDQ would still emit the cross-term
+// product and then XOR its result to zero; the intrinsic is opaque, so nothing
+// downstream can prove that and delete it.
+Value squareGhashPCLMULQDQ(ImplicitLocOpBuilder &b, Value val) {
+  Value ll = emitPCLMULQDQ128(b, val, val, 0x00);
+  Value hh = emitPCLMULQDQ128(b, val, val, 0x11);
 
-  auto [r2_red, r2_overflow] = reduceGhash(b, r2);
-  r0 = arith::XOrIOp::create(b, r0, r2_red);
-  r1 = arith::XOrIOp::create(b, r1, r2_overflow);
-
-  return vector::FromElementsOp::create(b, vec2i64Type, ValueRange{r0, r1});
+  return reduceGhashProduct(
+      b, vector::ExtractOp::create(b, ll, ArrayRef<int64_t>{0}),
+      vector::ExtractOp::create(b, ll, ArrayRef<int64_t>{1}),
+      vector::ExtractOp::create(b, hh, ArrayRef<int64_t>{0}),
+      vector::ExtractOp::create(b, hh, ArrayRef<int64_t>{1}));
 }
 
 //===----------------------------------------------------------------------===//
@@ -297,6 +317,38 @@ struct ConvertGhashMulToPCLMULQDQ : public OpRewritePattern<MulOp> {
   }
 };
 
+// `field.square` on a GHASH value gets its own pattern rather than being routed
+// through the multiply with both operands equal, so it can drop the cross-term
+// product (see squareGhashPCLMULQDQ). replaceFlatFieldMul is op-agnostic and
+// takes the input twice; only the scalar callback differs.
+struct ConvertGhashSquareToPCLMULQDQ : public OpRewritePattern<SquareOp> {
+  using OpRewritePattern<SquareOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(SquareOp op,
+                                PatternRewriter &rewriter) const override {
+    auto bfType = dyn_cast<BinaryFieldType>(
+        getElementTypeOrSelf(op.getResult().getType()));
+    if (!bfType || !bfType.isGhash())
+      return failure();
+    Type ghashType = bfType;
+
+    auto squareScalar = [ghashType](ImplicitLocOpBuilder &b, Value val,
+                                    Value) -> Value {
+      auto i128Type = b.getIntegerType(128);
+      auto vec2i64Type = VectorType::get(2, b.getI64Type());
+      Value valI128 =
+          UnrealizedConversionCastOp::create(b, i128Type, val).getResult(0);
+      Value valVec = LLVM::BitcastOp::create(b, vec2i64Type, valI128);
+      Value resultVec = squareGhashPCLMULQDQ(b, valVec);
+      Value resultI128 = LLVM::BitcastOp::create(b, i128Type, resultVec);
+      return UnrealizedConversionCastOp::create(b, ghashType, resultI128)
+          .getResult(0);
+    };
+    return replaceFlatFieldMul(rewriter, op, op.getInput(), op.getInput(),
+                               squareScalar);
+  }
+};
+
 // Pattern for packed 8-bit binary field squaring using GFNI
 struct ConvertPackedBF8SquareToGFNI : public OpRewritePattern<SquareOp> {
   using OpRewritePattern<SquareOp>::OpRewritePattern;
@@ -357,7 +409,8 @@ struct SpecializeBinaryFieldToX86
     }
 
     if (usePCLMULQDQ) {
-      patterns.add<ConvertGhashMulToPCLMULQDQ>(context);
+      patterns.add<ConvertGhashMulToPCLMULQDQ, ConvertGhashSquareToPCLMULQDQ>(
+          context);
     }
 
     // Use greedy pattern rewriting (not partial conversion)

--- a/tests/Dialect/Field/specialize_binary_field_to_nvptx.mlir
+++ b/tests/Dialect/Field/specialize_binary_field_to_nvptx.mlir
@@ -58,6 +58,24 @@ func.func @test_ghash_mul(%a: !GHASH, %b: !GHASH) -> !GHASH {
   return %c : !GHASH
 }
 
+// Squaring drops the Karatsuba cross term — a₀·a₁ + a₁·a₀ = 0 in characteristic
+// 2 — so it is four clmad against the multiply's six. Same reasoning as above
+// for the trailing NOT: routing a square through mulGhashClmad would still emit
+// the two cross-term clmad and XOR their result to zero, and COUNT-4 alone
+// would still pass.
+// CHECK-CLMAD-LABEL: @test_ghash_square
+// CHECK-CLMAD: builtin.unrealized_conversion_cast
+// CHECK-CLMAD-COUNT-4: llvm.inline_asm{{.*}}clmad{{.*}}u64
+// CHECK-CLMAD-NOT: llvm.inline_asm{{.*}}clmad{{.*}}u64
+// CHECK-CLMAD: builtin.unrealized_conversion_cast
+// CHECK-OFF-LABEL: @test_ghash_square
+// CHECK-OFF: field.square
+// CHECK-OFF-NOT: clmad
+func.func @test_ghash_square(%a: !GHASH) -> !GHASH {
+  %c = field.square %a : !GHASH
+  return %c : !GHASH
+}
+
 // BF32 (tower) multiplies via the flat basis: three clmad.lo.u64 (one product
 // + two reduction folds) between the conversion ladders.
 // CHECK-CLMAD-LABEL: @test_bf32_mul

--- a/tests/Dialect/Field/specialize_binary_field_to_x86.mlir
+++ b/tests/Dialect/Field/specialize_binary_field_to_x86.mlir
@@ -202,6 +202,26 @@ func.func @test_ghash_mul(%a: !GHASH, %b: !GHASH) -> !GHASH {
   return %c : !GHASH
 }
 
+// Squaring drops the Karatsuba cross term — a₀·a₁ + a₁·a₀ = 0 in characteristic
+// 2 — so it is two vpclmulqdq against the multiply's three. The trailing NOT
+// makes that an exact bound: routing a square through the multiply would still
+// emit the third, and a bare positive-match list would not notice.
+// CHECK-GFNI-LABEL: @test_ghash_square
+// CHECK-GFNI: field.square
+// CHECK-GFNI-NOT: llvm.inline_asm
+// CHECK-PCLMULQDQ-LABEL: @test_ghash_square
+// CHECK-PCLMULQDQ: builtin.unrealized_conversion_cast
+// CHECK-PCLMULQDQ-COUNT-2: llvm.inline_asm{{.*}}vpclmulqdq
+// CHECK-PCLMULQDQ-NOT: llvm.inline_asm{{.*}}vpclmulqdq
+// CHECK-PCLMULQDQ: builtin.unrealized_conversion_cast
+// CHECK-ALL-LABEL: @test_ghash_square
+// CHECK-ALL-COUNT-2: llvm.inline_asm{{.*}}vpclmulqdq
+// CHECK-ALL-NOT: llvm.inline_asm{{.*}}vpclmulqdq
+func.func @test_ghash_square(%a: !GHASH) -> !GHASH {
+  %c = field.square %a : !GHASH
+  return %c : !GHASH
+}
+
 // Vector of BF64 should NOT be specialized by this pass (use ARM pass for vectors)
 // CHECK-GFNI-LABEL: @test_bf64_vec_mul
 // CHECK-GFNI: field.mul


### PR DESCRIPTION
## Description

`field.square` on `bf<7, ghash>` had no carryless-multiply pattern on NVPTX or
x86 at all — it fell through to the portable software path and got no clmad /
PCLMULQDQ. ARM was the only backend that specialized it. Found while checking
backend parity after #427.

The interesting part is that a square is not just a multiply with equal operands.
In characteristic 2 the cross term vanishes — `a₀·a₁ + a₁·a₀ = 0` — so only the
two diagonal sub-products survive:

| | multiply | square |
|---|---|---|
| NVPTX | 6 clmad | **4 clmad** |
| x86 | 3 PCLMULQDQ | **2 PCLMULQDQ** |

Routing a square through the multiply (which is what ARM does) still emits the
cross-term products and then XORs their result to zero. Both are opaque inline
asm, so nothing downstream can prove that and delete them — hence a dedicated
pattern rather than reusing the mul with the input passed twice.

The reduction tail was byte-identical between the two multiplies, so it is now a
`reduceGhashProduct` helper in each backend; the multiply and the square share
it and cannot drift in how they fold the high half.

Verified by construction and by execution: the diagonal-only limbs were checked
against the full Karatsuba product over 20k random 128-bit values plus edge
cases, and `ghash_runner.mlir` — which has two `field.square` cases and executes
through the x86 specializer on the host pipeline — passes. The NVPTX square has
no execution test because none can exist without a GPU and a CUDA-13.3 ptxas,
which is a pre-existing gap; it shares the reduction tail and the algebra with
the x86 path that is gated.

ARM is deliberately untouched. The same win applies there, but it wants its own
measurement on ARM hardware rather than a blind edit — flagged rather than done.

## Related Issues/PRs

Follows #427 (Karatsuba for the NVPTX GHASH product), which is where the missing
square specialization surfaced. No tracking issue in this repo; the lineage is on
the flock-zorch board.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline