### PR TITLE
fix(dialect/ec): register twisted Edwards points with the LLVM type converter

### DIFF
--- a/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToLLVM/EllipticCurveToLLVM.cpp
+++ b/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToLLVM/EllipticCurveToLLVM.cpp
@@ -39,28 +39,27 @@ using namespace mlir::LLVM;
 // Conversion patterns.
 //===----------------------------------------------------------------------===//
 namespace {
-template <typename T>
-Type convertPointType(T type, LLVMTypeConverter &typeConverter) {
-  Type baseFieldType = type.getCurve().getBaseField();
+// A point lowers to a flat struct of one converted coordinate per coordinate
+// slot. Keyed on the interface rather than on each concrete point type: a
+// per-type registration is a list of lambdas, so a family added later (twisted
+// Edwards was) compiles fine while silently converting to null, and the first
+// symptom is a null dereference deep inside the LLVM lowering. getNumCoords()
+// is an exhaustive switch over PointKind, so it is the one place that cannot
+// forget a representation.
+Type convertPointType(PointTypeInterface type,
+                      LLVMTypeConverter &typeConverter) {
+  Type baseFieldType = type.getBaseFieldType();
   Type coordType;
   if (auto pfType = dyn_cast<field::PrimeFieldType>(baseFieldType)) {
     coordType = pfType.getStorageType();
   } else {
     coordType = typeConverter.convertType(baseFieldType);
   }
-  if constexpr (std::is_same_v<T, AffineType>) {
-    return LLVM::LLVMStructType::getLiteral(type.getContext(),
-                                            {coordType, coordType});
-  } else if constexpr (std::is_same_v<T, JacobianType>) {
-    return LLVM::LLVMStructType::getLiteral(type.getContext(),
-                                            {coordType, coordType, coordType});
-
-  } else if constexpr (std::is_same_v<T, XYZZType>) {
-    return LLVM::LLVMStructType::getLiteral(
-        type.getContext(), {coordType, coordType, coordType, coordType});
-  } else {
-    return type;
+  if (!coordType) {
+    return nullptr;
   }
+  SmallVector<Type> coordTypes(type.getNumCoords(), coordType);
+  return LLVM::LLVMStructType::getLiteral(type.getContext(), coordTypes);
 }
 
 struct ConvertFromCoords : public ConvertOpToLLVMPattern<FromCoordsOp> {
@@ -71,20 +70,33 @@ struct ConvertFromCoords : public ConvertOpToLLVMPattern<FromCoordsOp> {
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     auto structType = typeConverter->convertType(op.getType());
-    if (isa<AffineType>(op.getType())) {
+    if (!structType) {
+      return failure();
+    }
+    switch (cast<PointTypeInterface>(op.getType()).getNumCoords()) {
+    case 2: {
       auto pointStruct = SimpleStructBuilder<2>::initialized(
           rewriter, loc, structType, adaptor.getCoords());
       rewriter.replaceOp(op, {pointStruct});
-    } else if (isa<JacobianType>(op.getType())) {
+      return success();
+    }
+    case 3: {
       auto pointStruct = SimpleStructBuilder<3>::initialized(
           rewriter, loc, structType, adaptor.getCoords());
       rewriter.replaceOp(op, {pointStruct});
-    } else if (isa<XYZZType>(op.getType())) {
+      return success();
+    }
+    case 4: {
       auto pointStruct = SimpleStructBuilder<4>::initialized(
           rewriter, loc, structType, adaptor.getCoords());
       rewriter.replaceOp(op, {pointStruct});
+      return success();
     }
-    return success();
+    default:
+      // Reported rather than ignored: falling through used to leave the op in
+      // place and still return success, which loses the point silently.
+      return op.emitOpError("unsupported coordinate count for LLVM lowering");
+    }
   }
 };
 
@@ -94,21 +106,30 @@ struct ConvertToCoords : public ConvertOpToLLVMPattern<ToCoordsOp> {
   LogicalResult
   matchAndRewrite(ToCoordsOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (isa<AffineType>(op.getInput().getType())) {
-      SimpleStructBuilder<2> affineStruct(adaptor.getInput());
-      SmallVector<Value> coords = affineStruct.getValues(rewriter, op.getLoc());
+    auto loc = op.getLoc();
+    switch (cast<PointTypeInterface>(op.getInput().getType()).getNumCoords()) {
+    case 2: {
+      SimpleStructBuilder<2> pointStruct(adaptor.getInput());
+      SmallVector<Value> coords = pointStruct.getValues(rewriter, loc);
       rewriter.replaceOpWithMultiple(op, coords);
-    } else if (isa<JacobianType>(op.getInput().getType())) {
-      SimpleStructBuilder<3> jacobianStruct(adaptor.getInput());
-      SmallVector<Value> coords =
-          jacobianStruct.getValues(rewriter, op.getLoc());
-      rewriter.replaceOpWithMultiple(op, coords);
-    } else if (isa<XYZZType>(op.getInput().getType())) {
-      SimpleStructBuilder<4> xyzzStruct(adaptor.getInput());
-      SmallVector<Value> coords = xyzzStruct.getValues(rewriter, op.getLoc());
-      rewriter.replaceOpWithMultiple(op, coords);
+      return success();
     }
-    return success();
+    case 3: {
+      SimpleStructBuilder<3> pointStruct(adaptor.getInput());
+      SmallVector<Value> coords = pointStruct.getValues(rewriter, loc);
+      rewriter.replaceOpWithMultiple(op, coords);
+      return success();
+    }
+    case 4: {
+      SimpleStructBuilder<4> pointStruct(adaptor.getInput());
+      SmallVector<Value> coords = pointStruct.getValues(rewriter, loc);
+      rewriter.replaceOpWithMultiple(op, coords);
+      return success();
+    }
+    default:
+      // See ConvertFromCoords: silence here loses the coordinates.
+      return op.emitOpError("unsupported coordinate count for LLVM lowering");
+    }
   }
 };
 
@@ -215,12 +236,9 @@ void populateEllipticCurveToLLVMTypeConversion(
     LLVMTypeConverter &typeConverter) {
   typeConverter.addConversion(
       [](field::PrimeFieldType type) { return type.getStorageType(); });
-  typeConverter.addConversion(
-      [&](AffineType type) { return convertPointType(type, typeConverter); });
-  typeConverter.addConversion(
-      [&](JacobianType type) { return convertPointType(type, typeConverter); });
-  typeConverter.addConversion(
-      [&](XYZZType type) { return convertPointType(type, typeConverter); });
+  typeConverter.addConversion([&](PointTypeInterface type) {
+    return convertPointType(type, typeConverter);
+  });
 }
 
 void populateEllipticCurveToLLVMConversionPatterns(

--- a/tests/Dialect/EllipticCurve/ed_to_llvm.mlir
+++ b/tests/Dialect/EllipticCurve/ed_to_llvm.mlir
@@ -1,0 +1,64 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// RUN: cat %S/../../ed25519_defs.mlir %s \
+// RUN:   | prime-ir-opt -convert-to-llvm \
+// RUN:   | FileCheck %s -enable-var-scope
+
+// The twisted Edwards point types have to reach LLVM like the short Weierstrass
+// ones do. When only the Weierstrass types were registered with the LLVM type
+// converter, an Edwards type converted to null instead of failing, and the first
+// symptom was a null dereference in MemRefDescriptor::fromStaticShape during
+// XLA's CPU fusion lowering -- a SIGSEGV with no diagnostic.
+
+!ed_affine = !elliptic_curve.ed_affine<#ed25519>
+
+// A 2-coordinate Edwards point lowers to the same flat struct shape a
+// 2-coordinate Weierstrass affine point does.
+// CHECK-LABEL: @test_ed_from_coords
+func.func @test_ed_from_coords(%v1: i256, %v2: i256, %v3: i256, %v4: i256) {
+  // CHECK-NOT: elliptic_curve.from_coords
+  // CHECK: llvm.insertvalue
+  %aff = elliptic_curve.from_coords %v1, %v2
+      : (i256, i256) -> !ed_affine
+  %ext = elliptic_curve.from_coords %v1, %v2, %v3, %v4
+      : (i256, i256, i256, i256) -> !ed_extended
+  return
+}
+
+// CHECK-LABEL: @test_ed_to_coords
+func.func @test_ed_to_coords(%aff: !ed_affine, %ext: !ed_extended) {
+  // CHECK-NOT: elliptic_curve.to_coords
+  // CHECK: llvm.extractvalue
+  %aff_coords:2 = elliptic_curve.to_coords %aff
+      : (!ed_affine) -> (i256, i256)
+  %ext_coords:4 = elliptic_curve.to_coords %ext
+      : (!ed_extended) -> (i256, i256, i256, i256)
+  return
+}
+
+// The signature itself is the regression: an unregistered element type made the
+// converted function type null rather than reporting a failure.
+// CHECK-LABEL: @test_ed_extended_signature
+// CHECK-SAME: !llvm.struct<(i256, i256, i256, i256)>
+func.func @test_ed_extended_signature(%ext: !ed_extended) -> !ed_extended {
+  return %ext : !ed_extended
+}
+
+// CHECK-LABEL: @test_ed_affine_signature
+// CHECK-SAME: !llvm.struct<(i256, i256)>
+func.func @test_ed_affine_signature(%aff: !ed_affine) -> !ed_affine {
+  return %aff : !ed_affine
+}


### PR DESCRIPTION
## Description

The LLVM type converter only ever had the three short Weierstrass point
types registered, so an `ed_affine` or `ed_extended` type converted to
**null** rather than reporting a conversion failure. Nothing checks for
that null, so the first symptom was a null dereference several layers
away, inside XLA's CPU fusion lowering — a `SIGSEGV` with no diagnostic
at all, which is why this read as a missing group law rather than a
missing registration:

```
mlir::LLVM::LLVMStructType::getBody()
mlir::MemRefDescriptor::fromStaticShape(...)
xla::cpu::LowerLoadOp::matchAndRewrite(xla::cpu::LoadOp, ...)
xla::cpu::LowerToLLVMPass::runOnOperation()
xla::cpu::FusionCompiler::Compile(...)
```

Registering two more per-type lambdas would fix today's curve and lose
to the next one. A list of `addConversion` callbacks is structurally
invisible to `-Werror=switch`, so nothing can flag the family somebody
forgets — which is exactly how twisted Edwards got missed after it was
added everywhere else. Keying on the interface and taking the width from
`getNumCoords()` moves the decision to the one place that is an
exhaustive switch over `PointKind` and therefore *does* fail to build
when a representation is added without being handled.

The two coordinate patterns had the same Weierstrass-only shape but
returned `success()` unconditionally, so an Edwards point left the op
unreplaced *and* reported success — a silent miscompile rather than a
crash. They now report an error instead of falling through.

Out of scope, found while confirming this: `add(affine, affine)` fails
for short Weierstrass and twisted Edwards alike (bn254, secp256k1 and
ed25519 all reproduce), because the result tile takes the operand
element type instead of the widened result type. That is an XLA-side
defect with its own tracking item, unrelated to this crash.

## Related Issues/PRs

- Reproducer: fractalyze/jax#276 (held as draft; it is red on exactly
  this path). It exercises `ed_affine + ed_affine`, so it stays red on
  the separate affine-add defect above and is not closed by this PR.
- Follows fractalyze/xla#589 and #439, which registered these types at
  every layer above the LLVM conversion.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline