### PR TITLE
fix(dialect/ec): accept twisted Edwards points in the group-law ops

### DIFF
--- a/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveOps.cpp
+++ b/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveOps.cpp
@@ -44,6 +44,13 @@ namespace mlir::prime_ir::elliptic_curve {
 namespace {
 template <typename OpType>
 LogicalResult verifyMSMPointTypes(OpType op, Type inputType, Type outputType) {
+  // Named rather than left to fall through the short-Weierstrass cases below:
+  // no backend carries a twisted-Edwards MSM, so accepting one here would push
+  // the failure down to a lowering that cannot express it.
+  if (isa<EdAffineType, EdExtendedType>(inputType) ||
+      isa<EdAffineType, EdExtendedType>(outputType)) {
+    return op.emitError() << "MSM does not support twisted Edwards points";
+  }
   if (isa<JacobianType>(inputType) && isa<AffineType>(outputType)) {
     return op.emitError()
            << "jacobian input points require a jacobian or xyzz output type";
@@ -126,6 +133,17 @@ Value createZeroPoint(ImplicitLocOpBuilder &b, Type pointType) {
     return FromCoordsOp::create(b, pointType,
                                 ValueRange{oneBF, oneBF, zeroBF, zeroBF});
   }
+  // Twisted Edwards has a real affine identity, (0, 1), rather than the
+  // off-curve sentinel short Weierstrass uses for the point at infinity —
+  // a*0^2 + 1^2 = 1 = 1 + d*0^2*1^2. Extended carries it as x = X/Z, y = Y/Z,
+  // T = XY/Z, so (0 : 1 : 1 : 0).
+  if (isa<EdAffineType>(pointType)) {
+    return FromCoordsOp::create(b, pointType, ValueRange{zeroBF, oneBF});
+  }
+  if (isa<EdExtendedType>(pointType)) {
+    return FromCoordsOp::create(b, pointType,
+                                ValueRange{zeroBF, oneBF, oneBF, zeroBF});
+  }
   llvm_unreachable("Unsupported point type for createZeroPoint");
 }
 
@@ -154,35 +172,67 @@ LogicalResult ToCoordsOp::verify() {
 
 LogicalResult IsZeroOp::verify() {
   Type inputType = getInput().getType();
-  if (isa<AffineType, JacobianType, XYZZType>(getElementTypeOrSelf(inputType)))
+  if (isa<PointTypeInterface>(getElementTypeOrSelf(inputType)))
     return success();
   return emitError() << "invalid input type";
 }
 
 namespace {
+std::optional<PointKind> getPointKindOf(Type type) {
+  if (auto point = dyn_cast<PointTypeInterface>(type)) {
+    return point.getPointKind();
+  }
+  return std::nullopt;
+}
+
+// Stated over PointKind rather than the concrete types so the rule reads the
+// same for both curve families: affine is not closed under the group law, so
+// an affine operand widens the result to a projective kind of its own family
+// (jacobian or xyzz for short Weierstrass, extended for twisted Edwards).
 template <typename OpType>
 LogicalResult verifyBinaryOp(OpType op) {
   Type lhsType = getElementTypeOrSelf(op.getLhs().getType());
   Type rhsType = getElementTypeOrSelf(op.getRhs().getType());
   Type outputType = getElementTypeOrSelf(op.getType());
-  if (isa<AffineType>(lhsType) || isa<AffineType>(rhsType)) {
-    if (lhsType == rhsType && isa<JacobianType, XYZZType>(outputType)) {
-      // affine, affine -> jacobian
-      // affine, affine -> xyzz
+  std::optional<PointKind> lhs = getPointKindOf(lhsType);
+  std::optional<PointKind> rhs = getPointKindOf(rhsType);
+  std::optional<PointKind> out = getPointKindOf(outputType);
+  if (!lhs || !rhs || !out) {
+    return op->emitError() << "input or output types are wrong";
+  }
+  if (!isSameFamily(*lhs, *rhs) || !isSameFamily(*lhs, *out)) {
+    return op->emitError()
+           << "cannot mix short Weierstrass and twisted Edwards points";
+  }
+  if (isAffine(*lhs) || isAffine(*rhs)) {
+    // affine, affine -> any projective kind of the family
+    if (lhsType == rhsType && !isAffine(*out)) {
       return success();
-    } else if (!isa<AffineType>(outputType) &&
-               (lhsType == outputType || rhsType == outputType)) {
-      // affine, jacobian -> jacobian
-      // affine, xyzz -> xyzz
+    }
+    // affine, projective -> that same projective type
+    if (!isAffine(*out) && (lhsType == outputType || rhsType == outputType)) {
       return success();
     }
   } else if (lhsType == rhsType && rhsType == outputType) {
-    // jacobian, jacobian -> jacobian
-    // xyzz, xyzz -> xyzz
+    // projective, projective -> the same projective type
     return success();
   }
   // TODO(ashjeong): check the curves of given types are the same
   return op->emitError() << "input or output types are wrong";
+}
+
+// Shared by the two unary group operations: an affine input widens to a
+// projective kind of the same family, and any other kind passes through.
+LogicalResult verifyAffineWidens(Operation *op, Type inputType, Type outputType,
+                                 StringRef what) {
+  std::optional<PointKind> in = getPointKindOf(inputType);
+  std::optional<PointKind> out = getPointKindOf(outputType);
+  if (in && out && isSameFamily(*in, *out) &&
+      ((isAffine(*in) && !isAffine(*out)) || inputType == outputType)) {
+    return success();
+  }
+  // TODO(ashjeong): check curves/fields are the same
+  return op->emitError() << "wrong output type given " << what;
 }
 } // namespace
 
@@ -191,23 +241,13 @@ LogicalResult AddOp::verify() { return verifyBinaryOp(*this); }
 LogicalResult SubOp::verify() { return verifyBinaryOp(*this); }
 
 LogicalResult DoubleOp::verify() {
-  Type inputType = getElementTypeOrSelf(getInput());
-  Type outputType = getElementTypeOrSelf(getType());
-  if ((isa<AffineType>(inputType) && isa<JacobianType, XYZZType>(outputType)) ||
-      inputType == outputType)
-    return success();
-  // TODO(ashjeong): check curves/fields are the same
-  return emitError() << "wrong output type given input type";
+  return verifyAffineWidens(*this, getElementTypeOrSelf(getInput()),
+                            getElementTypeOrSelf(getType()), "input type");
 }
 
 LogicalResult ScalarMulOp::verify() {
-  Type pointType = getElementTypeOrSelf(getPoint());
-  Type outputType = getElementTypeOrSelf(getType());
-  if ((isa<AffineType>(pointType) && isa<JacobianType, XYZZType>(outputType)) ||
-      pointType == outputType)
-    return success();
-  // TODO(ashjeong): check curves/fields are the same
-  return emitError() << "wrong output type given point type";
+  return verifyAffineWidens(*this, getElementTypeOrSelf(getPoint()),
+                            getElementTypeOrSelf(getType()), "point type");
 }
 
 LogicalResult CmpOp::verify() {

--- a/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveOps.td
+++ b/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveOps.td
@@ -183,6 +183,11 @@ def EllipticCurve_AddOp : EllipticCurve_BinaryOp<"add", [Commutative]> {
     affine, xyzz -> xyzz
     jacobian, jacobian -> jacobian
     xyzz, xyzz -> xyzz
+    ed_affine, ed_affine -> ed_extended
+    ed_affine, ed_extended -> ed_extended
+    ed_extended, ed_extended -> ed_extended
+
+    Both operands and the result must belong to the same curve family.
 
     Example:
     ```
@@ -205,6 +210,11 @@ def EllipticCurve_SubOp : EllipticCurve_BinaryOp<"sub"> {
     affine, xyzz -> xyzz
     jacobian, jacobian -> jacobian
     xyzz, xyzz -> xyzz
+    ed_affine, ed_affine -> ed_extended
+    ed_affine, ed_extended -> ed_extended
+    ed_extended, ed_extended -> ed_extended
+
+    Both operands and the result must belong to the same curve family.
 
     Example:
     ```
@@ -245,6 +255,8 @@ def EllipticCurve_DoubleOp : EllipticCurve_UnaryOp<"double"> {
     affine -> xyzz
     jacobian -> jacobian
     xyzz -> xyzz
+    ed_affine -> ed_extended
+    ed_extended -> ed_extended
 
     Example:
     ```
@@ -268,6 +280,8 @@ def EllipticCurve_ScalarMulOp : EllipticCurve_Op<"scalar_mul"> {
     affine -> xyzz
     jacobian -> jacobian
     xyzz -> xyzz
+    ed_affine -> ed_extended
+    ed_extended -> ed_extended
 
     Example:
     ```

--- a/prime_ir/Dialect/EllipticCurve/IR/PointKind.h
+++ b/prime_ir/Dialect/EllipticCurve/IR/PointKind.h
@@ -35,6 +35,18 @@ constexpr bool isEdwards(PointKind kind) {
   return kind == PointKind::kEdAffine || kind == PointKind::kEdExtended;
 }
 
+// Affine in either family. Affine is not closed under the group law, so these
+// are the kinds an add/sub/double/scalar-mul result has to widen away from.
+constexpr bool isAffine(PointKind kind) {
+  return kind == PointKind::kAffine || kind == PointKind::kEdAffine;
+}
+
+// The two families have disjoint coordinate systems, so a group operation
+// mixing them is meaningless however the individual kinds line up.
+constexpr bool isSameFamily(PointKind lhs, PointKind rhs) {
+  return isEdwards(lhs) == isEdwards(rhs);
+}
+
 constexpr size_t getNumCoords(PointKind kind) {
   switch (kind) {
   case PointKind::kAffine:

--- a/tests/Dialect/EllipticCurve/BUILD.bazel
+++ b/tests/Dialect/EllipticCurve/BUILD.bazel
@@ -69,5 +69,6 @@ prime_ir_cc_test(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Support",
         "@zk_dtypes//zk_dtypes:bn254_g1",
+        "@zk_dtypes//zk_dtypes:ed25519_g1",
     ],
 )

--- a/tests/Dialect/EllipticCurve/CreateZeroPointTest.cpp
+++ b/tests/Dialect/EllipticCurve/CreateZeroPointTest.cpp
@@ -28,6 +28,7 @@ limitations under the License.
 #include "prime_ir/Dialect/Field/IR/FieldOps.h"
 #include "prime_ir/Dialect/Field/IR/PrimeFieldOperation.h"
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g1.h"
+#include "zk_dtypes/include/elliptic_curve/curve25519/ed25519/g1.h"
 
 namespace mlir::prime_ir::elliptic_curve {
 namespace {
@@ -110,6 +111,25 @@ TEST_F(CreateZeroPointTest, XYZZ) {
   auto attr = AffinePointOperation::getPointType<zk_dtypes::bn254::G1PointXyzz>(
       &context);
   testCreateZeroPoint(attr, {false, false, true, true});
+}
+
+// Twisted Edwards has a real affine identity, (0, 1), on the curve — unlike
+// the short-Weierstrass (0, 0), which is a sentinel precisely because it is
+// off the curve. Getting this wrong yields a point that verifies and computes
+// the wrong answer, so the pattern is pinned per representation.
+TEST_F(CreateZeroPointTest, EdAffine) {
+  auto attr =
+      AffinePointOperation::getPointType<zk_dtypes::ed25519::G1AffinePoint>(
+          &context);
+  testCreateZeroPoint(attr, {true, false});
+}
+
+// Extended carries x = X/Z, y = Y/Z and T = XY/Z, so (0, 1) is (0 : 1 : 1 : 0).
+TEST_F(CreateZeroPointTest, EdExtended) {
+  auto attr =
+      AffinePointOperation::getPointType<zk_dtypes::ed25519::G1ExtendedPoint>(
+          &context);
+  testCreateZeroPoint(attr, {true, false, false, true});
 }
 
 } // namespace

--- a/tests/Dialect/EllipticCurve/ed_op_verifiers.mlir
+++ b/tests/Dialect/EllipticCurve/ed_op_verifiers.mlir
@@ -1,0 +1,109 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// RUN: prime-ir-opt -split-input-file -verify-diagnostics %s | FileCheck %s
+
+// The group-law rule is stated once over point kinds, so it has to hold for
+// twisted Edwards the same way it does for short Weierstrass: affine is not
+// closed, and the result widens to the projective kind of its own family —
+// extended here, where short Weierstrass would give jacobian or xyzz.
+
+!EdBF = !field.pf<57896044618658097711785492504343953926634992332820282019728792003956564819949:i256>
+#ed25519 = #elliptic_curve.te<57896044618658097711785492504343953926634992332820282019728792003956564819948:i256, 37095705934669439343138083508754565189542113879843219016388785533085940283555:i256, (15112221349535400772501151409588531511454012693041857206046113283949847762202:i256, 46316835694926478169428394003475163141307993866256225615783033603165251855960:i256)> : !EdBF
+!EdSF = !field.pf<7237005577332262213973186563042994240857116359379907606001950938285454250989:i256>
+!ed_affine = !elliptic_curve.ed_affine<#ed25519>
+!ed_extended = !elliptic_curve.ed_extended<#ed25519>
+
+// CHECK-LABEL: @ed_affine_add_widens_to_extended
+func.func @ed_affine_add_widens_to_extended(%a: !ed_affine, %b: !ed_affine) -> !ed_extended {
+  // CHECK: elliptic_curve.add
+  %r = elliptic_curve.add %a, %b : !ed_affine, !ed_affine -> !ed_extended
+  return %r : !ed_extended
+}
+
+// CHECK-LABEL: @ed_mixed_add_keeps_extended
+func.func @ed_mixed_add_keeps_extended(%a: !ed_affine, %b: !ed_extended) -> !ed_extended {
+  // CHECK: elliptic_curve.add
+  %r = elliptic_curve.add %a, %b : !ed_affine, !ed_extended -> !ed_extended
+  return %r : !ed_extended
+}
+
+// CHECK-LABEL: @ed_extended_sub
+func.func @ed_extended_sub(%a: !ed_extended, %b: !ed_extended) -> !ed_extended {
+  // CHECK: elliptic_curve.sub
+  %r = elliptic_curve.sub %a, %b : !ed_extended, !ed_extended -> !ed_extended
+  return %r : !ed_extended
+}
+
+// CHECK-LABEL: @ed_affine_double_widens
+func.func @ed_affine_double_widens(%a: !ed_affine) -> !ed_extended {
+  // CHECK: elliptic_curve.double
+  %r = elliptic_curve.double %a : !ed_affine -> !ed_extended
+  return %r : !ed_extended
+}
+
+// CHECK-LABEL: @ed_affine_scalar_mul_widens
+func.func @ed_affine_scalar_mul_widens(%s: !EdSF, %p: !ed_affine) -> !ed_extended {
+  // CHECK: elliptic_curve.scalar_mul
+  %r = elliptic_curve.scalar_mul %s, %p : !EdSF, !ed_affine -> !ed_extended
+  return %r : !ed_extended
+}
+
+// -----
+
+!EdBF = !field.pf<57896044618658097711785492504343953926634992332820282019728792003956564819949:i256>
+#ed25519 = #elliptic_curve.te<57896044618658097711785492504343953926634992332820282019728792003956564819948:i256, 37095705934669439343138083508754565189542113879843219016388785533085940283555:i256, (15112221349535400772501151409588531511454012693041857206046113283949847762202:i256, 46316835694926478169428394003475163141307993866256225615783033603165251855960:i256)> : !EdBF
+!ed_affine = !elliptic_curve.ed_affine<#ed25519>
+
+// Affine is no more closed under the group law here than it is for short
+// Weierstrass, so an affine result has to be rejected rather than silently
+// producing a point off the representation.
+func.func @ed_affine_result_is_not_closed(%a: !ed_affine, %b: !ed_affine) -> !ed_affine {
+  // expected-error @+1 {{input or output types are wrong}}
+  %r = elliptic_curve.add %a, %b : !ed_affine, !ed_affine -> !ed_affine
+  return %r : !ed_affine
+}
+
+// -----
+
+!EdBF = !field.pf<57896044618658097711785492504343953926634992332820282019728792003956564819949:i256>
+#ed25519 = #elliptic_curve.te<57896044618658097711785492504343953926634992332820282019728792003956564819948:i256, 37095705934669439343138083508754565189542113879843219016388785533085940283555:i256, (15112221349535400772501151409588531511454012693041857206046113283949847762202:i256, 46316835694926478169428394003475163141307993866256225615783033603165251855960:i256)> : !EdBF
+#sw = #elliptic_curve.sw<0:i256, 7:i256, (2:i256, 2439533663544638029669143078078524294665610446926061315433185154815338255773:i256)> : !EdBF
+!ed_extended = !elliptic_curve.ed_extended<#ed25519>
+!sw_affine = !elliptic_curve.affine<#sw>
+
+// The two families have disjoint coordinate systems. Worth pinning because the
+// affine-operand arm matches on the *other* operand's type, so a mixed pair
+// lines up with it structurally even though the operation is meaningless.
+func.func @families_do_not_mix(%a: !sw_affine, %b: !ed_extended) -> !ed_extended {
+  // expected-error @+1 {{cannot mix short Weierstrass and twisted Edwards points}}
+  %r = elliptic_curve.add %a, %b : !sw_affine, !ed_extended -> !ed_extended
+  return %r : !ed_extended
+}
+
+// -----
+
+!EdBF = !field.pf<57896044618658097711785492504343953926634992332820282019728792003956564819949:i256>
+#ed25519 = #elliptic_curve.te<57896044618658097711785492504343953926634992332820282019728792003956564819948:i256, 37095705934669439343138083508754565189542113879843219016388785533085940283555:i256, (15112221349535400772501151409588531511454012693041857206046113283949847762202:i256, 46316835694926478169428394003475163141307993866256225615783033603165251855960:i256)> : !EdBF
+!EdSF = !field.pf<7237005577332262213973186563042994240857116359379907606001950938285454250989:i256>
+!ed_affine = !elliptic_curve.ed_affine<#ed25519>
+
+// No backend carries a twisted-Edwards MSM, so it is rejected here rather than
+// at a lowering that cannot express it.
+func.func @msm_rejects_edwards(%s: tensor<4x!EdSF>, %p: tensor<4x!ed_affine>) -> !ed_affine {
+  // expected-error @+1 {{MSM does not support twisted Edwards points}}
+  %r = elliptic_curve.msm %s, %p degree=1 : tensor<4x!EdSF>, tensor<4x!ed_affine> -> !ed_affine
+  return %r : !ed_affine
+}


### PR DESCRIPTION
## Description

#438 gave the dialect `EdAffineType` and `EdExtendedType`, but the op
verifiers predate the second family and match on the short-Weierstrass types
by name. The result is that an Edwards point is constructible and storable in
a tensor while the operation a frontend actually emits —
`ed_affine + ed_affine -> ed_extended` — fails to verify. Affine is not closed
under the group law in either family; the families differ only in where it
widens to.

Worth knowing before reviewing the size of this: **nothing below the verifier
needed writing.** `-elliptic-curve-to-field` already expands the widening case
end to end — no `elliptic_curve.add` survives and it emits field ops plus a
four-coordinate `from_coords`. The verifier was the only gate, so this is
narrower than "add Edwards support to the ops".

The rule is now stated over `PointKind` instead of over concrete types, which
lets it be written once for both families and collapses `DoubleOp` and
`ScalarMulOp` onto one helper. `isAffine` and `isSameFamily` sit next to the
existing `isEdwards`, so a third family extends two predicates rather than
four verifiers.

Two things fell out of admitting the second family, and both are the reason
this touches more than the four verifiers:

- **`createZeroPoint` reached `llvm_unreachable` for both Edwards kinds**, and
  it is called from the lowering, not from a verifier — so fixing only the
  verifiers would have swapped a clean rejection for UB in release. Twisted
  Edwards has a *real* affine identity, `(0, 1)`, on the curve, whereas the
  short-Weierstrass `(0, 0)` works as a point-at-infinity sentinel precisely
  because it is off the curve. Extended carries it as `(0 : 1 : 1 : 0)`. The
  lowering's own `is_zero` expansion already compared against `(0, 1)`, so the
  two agree now rather than by luck.
- **The affine arm of `verifyBinaryOp` accepts an output matching either
  operand**, so with two families in play `sw_affine + ed_extended ->
  ed_extended` lined up structurally and verified. Unreachable while Edwards
  types could not appear in these ops; rejected explicitly now.

MSM names the Edwards types and rejects them rather than letting them fall
through the short-Weierstrass cases. No backend carries a twisted-Edwards MSM,
so accepting one here would only move the failure to a lowering that cannot
express it.

## Related Issues/PRs

Follows #438, which added the types. Unblocks the execution half of
fractalyze/jax#274 (ed25519 point dtypes), whose runtime tests are skipped
pending this and the xla-side registration in fractalyze/xla#589.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline