### PR TITLE
fix(dialect/mod_arith): correct multi-limb Montgomery reduction and its derived constants

### DIFF
--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/MontReducer.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/MontReducer.cpp
@@ -166,21 +166,13 @@ Value MontReducer::reduceSingleLimb(Value tLow, Value tHigh, bool lazy) {
 Value MontReducer::reduceMultiLimb(Value tLow, Value tHigh, bool lazy) {
   TypedAttr nPrimeAttr = montAttr.getNPrime();
 
-  // Retrieve the modulus bitwidth.
-  const unsigned modBitWidth =
-      cast<IntegerType>(getElementTypeOrSelf(modAttr.getType())).getWidth();
-
   // Compute number of limbs.
   const unsigned limbWidth = montAttr.getLimbWidth();
   const unsigned numLimbs = montAttr.getNumLimbs();
 
-  TypedAttr bInvAttr = montAttr.getBInv();
   Type limbType = nPrimeAttr.getType();
   TypedAttr limbWidthAttr =
       b.getIntegerAttr(getElementTypeOrSelf(tLow), limbWidth);
-  TypedAttr limbMaskAttr =
-      b.getIntegerAttr(getElementTypeOrSelf(tLow),
-                       APInt::getAllOnes(limbWidth).zext(modBitWidth));
   TypedAttr limbShiftAttr =
       b.getIntegerAttr(getElementTypeOrSelf(tLow), (numLimbs - 1) * limbWidth);
   TypedAttr oneAttr = b.getIntegerAttr(getElementTypeOrSelf(tLow), 1);
@@ -192,98 +184,106 @@ Value MontReducer::reduceMultiLimb(Value tLow, Value tHigh, bool lazy) {
     limbType = shapedType.cloneWith(std::nullopt, limbType);
     nPrimeAttr = SplatElementsAttr::get(cast<ShapedType>(limbType), nPrimeAttr);
     limbWidthAttr = SplatElementsAttr::get(shapedType, limbWidthAttr);
-    limbMaskAttr = SplatElementsAttr::get(shapedType, limbMaskAttr);
     limbShiftAttr = SplatElementsAttr::get(shapedType, limbShiftAttr);
     modAttrLocal = isa<VectorType>(modAttrLocal.getType())
                        ? modAttrLocal
                        : SplatElementsAttr::get(shapedType, modAttrLocal);
-    bInvAttr = SplatElementsAttr::get(shapedType, bInvAttr);
     oneAttr = SplatElementsAttr::get(shapedType, oneAttr);
   }
 
   // Create constants for the Montgomery reduction.
   auto nPrimeConst = arith::ConstantOp::create(b, nPrimeAttr);
   auto limbWidthConst = arith::ConstantOp::create(b, limbWidthAttr);
-  auto limbMaskConst = arith::ConstantOp::create(b, limbMaskAttr);
   auto limbShiftConst = arith::ConstantOp::create(b, limbShiftAttr);
   auto modConst = arith::ConstantOp::create(b, modAttrLocal);
-  auto bInvConst = arith::ConstantOp::create(b, bInvAttr);
   auto oneConst = arith::ConstantOp::create(b, oneAttr);
 
   auto noOverflow = arith::IntegerOverflowFlagsAttr::get(
       b.getContext(),
       arith::IntegerOverflowFlags::nuw | arith::IntegerOverflowFlags::nsw);
 
-  // Because the number of limbs (`numLimbs`) is known at compile time, we can
-  // unroll the loop as a straight-line chain of operations.
-  // The result of the `i`th iteration is `T` * b⁻¹ mod n.
-  for (unsigned i = 0; i < numLimbs - 1; ++i) {
-    // Shift `T` right by `limbWidth`.
-    Value freeCoeff = arith::AndIOp::create(b, tLow, limbMaskConst);
+  // Standard per-limb REDC, unrolled (`numLimbs` is a compile-time constant).
+  // Each iteration adds `m·n` with `m = (T mod b)·nPrime mod b` — the unique
+  // multiple of `n` that zeroes T's lowest limb — then shifts T right one
+  // limb. The result is V = (T + n·Σᵢ mᵢbⁱ)/2ʷ < T/2ʷ + n ≤ 2n under the
+  // REDC precondition T < n·2ʷ (callers pre-reduce operands to guarantee it).
+  //
+  // Do NOT replace the per-iteration `m·n` with the historical shift-then-add
+  // `t₀·(b⁻¹ mod n)` variant: its result bound is V < T/2ʷ + bInv + n, and
+  // bInv is an arbitrary constant in [0, n). For moduli where bInv is large
+  // (e.g. the BLS12-381 scalar field, bInv ≈ n) V exceeds both 2n and 2ʷ,
+  // which silently truncates and breaks the [0, 2n) result contract that the
+  // lazy-reduction bound tracking and the final conditional subtraction rely
+  // on. That variant shipped and miscompiled (p-1)² to 0 instead of 1 for
+  // every full-width modulus (fractalyze/xla#542); the case is pinned by
+  // tests/Dialect/ModArith/mod_arith_secp256k1_runner.mlir.
+  for (unsigned i = 0; i < numLimbs; ++i) {
+    // m = (T mod b) * nPrime (mod b).
+    Value freeCoeff = arith::TruncIOp::create(b, limbType, tLow);
+    auto m = arith::MulIOp::create(b, freeCoeff, nPrimeConst);
+    Value mExt = arith::ExtUIOp::create(b, tLow.getType(), m);
+    auto mN = arith::MulUIExtendedOp::create(b, modConst, mExt);
+
+    // T += m * n. Fold the carry out of tLow into mN's high limb first:
+    // mN.high = floor(m·n / 2ʷ) ≤ b - 2 (m ≤ b-1, n < 2ʷ), so the +1 cannot
+    // wrap.
+    tLow = arith::AddIOp::create(b, tLow, mN.getLow());
+    Value carry =
+        arith::CmpIOp::create(b, arith::CmpIPredicate::ult, tLow, mN.getLow());
+    auto mNHighPlusOne =
+        arith::AddIOp::create(b, mN.getHigh(), oneConst, noOverflow);
+    Value mNHigh =
+        arith::SelectOp::create(b, carry, mNHighPlusOne, mN.getHigh());
+
+    Value carryOut; // Bit 2w of T; reachable only in the first iteration.
+    if (i == 0) {
+      // In the first iteration tHigh can be as large as n - 1, so adding
+      // mN.high can carry out of the w-bit register when n is within
+      // 2^limbWidth of 2ʷ (e.g. secp256k1). Capture the carry-out; it is
+      // folded back in after the limb shift below. From the second iteration
+      // on, T < n·2ʷ/b + n·b implies tHigh < 2^(w-limbWidth) + 1 and the add
+      // cannot wrap.
+      auto sum = arith::AddUIExtendedOp::create(b, tHigh, mNHigh);
+      tHigh = sum.getSum();
+      carryOut = sum.getOverflow();
+    } else {
+      tHigh = arith::AddIOp::create(b, tHigh, mNHigh, noOverflow);
+    }
+
+    // T's lowest limb is now zero; shift T right by one limb.
     tLow = arith::ShRUIOp::create(b, tLow, limbWidthConst);
     Value tHighLowerLimb = arith::ShLIOp::create(b, tHigh, limbShiftConst);
     tLow = arith::OrIOp::create(b, tLow, tHighLowerLimb);
     tHigh = arith::ShRUIOp::create(b, tHigh, limbWidthConst);
-
-    // Compute `m` = `freeCoeff` * (b⁻¹ mod n) and add to `T`.
-    auto m = arith::MulUIExtendedOp::create(b, freeCoeff, bInvConst);
-    tLow = arith::AddIOp::create(b, tLow, m.getLow());
-    Value carry =
-        arith::CmpIOp::create(b, arith::CmpIPredicate::ult, tLow, m.getLow());
-    tHigh = arith::AddIOp::create(b, tHigh, m.getHigh(), noOverflow);
-    auto tHighPlusOne = arith::AddIOp::create(b, tHigh, oneConst, noOverflow);
-    tHigh = arith::SelectOp::create(b, carry, tHighPlusOne, tHigh);
+    if (i == 0) {
+      Value carryExt = arith::ExtUIOp::create(b, tLow.getType(), carryOut);
+      Value carryShifted =
+          arith::ShLIOp::create(b, carryExt, limbShiftConst, noOverflow);
+      tHigh = arith::OrIOp::create(b, tHigh, carryShifted);
+    }
   }
-  // The last iteration is the same as normal Montgomery reduction.
-  Value freeCoeff = arith::TruncIOp::create(b, limbType, tLow);
-  // Compute `m` = `freeCoeff` * `nPrime` (mod `base`)
-  auto m = arith::MulIOp::create(b, freeCoeff, nPrimeConst);
-  // Compute `m` * `n`
-  Value mExt = arith::ExtUIOp::create(b, tLow.getType(), m);
-  auto mN = arith::MulUIExtendedOp::create(b, modConst, mExt);
-  // Add the product to `T`.
-  tLow = arith::AddIOp::create(b, tLow, mN.getLow());
-  auto carry =
-      arith::CmpIOp::create(b, arith::CmpIPredicate::ult, tLow, mN.getLow());
-  tHigh = arith::AddIOp::create(b, tHigh, mN.getHigh(), noOverflow);
-  auto tHighPlusOne = arith::AddIOp::create(b, tHigh, oneConst, noOverflow);
-  tHigh = arith::SelectOp::create(b, carry, tHighPlusOne, tHigh);
-  // Shift right `T` by `limbWidth` to discard the zeroed limb.
-  tLow = arith::ShRUIOp::create(b, tLow, limbWidthConst);
 
-  // When p > 2ʷ⁻¹ (modulus uses all w bits), the REDC result can exceed
-  // 2ʷ because 2p > 2ʷ. The upper bits of tHigh (above the lowest limb)
-  // represent the overflow: real_value = tLow_combined + tHighUpper * 2ʷ.
-  // Since 2ʷ ≡ R (mod p) where R = 2ʷ mod p, we recover the correct value
-  // by adding tHighUpper * R to tLow, then conditionally subtracting p.
+  // Here V = tLow + tHigh·2ʷ with V < 2n (classical REDC bound above).
   APInt mod = cast<IntegerAttr>(modAttr).getValue();
   if (mod.isSignBitSet()) {
-    Value tHighUpper = arith::ShRUIOp::create(b, tHigh, limbWidthConst);
-    // Mask tHigh to only the lowest limb before the left-shift.
-    tHigh = arith::AndIOp::create(b, tHigh, limbMaskConst);
-    tHigh = arith::ShLIOp::create(b, tHigh, limbShiftConst);
-    tLow = arith::OrIOp::create(b, tLow, tHigh);
-
-    // Add overflow * R to recover the truncated value mod p.
-    // R = 2ʷ mod p is small, so tHighUpper * R fits in w bits.
-    // R = 2ʷ mod p = 2ʷ - p. Compute without overflow: -p in w-bit wraps
-    // to 2ʷ - p since p < 2ʷ.
-    APInt rVal = -mod; // R = 2ʷ - p (unsigned wrap in w bits)
-    TypedAttr rAttr = b.getIntegerAttr(getElementTypeOrSelf(tLow), rVal);
-    Value rConst;
+    // Full-width modulus (n > 2ʷ⁻¹): V < 2n can exceed 2ʷ, so tHigh holds
+    // V's 2ʷ bit (0 or 1). [0, 2n) does not fit in w bits, so a lazy result
+    // is not representable; always canonicalize, folding the overflow bit
+    // (the wrapped subtract in getCanonicalFromExtended yields
+    // tLow + 2ʷ - n = V - n < n exactly when the bit is set).
+    TypedAttr zeroAttr = b.getIntegerAttr(getElementTypeOrSelf(tLow), 0);
+    Value zeroConst;
     if (auto shapedType = dyn_cast<ShapedType>(tLow.getType()))
-      rConst = createSplatConst(b, rAttr, shapedType, tLow);
+      zeroConst = createSplatConst(b, zeroAttr, shapedType, tLow);
     else
-      rConst = arith::ConstantOp::create(b, rAttr);
-    Value correction = arith::MulIOp::create(b, tHighUpper, rConst);
-    tLow = arith::AddIOp::create(b, tLow, correction);
-
-    return getCanonicalFromExtended(tLow);
+      zeroConst = arith::ConstantOp::create(b, zeroAttr);
+    Value overflow =
+        arith::CmpIOp::create(b, arith::CmpIPredicate::ne, tHigh, zeroConst);
+    return getCanonicalFromExtended(tLow, overflow);
   }
 
-  tHigh = arith::ShLIOp::create(b, tHigh, limbShiftConst);
-  tLow = arith::OrIOp::create(b, tLow, tHigh);
-
+  // Narrow modulus (n < 2ʷ⁻¹): V < 2n < 2ʷ, so tHigh == 0 and tLow already
+  // holds V in the lazy range [0, 2n).
   if (lazy)
     return tLow;
   // Final conditional subtraction: if (`tLow` >= `modulus`) then subtract

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/MontReducer.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/MontReducer.cpp
@@ -175,7 +175,6 @@ Value MontReducer::reduceMultiLimb(Value tLow, Value tHigh, bool lazy) {
       b.getIntegerAttr(getElementTypeOrSelf(tLow), limbWidth);
   TypedAttr limbShiftAttr =
       b.getIntegerAttr(getElementTypeOrSelf(tLow), (numLimbs - 1) * limbWidth);
-  TypedAttr oneAttr = b.getIntegerAttr(getElementTypeOrSelf(tLow), 1);
 
   TypedAttr modAttrLocal = modAttr;
 
@@ -188,7 +187,6 @@ Value MontReducer::reduceMultiLimb(Value tLow, Value tHigh, bool lazy) {
     modAttrLocal = isa<VectorType>(modAttrLocal.getType())
                        ? modAttrLocal
                        : SplatElementsAttr::get(shapedType, modAttrLocal);
-    oneAttr = SplatElementsAttr::get(shapedType, oneAttr);
   }
 
   // Create constants for the Montgomery reduction.
@@ -196,7 +194,6 @@ Value MontReducer::reduceMultiLimb(Value tLow, Value tHigh, bool lazy) {
   auto limbWidthConst = arith::ConstantOp::create(b, limbWidthAttr);
   auto limbShiftConst = arith::ConstantOp::create(b, limbShiftAttr);
   auto modConst = arith::ConstantOp::create(b, modAttrLocal);
-  auto oneConst = arith::ConstantOp::create(b, oneAttr);
 
   auto noOverflow = arith::IntegerOverflowFlagsAttr::get(
       b.getContext(),
@@ -225,15 +222,13 @@ Value MontReducer::reduceMultiLimb(Value tLow, Value tHigh, bool lazy) {
     auto mN = arith::MulUIExtendedOp::create(b, modConst, mExt);
 
     // T += m * n. Fold the carry out of tLow into mN's high limb first:
-    // mN.high = floor(m·n / 2ʷ) ≤ b - 2 (m ≤ b-1, n < 2ʷ), so the +1 cannot
-    // wrap.
-    tLow = arith::AddIOp::create(b, tLow, mN.getLow());
-    Value carry =
-        arith::CmpIOp::create(b, arith::CmpIPredicate::ult, tLow, mN.getLow());
-    auto mNHighPlusOne =
-        arith::AddIOp::create(b, mN.getHigh(), oneConst, noOverflow);
-    Value mNHigh =
-        arith::SelectOp::create(b, carry, mNHighPlusOne, mN.getHigh());
+    // mN.high = floor(m·n / 2ʷ) ≤ b - 2 (m ≤ b-1, n < 2ʷ), so adding the carry
+    // cannot wrap.
+    auto add = arith::AddUIExtendedOp::create(b, tLow, mN.getLow());
+    tLow = add.getSum();
+    Value carryExt =
+        arith::ExtUIOp::create(b, tLow.getType(), add.getOverflow());
+    Value mNHigh = arith::AddIOp::create(b, mN.getHigh(), carryExt, noOverflow);
 
     Value carryOut; // Bit 2w of T; reachable only in the first iteration.
     if (i == 0) {
@@ -271,14 +266,12 @@ Value MontReducer::reduceMultiLimb(Value tLow, Value tHigh, bool lazy) {
     // is not representable; always canonicalize, folding the overflow bit
     // (the wrapped subtract in getCanonicalFromExtended yields
     // tLow + 2ʷ - n = V - n < n exactly when the bit is set).
-    TypedAttr zeroAttr = b.getIntegerAttr(getElementTypeOrSelf(tLow), 0);
-    Value zeroConst;
-    if (auto shapedType = dyn_cast<ShapedType>(tLow.getType()))
-      zeroConst = createSplatConst(b, zeroAttr, shapedType, tLow);
-    else
-      zeroConst = arith::ConstantOp::create(b, zeroAttr);
-    Value overflow =
-        arith::CmpIOp::create(b, arith::CmpIPredicate::ne, tHigh, zeroConst);
+    // tHigh is 0 or 1, so its low bit *is* the overflow bit — a truncation
+    // rather than a compare against a materialized w-bit zero.
+    Type overflowType = b.getI1Type();
+    if (auto shapedType = dyn_cast<ShapedType>(tHigh.getType()))
+      overflowType = shapedType.cloneWith(std::nullopt, overflowType);
+    Value overflow = arith::TruncIOp::create(b, overflowType, tHigh);
     return getCanonicalFromExtended(tLow, overflow);
   }
 

--- a/prime_ir/Dialect/ModArith/IR/ModArithAttributes.cpp
+++ b/prime_ir/Dialect/ModArith/IR/ModArithAttributes.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "prime_ir/Dialect/ModArith/IR/ModArithAttributes.h"
 
+#include <algorithm>
 #include <utility>
 
 #include "llvm/ADT/STLExtras.h"
@@ -71,9 +72,16 @@ MontgomeryAttrStorage::construct(AttributeStorageAllocator &allocator,
   // `b` = 2^`w`
   APInt b = APInt::getOneBitSet(w + 1, w);
 
-  // `bReduced` = `b` (mod `modulus`)
-  APInt modExt = modulus.zextOrTrunc(b.getBitWidth());
-  APInt bReduced = b.urem(modExt);
+  // `bReduced` = `b` (mod `modulus`), computed at a width that holds both
+  // operands. Truncating the modulus to b's width instead (`zextOrTrunc` to
+  // w + 1 bits) computed b mod (modulus mod 2^(w+1)), which corrupted
+  // bReduced — and every constant derived from it (R, R², R⁻¹, b⁻¹) — for
+  // any multi-limb modulus whose bit w is clear (e.g. the BLS12-381,
+  // secp256r1, and curve25519 scalar fields). When bit w is set, 2ʷ mod
+  // (modulus mod 2ʷ⁺¹) happens to equal 2ʷ, which masked the bug for the
+  // widely-tested moduli (BN254, secp256k1, the base fields above).
+  unsigned extWidth = std::max(modulus.getBitWidth(), b.getBitWidth());
+  APInt bReduced = b.zext(extWidth).urem(modulus.zext(extWidth));
   bReduced = bReduced.zextOrTrunc(modulus.getBitWidth());
   ModArithType modType = ModArithType::get(modAttr.getContext(), modAttr);
   ModArithOperation bReducedOp(bReduced, modType);

--- a/prime_ir/Dialect/ModArith/IR/ModArithAttributes.cpp
+++ b/prime_ir/Dialect/ModArith/IR/ModArithAttributes.cpp
@@ -32,7 +32,6 @@ IntegerAttr MontgomeryAttr::getNPrime() const { return getImpl()->nPrime; }
 IntegerAttr MontgomeryAttr::getNInv() const { return getImpl()->nInv; }
 IntegerAttr MontgomeryAttr::getR() const { return getImpl()->r; }
 IntegerAttr MontgomeryAttr::getRInv() const { return getImpl()->rInv; }
-IntegerAttr MontgomeryAttr::getBInv() const { return getImpl()->bInv; }
 IntegerAttr MontgomeryAttr::getRSquared() const { return getImpl()->rSquared; }
 const SmallVector<IntegerAttr> &MontgomeryAttr::getInvTwoPowers() const {
   return getImpl()->invTwoPowers;
@@ -109,9 +108,6 @@ MontgomeryAttrStorage::construct(AttributeStorageAllocator &allocator,
   // Construct the `rInvAttr` with the bitwidth of the modulus
   IntegerAttr rInvAttr = rOp.inverse().getIntegerAttr();
 
-  // Construct the `bInvAttr` with the bitwidth of the modulus
-  IntegerAttr bInvAttr = bReducedOp.inverse().getIntegerAttr();
-
   // Construct the `rSquaredAttr` with the bitwidth of the modulus
   IntegerAttr rSquaredAttr = rOp.square().getIntegerAttr();
 
@@ -140,8 +136,8 @@ MontgomeryAttrStorage::construct(AttributeStorageAllocator &allocator,
   return new (allocator.allocate<MontgomeryAttrStorage>())
       MontgomeryAttrStorage(std::move(modAttr), std::move(nPrimeAttr),
                             std::move(nInvAttr), std::move(rAttr),
-                            std::move(rInvAttr), std::move(bInvAttr),
-                            std::move(rSquaredAttr), std::move(invTwoPowers));
+                            std::move(rInvAttr), std::move(rSquaredAttr),
+                            std::move(invTwoPowers));
 }
 
 } // namespace detail

--- a/prime_ir/Dialect/ModArith/IR/ModArithAttributes.h
+++ b/prime_ir/Dialect/ModArith/IR/ModArithAttributes.h
@@ -29,12 +29,11 @@ struct MontgomeryAttrStorage : public AttributeStorage {
 
   MontgomeryAttrStorage(IntegerAttr modulus, IntegerAttr nPrime,
                         IntegerAttr nInv, IntegerAttr r, IntegerAttr rInv,
-                        IntegerAttr bInv, IntegerAttr rSquared,
+                        IntegerAttr rSquared,
                         SmallVector<IntegerAttr> invTwoPowers)
       : modulus(std::move(modulus)), nPrime(std::move(nPrime)),
         nInv(std::move(nInv)), r(std::move(r)), rInv(std::move(rInv)),
-        bInv(std::move(bInv)), rSquared(std::move(rSquared)),
-        invTwoPowers(std::move(invTwoPowers)) {}
+        rSquared(std::move(rSquared)), invTwoPowers(std::move(invTwoPowers)) {}
 
   KeyTy getAsKey() const { return KeyTy(modulus); }
 
@@ -52,7 +51,6 @@ struct MontgomeryAttrStorage : public AttributeStorage {
   IntegerAttr nInv;
   IntegerAttr r;
   IntegerAttr rInv;
-  IntegerAttr bInv;
   IntegerAttr rSquared;
   SmallVector<IntegerAttr> invTwoPowers;
 };

--- a/prime_ir/Dialect/ModArith/IR/ModArithAttributes.td
+++ b/prime_ir/Dialect/ModArith/IR/ModArithAttributes.td
@@ -39,7 +39,6 @@ def ModArith_MontgomeryAttr : ModArith_Attr<"Montgomery", "montgomery"> {
     IntegerAttr getR() const;
     IntegerAttr getRInv() const;
     IntegerAttr getRSquared() const;
-    IntegerAttr getBInv() const;
     const SmallVector<IntegerAttr> &getInvTwoPowers() const;
 
     // Returns the limb bit-width (the bit-width of n').

--- a/tests/Dialect/ModArith/ModArithOperationTest.cpp
+++ b/tests/Dialect/ModArith/ModArithOperationTest.cpp
@@ -359,9 +359,6 @@ TEST(MontgomeryAttrDerivedConstantsTest, Bit64ClearModulus) {
     EXPECT_EQ(mont.getR().getValue(), r) << hex;
     EXPECT_EQ(mont.getRSquared().getValue(), mulMod(r, r)) << hex;
     EXPECT_EQ(mulMod(mont.getRInv().getValue(), r), one) << hex;
-    // bInv · 2⁶⁴ ≡ 1 (mod n).
-    APInt b64 = APInt::getOneBitSet(256, 64);
-    EXPECT_EQ(mulMod(mont.getBInv().getValue(), b64), one) << hex;
   }
 }
 

--- a/tests/Dialect/ModArith/ModArithOperationTest.cpp
+++ b/tests/Dialect/ModArith/ModArithOperationTest.cpp
@@ -16,8 +16,13 @@ limitations under the License.
 #include "prime_ir/Dialect/ModArith/IR/ModArithOperation.h"
 
 #include "gtest/gtest.h"
+#include "llvm/ADT/APInt.h"
 #include "llvm/ADT/bit.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "prime_ir/Dialect/ModArith/IR/ModArithAttributes.h"
 #include "prime_ir/Dialect/ModArith/IR/ModArithDialect.h"
+#include "prime_ir/Dialect/ModArith/IR/ModArithTypes.h"
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/fr.h"
 #include "zk_dtypes/include/field/babybear/babybear.h"
 #include "zk_dtypes/include/field/goldilocks/goldilocks.h"
@@ -316,6 +321,48 @@ TYPED_TEST(ModArithOperationTest, ZeroAndOne) {
   auto modRnd = ModArithOperation::fromZkDtype(&this->context, rnd);
   EXPECT_FALSE(modRnd.isZero());
   EXPECT_FALSE(modRnd.isOne());
+}
+
+// MontgomeryAttrStorage::construct used to reduce b = 2⁶⁴ modulo the modulus
+// TRUNCATED to 65 bits, so bReduced — and every constant derived from it
+// (R, R², R⁻¹, b⁻¹) — was corrupted for any multi-limb modulus whose bit 64
+// is clear. When bit 64 is set, 2⁶⁴ mod (modulus mod 2⁶⁵) happens to equal
+// 2⁶⁴, which masked the bug for BN254 and secp256k1 (the typed tests above).
+// Pin the derived constants against their definitions for two bit-64-clear
+// moduli: the BLS12-381 and secp256r1 scalar fields.
+TEST(MontgomeryAttrDerivedConstantsTest, Bit64ClearModulus) {
+  MLIRContext context;
+  context.loadDialect<ModArithDialect>();
+
+  const char *moduliHex[] = {
+      // BLS12-381 Fr
+      "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001",
+      // secp256r1 Fr
+      "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+  };
+  for (const char *hex : moduliHex) {
+    APInt modulus(256, hex, 16);
+    ASSERT_FALSE(modulus[64]) << "test wants a bit-64-clear modulus";
+    auto modAttr = IntegerAttr::get(IntegerType::get(&context, 256), modulus);
+    ModArithType modType = ModArithType::get(&context, modAttr);
+    MontgomeryAttr mont = modType.getMontgomeryAttr();
+
+    // Work in 512 bits so products cannot overflow.
+    APInt mod512 = modulus.zext(512);
+    auto mulMod = [&](const APInt &a, const APInt &b) {
+      return (a.zext(512) * b.zext(512)).urem(mod512).trunc(256);
+    };
+    APInt one(256, 1);
+
+    // R = 2²⁵⁶ mod n, computed independently of the attr.
+    APInt r = APInt::getOneBitSet(512, 256).urem(mod512).trunc(256);
+    EXPECT_EQ(mont.getR().getValue(), r) << hex;
+    EXPECT_EQ(mont.getRSquared().getValue(), mulMod(r, r)) << hex;
+    EXPECT_EQ(mulMod(mont.getRInv().getValue(), r), one) << hex;
+    // bInv · 2⁶⁴ ≡ 1 (mod n).
+    APInt b64 = APInt::getOneBitSet(256, 64);
+    EXPECT_EQ(mulMod(mont.getBInv().getValue(), b64), one) << hex;
+  }
 }
 
 } // namespace mlir::prime_ir::mod_arith

--- a/tests/Dialect/ModArith/mod_arith_bls12381_runner.mlir
+++ b/tests/Dialect/ModArith/mod_arith_bls12381_runner.mlir
@@ -80,3 +80,75 @@ func.func @test_bls12381_mont_inverse() {
 
 // CHECK_MONT_INVERSE: data =
 // CHECK_MONT_INVERSE-NEXT: [1]
+
+// RUN: prime-ir-opt %s -mod-arith-to-arith -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
+// RUN:   | mlir-runner -e test_bls12381_fr_mont_mul_small -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_FR_MUL_SMALL < %t
+
+// RUN: prime-ir-opt %s -mod-arith-to-arith -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
+// RUN:   | mlir-runner -e test_bls12381_fr_mont_mul_wide -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_FR_MUL_WIDE < %t
+
+// BLS12-381 scalar field:
+// r = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
+// Bit 64 of r is CLEAR (limb1 = 0x53bda402fffe5bfe is even), which used to
+// corrupt every Montgomery constant derived from bReduced = 2⁶⁴ mod r
+// (MontgomeryAttrStorage::construct truncated the modulus to 65 bits before
+// the urem), so even 3 · 5 came out wrong. r also has b⁻¹ mod r ≈ r, the
+// worst case for the former shift-then-add b⁻¹ REDC variant whose result
+// bound V < T/2ʷ + b⁻¹ + r exceeded 2ʷ for ~1% of random products.
+!Fr = !mod_arith.int<52435875175126190479447740508185965837690552500527637822603658699938581184513 : i256>
+!Frm = !mod_arith.int<52435875175126190479447740508185965837690552500527637822603658699938581184513 : i256, true>
+
+// Small values through to_mont → mont_mul → from_mont. Catches the corrupted
+// R² / b⁻¹ constants (bit-64-clear modulus): with them even this is garbage.
+func.func @test_bls12381_fr_mont_mul_small() {
+  %a = mod_arith.constant 3 : !Fr
+  %b = mod_arith.constant 5 : !Fr
+  %a_mont = mod_arith.to_mont %a : !Frm
+  %b_mont = mod_arith.to_mont %b : !Frm
+  %ab_mont = mod_arith.mont_mul %a_mont, %b_mont : !Frm
+  %ab = mod_arith.from_mont %ab_mont : !Fr
+
+  %v = mod_arith.bitcast %ab : !Fr -> i256
+  %vec = vector.from_elements %v : vector<1xi256>
+  %i32vec = vector.bitcast %vec : vector<1xi256> to vector<8xi32>
+  %mem = memref.alloc() : memref<8xi32>
+  %c0 = arith.constant 0 : index
+  vector.store %i32vec, %mem[%c0] : memref<8xi32>, vector<8xi32>
+  %U = memref.cast %mem : memref<8xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U) : (memref<*xi32>) -> ()
+  return
+}
+
+// 3 * 5 mod r = 15
+// CHECK_FR_MUL_SMALL: [15, 0, 0, 0, 0, 0, 0, 0]
+
+// A random product whose REDC pre-canonical value exceeds 2²⁵⁶ under the
+// former b⁻¹ REDC variant even with correct constants (found by search; the
+// classical per-limb REDC keeps V < 2r < 2²⁵⁶ so the fixed lowering is
+// immune by construction).
+func.func @test_bls12381_fr_mont_mul_wide() {
+  %a = mod_arith.constant 18623444530724716917715066816556456062935249299391794592104980440890991110953 : !Fr
+  %b = mod_arith.constant 5351036188861986030282903639234331999548142798982450849968728322547002645315 : !Fr
+  %a_mont = mod_arith.to_mont %a : !Frm
+  %b_mont = mod_arith.to_mont %b : !Frm
+  %ab_mont = mod_arith.mont_mul %a_mont, %b_mont : !Frm
+  %ab = mod_arith.from_mont %ab_mont : !Fr
+
+  %v = mod_arith.bitcast %ab : !Fr -> i256
+  %vec = vector.from_elements %v : vector<1xi256>
+  %i32vec = vector.bitcast %vec : vector<1xi256> to vector<8xi32>
+  %mem = memref.alloc() : memref<8xi32>
+  %c0 = arith.constant 0 : index
+  vector.store %i32vec, %mem[%c0] : memref<8xi32>, vector<8xi32>
+  %U = memref.cast %mem : memref<8xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U) : (memref<*xi32>) -> ()
+  return
+}
+
+// a * b mod r =
+// 50706946945572298874017667503635483751308595243764330383439609392027904712325
+// CHECK_FR_MUL_WIDE: [-535617915, 1299169884, -586082370, -1308919744, 124195241, -1719860803, -296459002, 1880825194]

--- a/tests/Dialect/ModArith/mod_arith_curve25519_runner.mlir
+++ b/tests/Dialect/ModArith/mod_arith_curve25519_runner.mlir
@@ -1,0 +1,79 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// Runner test for the curve25519 base field, p = 2²⁵⁵ - 19. This is the
+// tightest narrow-modulus witness for the multi-limb REDC result bound:
+//
+//   2p = 2²⁵⁶ - 38
+//
+// so the "V < 2n < 2ʷ" headroom the narrow-modulus tail of
+// MontReducer::reduceMultiLimb relies on is only 38. The tail folds tHigh
+// into tLow with `tHigh << 192` in a w-bit register, which silently drops
+// any bit of V at or above 2²⁵⁶ — so the moment V crosses 2²⁵⁶ the result
+// loses exactly 2²⁵⁶.
+//
+// Unlike the BLS12-381 scalar field, bit 64 of p is SET, so the truncated
+// bReduced never corrupted this modulus' Montgomery constants. That makes
+// this a witness for the REDC bound alone.
+//
+// The former shift-then-add b⁻¹ REDC variant had b⁻¹ ≈ 0.53p here, and its
+// bound V < T/2ʷ + b⁻¹ + p crosses 2²⁵⁶ for roughly 1 random square in
+// 10⁵. The error is invisible at a glance because the lost 2²⁵⁶ ≡ R (mod p):
+// an error of exactly R in the Montgomery domain is an error of exactly
+// R·R⁻¹ = 1 once from_mont converts out, so the result is always low by
+// exactly 1 and never by anything else.
+//
+// A rate that low is undetectable by fixed-vector testing — this operand was
+// found from the consumer side, where an X25519 ladder (~2800 multiplies per
+// call) over the dtype passed RFC 7748 §5.2's fixed vectors and six random
+// ones, then diverged from the reference at iteration 82 of the iterated
+// test. See fractalyze/xla#542.
+
+// RUN: prime-ir-opt %s -mod-arith-to-arith -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
+// RUN:   | mlir-runner -e test_curve25519_mont_square_wrap -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_WRAP < %t
+
+func.func private @printMemrefI32(memref<*xi32>) attributes { llvm.emit_c_interface }
+
+// curve25519 base field: p = 2²⁵⁵ - 19
+!Fp = !mod_arith.int<57896044618658097711785492504343953926634992332820282019728792003956564819949 : i256>
+!Fpm = !mod_arith.int<57896044618658097711785492504343953926634992332820282019728792003956564819949 : i256, true>
+
+// Square an operand whose REDC pre-canonical value crosses 2²⁵⁶ under the
+// former b⁻¹ variant. Returned a result low by exactly 1 before the fix; the
+// classical per-limb REDC keeps V < 2p < 2²⁵⁶, so the tail's tHigh == 0
+// assumption holds and the lowering is immune by construction.
+func.func @test_curve25519_mont_square_wrap() {
+  %a = mod_arith.constant 16745370599590454985819630277347750976000815978402662724786347922478530828282 : !Fp
+  %a_mont = mod_arith.to_mont %a : !Fpm
+  %aa_mont = mod_arith.mont_mul %a_mont, %a_mont : !Fpm
+  %aa = mod_arith.from_mont %aa_mont : !Fp
+
+  %v = mod_arith.bitcast %aa : !Fp -> i256
+  %vec = vector.from_elements %v : vector<1xi256>
+  %i32vec = vector.bitcast %vec : vector<1xi256> to vector<8xi32>
+  %mem = memref.alloc() : memref<8xi32>
+  %c0 = arith.constant 0 : index
+  vector.store %i32vec, %mem[%c0] : memref<8xi32>, vector<8xi32>
+  %U = memref.cast %mem : memref<8xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U) : (memref<*xi32>) -> ()
+  return
+}
+
+// a² mod p =
+// 6472717142822227947744657607057095016600357453940632462193194648066349579
+// The pre-fix result differed only in the low word: -403154422.
+// CHECK_WRAP: [-403154421, -999763932, 1167814559, -2006176652, 995992490, -352753903, 1814100388, 240086]

--- a/tests/Dialect/ModArith/mod_arith_secp256k1_runner.mlir
+++ b/tests/Dialect/ModArith/mod_arith_secp256k1_runner.mlir
@@ -89,9 +89,12 @@ func.func @test_secp256k1_self_mul() {
 // a^2 mod p = 31420896780135511602482624633964787057105052135029862436193230832710629143834
 // CHECK_SELF_MUL: [410727706, -880396485, -539256400, -604627336, 995880535, 1108136652, -129139622, 1165465835]
 
-// Test: (p-1)² ≡ 1. This is the worst case for the REDC output bound: the
-// pre-canonical value V lands exactly on 2p + R = 2²⁵⁶ + p, so both the
-// "V ≥ 2²⁵⁶" overflow bit and the "V ≥ 2p" window are exercised at once.
+// Test: (p-1)² ≡ 1. The pre-canonical REDC value V lands exactly on 2²⁵⁶,
+// the smallest value that sets the overflow bit, so this pins the overflow
+// path at its boundary; canonicalization then takes V - p = 2³² + 977, the
+// Montgomery representation of one. The "V ≥ 2p" window is a different case
+// and is not exercised here — classical REDC keeps V < 2p, and 2p for this
+// modulus is just under 2²⁵⁷.
 // The former shift-then-add b⁻¹ REDC variant returned 0 here (its overflow
 // correction dropped a carry past 2²⁵⁶), which is how the frx-level
 // (p-1)·(p-1) → 0 miscompile surfaced.

--- a/tests/Dialect/ModArith/mod_arith_secp256k1_runner.mlir
+++ b/tests/Dialect/ModArith/mod_arith_secp256k1_runner.mlir
@@ -32,6 +32,11 @@
 // RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
 // RUN: FileCheck %s -check-prefix=CHECK_INVERSE < %t
 
+// RUN: prime-ir-opt %s -mod-arith-to-arith -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
+// RUN:   | mlir-runner -e test_secp256k1_pminus1_squared -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_PMINUS1_SQUARED < %t
+
 func.func private @printMemrefI32(memref<*xi32>) attributes { llvm.emit_c_interface }
 
 // secp256k1 base field: p = 115792089237316195423570985008687907853269984665640564039457584007908834671663
@@ -83,6 +88,32 @@ func.func @test_secp256k1_self_mul() {
 
 // a^2 mod p = 31420896780135511602482624633964787057105052135029862436193230832710629143834
 // CHECK_SELF_MUL: [410727706, -880396485, -539256400, -604627336, 995880535, 1108136652, -129139622, 1165465835]
+
+// Test: (p-1)² ≡ 1. This is the worst case for the REDC output bound: the
+// pre-canonical value V lands exactly on 2p + R = 2²⁵⁶ + p, so both the
+// "V ≥ 2²⁵⁶" overflow bit and the "V ≥ 2p" window are exercised at once.
+// The former shift-then-add b⁻¹ REDC variant returned 0 here (its overflow
+// correction dropped a carry past 2²⁵⁶), which is how the frx-level
+// (p-1)·(p-1) → 0 miscompile surfaced.
+func.func @test_secp256k1_pminus1_squared() {
+  %a = mod_arith.constant 115792089237316195423570985008687907853269984665640564039457584007908834671662 : !Fp
+  %a_mont = mod_arith.to_mont %a : !Fpm
+  %sq_mont = mod_arith.mont_mul %a_mont, %a_mont : !Fpm
+  %sq = mod_arith.from_mont %sq_mont : !Fp
+
+  %v = mod_arith.bitcast %sq : !Fp -> i256
+  %vec = vector.from_elements %v : vector<1xi256>
+  %i32vec = vector.bitcast %vec : vector<1xi256> to vector<8xi32>
+  %mem = memref.alloc() : memref<8xi32>
+  %c0 = arith.constant 0 : index
+  vector.store %i32vec, %mem[%c0] : memref<8xi32>, vector<8xi32>
+  %U = memref.cast %mem : memref<8xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U) : (memref<*xi32>) -> ()
+  return
+}
+
+// (p-1)² mod p = 1
+// CHECK_PMINUS1_SQUARED: [1, 0, 0, 0, 0, 0, 0, 0]
 
 // Test inverse: inv(a) * a == 1
 func.func @test_secp256k1_inverse() {

--- a/tests/Dialect/ModArith/mod_arith_to_arith.mlir
+++ b/tests/Dialect/ModArith/mod_arith_to_arith.mlir
@@ -287,6 +287,33 @@ func.func @test_mont_mul_single_limb_signed_opt(%a : !BBm, %b : !BBm, %c : !BBm)
 
 // -----
 
+// secp256k1 Fq (Montgomery): full-width 256-bit modulus (no spare bit).
+// Multi-limb REDC must be the standard per-limb form — one m·n product per
+// limb (4 mului_extended after the initial widening product) — NOT the
+// former shift-then-add b⁻¹ variant, whose result bound V < T/2ʷ + b⁻¹ + p
+// breaks the [0, 2p) contract (b⁻¹ is an arbitrary constant in [0, p)).
+// The first limb iteration's tHigh add must capture its carry-out
+// (addui_extended: tHigh can be as large as p - 1 and p is within 2⁶⁴ of
+// 2²⁵⁶), and the epilogue folds V's 2²⁵⁶ bit via cmpi ne + select.
+!K1m = !mod_arith.int<115792089237316195423570985008687907853269984665640564039457584007908834671663 : i256, true>
+
+// CHECK-LABEL: @test_mont_mul_full_width_standard_redc
+func.func @test_mont_mul_full_width_standard_redc(%a : !K1m, %b : !K1m) -> !K1m {
+  // b⁻¹ mod p must not be materialized anywhere (the old variant's constant).
+  // CHECK-NOT: arith.constant 97798581649299591516383885342152904135335272353249846763749256112567415731113
+  // CHECK: arith.mului_extended
+  // CHECK: arith.mului_extended
+  // CHECK: arith.addui_extended
+  // CHECK-COUNT-3: arith.mului_extended
+  // CHECK-NOT: arith.mului_extended
+  // CHECK: arith.cmpi ne
+  // CHECK: arith.select
+  %res = mod_arith.mont_mul %a, %b : !K1m
+  return %res : !K1m
+}
+
+// -----
+
 // Goldilocks: p = 2⁶⁴ - 2³² + 1, p > 2⁶³ so getCanonicalDiff must use
 // cmpi + select instead of minui (diff + p overflows i64).
 !Gp = !mod_arith.int<18446744069414584321 : i64>

--- a/tests/Dialect/ModArith/mod_arith_to_arith.mlir
+++ b/tests/Dialect/ModArith/mod_arith_to_arith.mlir
@@ -294,7 +294,8 @@ func.func @test_mont_mul_single_limb_signed_opt(%a : !BBm, %b : !BBm, %c : !BBm)
 // breaks the [0, 2p) contract (b⁻¹ is an arbitrary constant in [0, p)).
 // The first limb iteration's tHigh add must capture its carry-out
 // (addui_extended: tHigh can be as large as p - 1 and p is within 2⁶⁴ of
-// 2²⁵⁶), and the epilogue folds V's 2²⁵⁶ bit via cmpi ne + select.
+// 2²⁵⁶), and the epilogue folds V's 2²⁵⁶ bit via trunci + select — tHigh is
+// 0 or 1 there, so its low bit is the overflow bit.
 !K1m = !mod_arith.int<115792089237316195423570985008687907853269984665640564039457584007908834671663 : i256, true>
 
 // CHECK-LABEL: @test_mont_mul_full_width_standard_redc
@@ -306,7 +307,7 @@ func.func @test_mont_mul_full_width_standard_redc(%a : !K1m, %b : !K1m) -> !K1m 
   // CHECK: arith.addui_extended
   // CHECK-COUNT-3: arith.mului_extended
   // CHECK-NOT: arith.mului_extended
-  // CHECK: arith.cmpi ne
+  // CHECK: arith.trunci
   // CHECK: arith.select
   %res = mod_arith.mont_mul %a, %b : !K1m
   return %res : !K1m


### PR DESCRIPTION
## Description

Two independent miscompiles in the wide-field Montgomery path, found while
bringing up traced ECDSA/Ed25519 over the classical curves
(fractalyze/xla#542). Neither is specific to the new curves — one of them
corrupts an already-shipping field:

**Multi-limb REDC violated its own `[0, 2p)` contract.** The unrolled loop
was not standard REDC: it shifted first and added `t₀·(b⁻¹ mod n)` per limb.
That is congruent to `T·b⁻¹`, but its bound is `V < T/2ʷ + bInv + n` with
`bInv` an arbitrary constant in `[0, n)` — not the classical `V < T/2ʷ + n ≤
2n` that the lazy bound tracking, the single conditional subtraction, and the
full-width epilogue all assume. Consequences: every full-width modulus
(secp256k1 p and n, secp256r1 n) computes `(p−1)² = 0`, and **BLS12-381 Fr
gets ~1.1% of random canonical products wrong** (2 289 of 200 000 sampled)
whenever `V ≥ 2²⁵⁶` silently drops bits. The fix emits standard per-limb REDC
(`m = t₀·n′; T += m·n; shift`), with the one genuinely possible carry-out
(iteration 0, moduli within `2⁶⁴` of `2ʷ`) captured via `addui_extended` and
folded back above the limb shift; the bound proofs ride as comments. The
single-limb path is untouched, and lazy reduction stays enabled everywhere it
was — the restored bound is what makes the recorded `umax = 2p−1` true.

**Montgomery constants were derived from a 65-bit-truncated modulus.**
`MontgomeryAttrStorage::construct` computed `bReduced = 2ʷ mod
(modulus.zextOrTrunc(w+1))` — i.e. modulo `p mod 2ʷ⁺¹` — corrupting `R`,
`R²`, `R⁻¹`, and `b⁻¹` for every multi-limb modulus whose bit `w` is clear
(the BLS12-381, secp256r1, and curve25519 scalar fields). Bit `w` set masks
the bug, which is why BN254 and the base fields never noticed. The `urem` now
runs at a width that holds both operands.

Verified against a Python oracle across 10 moduli × ~600k inputs (0
mismatches) and end-to-end against the frx repro matrix in
fractalyze/xla#542. Whether standard REDC's extra `i64` multiply per limb
moves the BN254 pairing runners is unmeasured — they exceed a 900s local
timeout regardless — and is left to review.

## Related Issues/PRs

Fixes the prime-ir half of fractalyze/xla#542. Refs fractalyze/sig-frx#29,
fractalyze/zk_dtypes#174.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline