### PR TITLE
perf(dialect/field): build the portable GHASH clmul from integer multiplies

### DIFF
--- a/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldToArith.cpp
+++ b/prime_ir/Dialect/Field/Conversions/BinaryFieldToArith/BinaryFieldToArith.cpp
@@ -389,7 +389,8 @@ struct ConvertBinaryFieldBitcast : public OpConversionPattern<BitcastOp> {
 // `bf<7, ghash>` is GF(2)[x]/(x¹²⁸ + x⁷ + x² + x + 1) in the monomial basis
 // (NOT the x²+x+α tower of the default `bf<7>`). Only the multiply differs;
 // it is a carryless product reduced mod the GHASH polynomial. This portable
-// lowering emits the carryless multiply as shift-XOR so it runs on targets
+// lowering builds the carryless multiply from integer multiplies (see
+// `emitClmul32`) so it runs on targets
 // without a CLMUL instruction (e.g. GPU); the x86/ARM specializers swap in
 // PCLMULQDQ/PMULL.
 
@@ -397,31 +398,75 @@ Value i64Const(ImplicitLocOpBuilder &b, uint64_t v) {
   return arith::ConstantIntOp::create(b, static_cast<int64_t>(v), 64);
 }
 
-// Portable 64x64 -> (lo, hi) carryless (GF(2)[x]) product, bit-serial shift-XOR
-// (mirrors flock's software clmul64). For bit i of `bv`, XOR in `a << i` (low
-// limb) and `a >> (64 - i)` (high limb); i == 0 contributes nothing to `hi`.
-std::pair<Value, Value> emitClmul64(ImplicitLocOpBuilder &b, Value a,
-                                    Value bv) {
-  Value zero = i64Const(b, 0);
-  Value one = i64Const(b, 1);
-  Value lo = zero;
-  Value hi = zero;
-  for (unsigned i = 0; i < 64; ++i) {
-    Value bShifted = bv;
-    Value aShl = a;
-    if (i != 0) {
-      Value shiftI = i64Const(b, i);
-      bShifted = arith::ShRUIOp::create(b, bv, shiftI);
-      aShl = arith::ShLIOp::create(b, a, shiftI);
-    }
-    Value bit = arith::AndIOp::create(b, bShifted, one);
-    Value mask = arith::SubIOp::create(b, zero, bit); // 0 or all-ones
-    lo = arith::XOrIOp::create(b, lo, arith::AndIOp::create(b, mask, aShl));
-    if (i != 0) {
-      Value aShr = arith::ShRUIOp::create(b, a, i64Const(b, 64 - i));
-      hi = arith::XOrIOp::create(b, hi, arith::AndIOp::create(b, mask, aShr));
+// Portable 32x32 -> 64 carryless (GF(2)[x]) product, built from sixteen
+// integer multiplies. `a` and `bv` are i64 holding values below 2^32.
+//
+// An integer multiply already computes Σ a<<i over the set bits i of b; it
+// differs from a carryless product only in that the partial products carry
+// into each other. Restrict both operands to bits four apart — a & 0x11111111
+// keeps positions 0, 4, 8, ... — and every partial product of that pair lands
+// on a position congruent to (k + j) mod 4. A 32-bit operand contributes at
+// most eight set bits to a group, so at most eight partial products stack on
+// any one output position; eight fits in the four bits separating consecutive
+// positions, so nothing carries into the next one and the position's low bit
+// IS the carryless parity. Masking those bits out and XOR-ing the sixteen
+// group pairs reconstructs the full product exactly.
+//
+// This replaced a bit-serial shift-XOR loop costing ~9 operations per bit,
+// about 1,150 for a 128x128 multiply once Karatsuba had cut four clmul64 to
+// three. Targets that reach this code have no CLMUL to lower onto, so their
+// integer multiplier is idle hardware; spending it costs roughly a fifth of
+// the operations. On GPUs this multiply was the dominant cost of the whole
+// flock prover (fractalyze/xla#491).
+Value emitClmul32(ImplicitLocOpBuilder &b, Value a, Value bv) {
+  // Bits four apart, selected by residue; the slot masks are the same pattern
+  // widened to the 64-bit product.
+  static constexpr uint64_t kGroup[4] = {0x11111111u, 0x22222222u, 0x44444444u,
+                                         0x88888888u};
+  static constexpr uint64_t kSlot[4] = {
+      0x1111111111111111ull, 0x2222222222222222ull, 0x4444444444444444ull,
+      0x8888888888888888ull};
+
+  Value aGroup[4], bGroup[4];
+  for (unsigned k = 0; k < 4; ++k) {
+    aGroup[k] = arith::AndIOp::create(b, a, i64Const(b, kGroup[k]));
+    bGroup[k] = arith::AndIOp::create(b, bv, i64Const(b, kGroup[k]));
+  }
+
+  Value acc;
+  for (unsigned k = 0; k < 4; ++k) {
+    for (unsigned j = 0; j < 4; ++j) {
+      Value prod = arith::MulIOp::create(b, aGroup[k], bGroup[j]);
+      Value slot =
+          arith::AndIOp::create(b, prod, i64Const(b, kSlot[(k + j) % 4]));
+      acc = acc ? arith::XOrIOp::create(b, acc, slot) : slot;
     }
   }
+  return acc;
+}
+
+// Portable 64x64 -> (lo, hi) carryless product: Karatsuba over three
+// `emitClmul32`, the same three-instead-of-four split `emitGhashMul` applies
+// one level up.
+std::pair<Value, Value> emitClmul64(ImplicitLocOpBuilder &b, Value a,
+                                    Value bv) {
+  Value lowMask = i64Const(b, 0xFFFFFFFFull);
+  Value sh32 = i64Const(b, 32);
+  Value a0 = arith::AndIOp::create(b, a, lowMask);
+  Value a1 = arith::ShRUIOp::create(b, a, sh32);
+  Value b0 = arith::AndIOp::create(b, bv, lowMask);
+  Value b1 = arith::ShRUIOp::create(b, bv, sh32);
+
+  Value ll = emitClmul32(b, a0, b0);
+  Value hh = emitClmul32(b, a1, b1);
+  Value mid = emitClmul32(b, arith::XOrIOp::create(b, a0, a1),
+                          arith::XOrIOp::create(b, b0, b1));
+  // cross = mid + ll + hh = a₀b₁ + a₁b₀, straddling the 32-bit boundary.
+  Value cross = arith::XOrIOp::create(b, arith::XOrIOp::create(b, mid, ll), hh);
+  Value lo =
+      arith::XOrIOp::create(b, ll, arith::ShLIOp::create(b, cross, sh32));
+  Value hi =
+      arith::XOrIOp::create(b, hh, arith::ShRUIOp::create(b, cross, sh32));
   return {lo, hi};
 }
 

--- a/tests/Dialect/Field/ghash_runner.mlir
+++ b/tests/Dialect/Field/ghash_runner.mlir
@@ -176,12 +176,64 @@ func.func @test_ghash_inverse_zero() {
 }
 // CHECK: [1]
 
+// Worst case for the integer-multiply construction in `emitClmul32`: with
+// every bit set, each output position takes the maximum eight stacked partial
+// products, so this is what fails first if the four-bit spacing between
+// positions were not enough to contain them.
+// (2^128-1)^2 = 0x5555555555555555555555555555402f.
+func.func @test_ghash_mul_all_ones() {
+  %ones = arith.constant -1 : i128
+  %a = field.bitcast %ones : i128 -> !G
+  %c = field.mul %a, %a : !G
+
+  %i = field.bitcast %c : !G -> i128
+  %want = arith.constant 113427455640312821154458202477256065071 : i128
+  func.call @check_i128_eq(%i, %want) : (i128, i128) -> ()
+  return
+}
+// CHECK: [1]
+
+// x^127 * x^127 = x^254, the deepest reduction a 256-bit product can need —
+// it folds twice before landing. = 0xc0000000000000000000000000001067.
+func.func @test_ghash_mul_top_bit() {
+  %c127 = arith.constant 170141183460469231731687303715884105728 : i128
+  %a = field.bitcast %c127 : i128 -> !G
+  %c = field.mul %a, %a : !G
+
+  %i = field.bitcast %c : !G -> i128
+  %want = arith.constant 255211775190703847597530955573826162791 : i128
+  func.call @check_i128_eq(%i, %want) : (i128, i128) -> ()
+  return
+}
+// CHECK: [1]
+
+// A full-width pair with no structure, so a construction that happens to be
+// right on sparse or repetitive inputs still has to be right here.
+// 0x0123456789abcdeffedcba9876543210 * 0xdeadbeefcafebabe1337c0de5ca1ab1e
+// = 0x958352597e5280557dd1e70e821122f5.
+func.func @test_ghash_mul_full_width() {
+  %ca = arith.constant 1512366075204170947332355369683137040 : i128
+  %cb = arith.constant 295990755076957304699463973005254830878 : i128
+  %a = field.bitcast %ca : i128 -> !G
+  %b = field.bitcast %cb : i128 -> !G
+  %c = field.mul %a, %b : !G
+
+  %i = field.bitcast %c : !G -> i128
+  %want = arith.constant 198736832508409339883152769906835006197 : i128
+  func.call @check_i128_eq(%i, %want) : (i128, i128) -> ()
+  return
+}
+// CHECK: [1]
+
 func.func @main() {
   func.call @test_ghash_mul() : () -> ()
   func.call @test_ghash_square() : () -> ()
   func.call @test_ghash_one() : () -> ()
   func.call @test_ghash_reduce() : () -> ()
   func.call @test_ghash_square_reduce() : () -> ()
+  func.call @test_ghash_mul_all_ones() : () -> ()
+  func.call @test_ghash_mul_top_bit() : () -> ()
+  func.call @test_ghash_mul_full_width() : () -> ()
   func.call @test_ghash_inverse_one() : () -> ()
   func.call @test_ghash_inverse_roundtrip() : () -> ()
   func.call @test_ghash_inverse_all_ones() : () -> ()


### PR DESCRIPTION
## What

The portable GHASH multiply in `BinaryFieldToArith` emitted a bit-serial shift-XOR loop per 64×64 carryless product — ~9 operations per bit, about 1,150 for a 128×128 multiply once Karatsuba had already cut four `clmul64` to three.

The targets that reach this code are exactly the ones with no CLMUL instruction to lower onto (x86/ARM/NVPTX all swap in their own). On GPUs that made this multiply the dominant cost of the entire flock prover — 45% of the prove at m=28 (fractalyze/xla#491).

## How

An integer multiply already computes `Σ a<<i` over the set bits `i` of `b`. It differs from a carryless product only in that the partial products carry into each other. So stop the carries:

- Restrict both operands to bits four apart (`a & 0x11111111` keeps positions 0, 4, 8, …). Every partial product of a group pair then lands on a position ≡ `(k+j) mod 4`.
- A 32-bit operand puts at most **eight** set bits in a group, so at most eight partial products stack on any one output position.
- Eight fits in the four bits separating consecutive positions, so nothing carries into the next one and the position's low bit **is** the carryless parity.
- Mask those bits out of each of the sixteen group products and XOR — that is the exact product.

`emitClmul64` becomes Karatsuba over three `emitClmul32`, the same three-instead-of-four split `emitGhashMul` already applies one level up. Those targets' integer multiplier was idle hardware; spending it costs roughly a fifth of the operations.

## Measured

Apple M4 Pro through XLA's Metal backend. Marginal cost of one GF(2^128) multiply in a 2^22-element elementwise kernel, from the k-slope (dependent and independent chains agree, so this is throughput not latency):

**11.65 ns/element → 0.45 ns/element.**

flock-zorch blake3, end to end:

| m | wall before | wall after | hash/s before | hash/s after |
|---|---|---|---|---|
| 22 | 202.1 ms | 93.7 ms | 1,267 | 2,732 |
| 26 | 478.1 ms | 185.0 ms | 8,567 | 22,142 |
| 28 | 1,653.9 ms | 466.4 ms | 9,907 | **35,130** |

The `zerocheck` phase alone goes 1,144 ms → 215 ms at m=28.

## Correctness

- `blake3_ligerito_oracle_test` full-proof byte gate: **PASS on Metal and on CPU** (18/18 sections each). The wire is unchanged.
- All 70 `//tests/Dialect/Field/...` targets pass.
- Three new `ghash_runner` cases, chosen for what the construction actually rests on rather than for coverage: all-ones squared is the worst case for the carry-containment bound (every position takes its maximum eight stacked products), x^127 squared is the deepest reduction a 256-bit product can need, and an unstructured full-width pair catches a construction that is only right on sparse or repetitive inputs.
- Negative control: dropping one bit from a single group mask fails the new cases, so they are a real gate and not a tautology.

Before this landed, the same construction was prototyped at the frx array level and validated bit-exactly against the native ghash multiply over 4.19M random inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)