### PR TITLE
fix(dialect/ec): decide affineness by point kind, not by isa<AffineType>

### DIFF
--- a/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/EllipticCurveToField.cpp
+++ b/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/EllipticCurveToField.cpp
@@ -743,15 +743,19 @@ struct ConvertScalarMul : public OpConversionPattern<ScalarMulOp> {
     Value point = op.getPoint();
     Value scalarPF = op.getScalar();
 
-    Type pointType = op.getPoint().getType();
     Type outputType = op.getType();
 
+    // By point kind, not isa<AffineType>: that names only the short Weierstrass
+    // affine type, so an Edwards affine point would skip the widening below.
+    const bool pointIsAffine =
+        isAffine(cast<PointTypeInterface>(point.getType()).getPointKind());
+
     // AOT runtime path: emit func.call for scalar multiply.
-    // Use "scalar_mul" for affine input, "scalar_mul_jac" for jacobian input.
+    // Use "scalar_mul" for affine input, "scalar_mul_jac" for projective
+    // input (the name predates the twisted Edwards representations).
     if (shouldUseAOTRuntime(op, outputType, aotConfig.mode,
                             aotConfig.inlineConstOps)) {
-      std::string opName =
-          isa<AffineType>(pointType) ? "scalar_mul" : "scalar_mul_jac";
+      std::string opName = pointIsAffine ? "scalar_mul" : "scalar_mul_jac";
       auto funcName = getAOTRuntimeFuncName(opName, outputType);
       if (funcName) {
         rewriter.replaceOp(op, emitAOTFuncCall(op, *funcName, op.getType(),
@@ -762,7 +766,7 @@ struct ConvertScalarMul : public OpConversionPattern<ScalarMulOp> {
 
     // Inline implementation: Double-and-Add algorithm
     Value zeroPoint = createZeroPoint(b, outputType);
-    Value initialPoint = isa<AffineType>(pointType)
+    Value initialPoint = pointIsAffine
                              ? ConvertPointTypeOp::create(b, outputType, point)
                              : point;
 

--- a/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/PointCodeGen.cpp
+++ b/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/PointCodeGen.cpp
@@ -66,17 +66,17 @@ PointCodeGen applyBinaryOp(const PointCodeGen::CodeGenType &a,
       [&](const auto &lhs, const auto &rhs) -> PointCodeGen {
         using LHS = std::decay_t<decltype(lhs)>;
         using RHS = std::decay_t<decltype(rhs)>;
-        constexpr bool lhsIsEd = std::is_same_v<LHS, EdAffinePointCodeGen> ||
-                                 std::is_same_v<LHS, EdExtendedPointCodeGen>;
-        constexpr bool rhsIsEd = std::is_same_v<RHS, EdAffinePointCodeGen> ||
-                                 std::is_same_v<RHS, EdExtendedPointCodeGen>;
-        if constexpr (lhsIsEd != rhsIsEd) {
+        // Either the same coordinate system on both sides, or a mixed
+        // addition with one affine operand. Classified by point kind rather
+        // than by naming concrete classes: is_same_v against
+        // AffinePointCodeGen covers only short Weierstrass, which silently
+        // excluded Edwards from the mixed-addition arm.
+        constexpr bool kRealizable = std::is_same_v<LHS, RHS> ||
+                                     isAffine(LHS::getKind()) ||
+                                     isAffine(RHS::getKind());
+        if constexpr (!isSameFamily(LHS::getKind(), RHS::getKind())) {
           llvm_unreachable("Cross-family binary op not supported");
-        } else if constexpr (std::is_same_v<LHS, RHS>) {
-          return op(lhs, rhs);
-          // NOLINTNEXTLINE(readability/braces)
-        } else if constexpr (std::is_same_v<LHS, AffinePointCodeGen> ||
-                             std::is_same_v<RHS, AffinePointCodeGen>) {
+        } else if constexpr (kRealizable) {
           return op(lhs, rhs);
         }
         llvm_unreachable("Unsupported field type in binary operator");

--- a/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/PointCodeGen.h
+++ b/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/PointCodeGen.h
@@ -80,7 +80,9 @@ public:
   PointCodeGenBase() = default;
   explicit PointCodeGenBase(Value value) : value(value) {}
 
-  PointKind getKind() const { return Kind; }
+  // Static so it is usable as LHS::getKind() in the if-constexpr dispatch
+  // in PointCodeGen.cpp; still callable on an instance.
+  static constexpr PointKind getKind() { return Kind; }
   operator Value() const { return value; }
 
   template <PointKind Kind2>

--- a/prime_ir/Dialect/EllipticCurve/IR/PointKind.h
+++ b/prime_ir/Dialect/EllipticCurve/IR/PointKind.h
@@ -31,14 +31,37 @@ enum class PointKind {
   kEdExtended,
 };
 
+// Written as default-less switches rather than equality chains: a chain answers
+// "no" for a representation added later, which is a silent misclassification,
+// while a switch is at least reachable by -Wswitch. Nothing in this repo's
+// build turns that warning into an error today, so treat these as the one place
+// to update rather than as a guarantee the compiler will stop you.
 constexpr bool isEdwards(PointKind kind) {
-  return kind == PointKind::kEdAffine || kind == PointKind::kEdExtended;
+  switch (kind) {
+  case PointKind::kEdAffine:
+  case PointKind::kEdExtended:
+    return true;
+  case PointKind::kAffine:
+  case PointKind::kJacobian:
+  case PointKind::kXYZZ:
+    return false;
+  }
+  return false;
 }
 
 // Affine in either family. Affine is not closed under the group law, so these
 // are the kinds an add/sub/double/scalar-mul result has to widen away from.
 constexpr bool isAffine(PointKind kind) {
-  return kind == PointKind::kAffine || kind == PointKind::kEdAffine;
+  switch (kind) {
+  case PointKind::kAffine:
+  case PointKind::kEdAffine:
+    return true;
+  case PointKind::kJacobian:
+  case PointKind::kXYZZ:
+  case PointKind::kEdExtended:
+    return false;
+  }
+  return false;
 }
 
 // The two families have disjoint coordinate systems, so a group operation
@@ -60,6 +83,8 @@ constexpr size_t getNumCoords(PointKind kind) {
   case PointKind::kEdExtended:
     return 4;
   }
+  // Unreachable for any declared kind; falling off the end would be UB.
+  return 0;
 }
 
 template <typename Point>

--- a/prime_ir/Dialect/EllipticCurve/IR/PointOperation.cpp
+++ b/prime_ir/Dialect/EllipticCurve/IR/PointOperation.cpp
@@ -49,18 +49,13 @@ PointOperation applyBinaryOp(const PointOperation::OperationType &a,
       [&](const auto &lhs, const auto &rhs) -> PointOperation {
         using LHS = std::decay_t<decltype(lhs)>;
         using RHS = std::decay_t<decltype(rhs)>;
-        constexpr bool lhsIsEd = std::is_same_v<LHS, EdAffinePointOperation> ||
-                                 std::is_same_v<LHS, EdExtendedPointOperation>;
-        constexpr bool rhsIsEd = std::is_same_v<RHS, EdAffinePointOperation> ||
-                                 std::is_same_v<RHS, EdExtendedPointOperation>;
-        if constexpr (lhsIsEd != rhsIsEd) {
-          // Cross-family (SW ↔ TE) binary ops are not supported.
+        // See the matching comment in PointCodeGen.cpp.
+        constexpr bool kRealizable = std::is_same_v<LHS, RHS> ||
+                                     isAffine(LHS::getKind()) ||
+                                     isAffine(RHS::getKind());
+        if constexpr (!isSameFamily(LHS::getKind(), RHS::getKind())) {
           llvm_unreachable("Cross-family binary op not supported");
-        } else if constexpr (std::is_same_v<LHS, RHS>) {
-          return op(lhs, rhs);
-          // NOLINTNEXTLINE(readability/braces)
-        } else if constexpr (std::is_same_v<LHS, AffinePointOperation> ||
-                             std::is_same_v<RHS, AffinePointOperation>) {
+        } else if constexpr (kRealizable) {
           return op(lhs, rhs);
         }
         llvm_unreachable("Unsupported field type in binary operator");

--- a/prime_ir/Dialect/EllipticCurve/IR/PointOperation.h
+++ b/prime_ir/Dialect/EllipticCurve/IR/PointOperation.h
@@ -153,7 +153,9 @@ public:
     }
   }
 
-  PointKind getKind() const { return Kind; }
+  // Static so it is usable as LHS::getKind() in the if-constexpr dispatch
+  // in PointOperation.cpp; still callable on an instance.
+  static constexpr PointKind getKind() { return Kind; }
 
   template <PointKind Kind2 = Kind,
             std::enable_if_t<Kind2 != PointKind::kAffine> * = nullptr>

--- a/tests/Dialect/EllipticCurve/ed_extended_to_field.mlir
+++ b/tests/Dialect/EllipticCurve/ed_extended_to_field.mlir
@@ -65,3 +65,38 @@ func.func @test_ed_extended_constant() {
   %gen = elliptic_curve.constant dense<[15112221349535400772501151409588531511454012693041857206046113283949847762202, 46316835694926478169428394003475163141307993866256225615783033603165251855960, 1, 46827403850823179245072216630277197565144205554125654976674165829533817101731]> : !ed_extended
   return
 }
+
+// The twisted Edwards affine representation has to reach the same paths the
+// short Weierstrass affine one does. Both cases below used to be decided by an
+// isa<AffineType> test, which names only the Weierstrass type: mixed addition
+// hit an llvm_unreachable, and scalar multiply skipped the widening and left an
+// affine value where the loop expected the projective output type.
+
+!ed_affine = !elliptic_curve.ed_affine<#ed25519>
+!EdSF = !field.pf<7237005577332262213973186563042994240857116359379907606001950938285454250989:i256>
+
+// Test: mixed addition, extended + affine -> extended.
+// CHECK-LABEL: @test_ed_mixed_add
+func.func @test_ed_mixed_add(%p1: !ed_extended, %p2: !ed_affine) -> !ed_extended {
+  // CHECK-NOT: elliptic_curve.add
+  // CHECK: field.mul
+  %result = elliptic_curve.add %p1, %p2 : !ed_extended, !ed_affine -> !ed_extended
+  return %result : !ed_extended
+}
+
+// Test: affine scalar multiply widens to extended.
+// CHECK-LABEL: @test_ed_affine_scalar_mul
+func.func @test_ed_affine_scalar_mul(%s: !EdSF, %p: !ed_affine) -> !ed_extended {
+  // CHECK-NOT: elliptic_curve.scalar_mul
+  %result = elliptic_curve.scalar_mul %s, %p : !EdSF, !ed_affine -> !ed_extended
+  return %result : !ed_extended
+}
+
+// Test: affine + affine also widens (no mixed operand involved).
+// CHECK-LABEL: @test_ed_affine_add
+func.func @test_ed_affine_add(%p1: !ed_affine, %p2: !ed_affine) -> !ed_extended {
+  // CHECK-NOT: elliptic_curve.add
+  // CHECK: field.mul
+  %result = elliptic_curve.add %p1, %p2 : !ed_affine, !ed_affine -> !ed_extended
+  return %result : !ed_extended
+}


### PR DESCRIPTION
## Description

`isa<AffineType>` names only the short Weierstrass affine type, so a twisted
Edwards affine point reads as already-projective. Three sites decided
affineness that way, and each failed differently once ed25519 reached them:

- `applyBinaryOp` — the codegen copy and the IR copy both — selected the mixed
  addition arm with `is_same_v<..., AffinePointCodeGen>`. For Edwards no arm
  matched, so `extended + ed_affine`, which the scalar-multiply ladder emits on
  *every* iteration, fell through to `llvm_unreachable`. That is UB rather than
  an abort in a release build, so it surfaced as a bare `SIGTRAP` with no
  message.
- `ConvertScalarMul` skipped the widening `convert_point_type` for an Edwards
  affine operand and handed the ladder an `ed_affine` value where it expected
  the projective output type, leaving an unresolved materialization that failed
  to legalize.

`isAffine()` / `isEdwards()` answer this for both families from one place, so
adding a representation becomes a single-file change instead of a grep across
call sites. This is the predicate form of what #440 fixed in registration form.

**Correction to an earlier revision of this description.** This body previously
claimed the enum helpers do *not* make a forgotten family fail the build,
because `.bazelrc` sets no `-Werror`. That was wrong: `bazel/prime_ir_cc.bzl`
puts `-Werror=all` on every `prime_ir_cc_*` target, and `-Wall` implies
`-Wswitch`. Verified by adding a sixth `PointKind` — clang reports
`error: enumeration value 'kProbeTemp' not handled in switch [-Werror,-Wswitch]`
and the build fails. So rewriting `isAffine`/`isEdwards` as default-less
switches here *does* buy a compile-time guarantee, and no `.bazelrc` change is
needed. The follow-up in fractalyze/prime-ir#443 corrects the comment in
`PointKind.h` that stated the same wrong thing.

`getNumCoords` also gained the `return` its switch was missing — falling off the
end of a non-void function is UB, and g++ already warned about it.

The existing `getKind()` accessor becomes `static constexpr` so it serves the
type-level dispatch as well as the instance calls it already had, rather than
adding a second spelling of the same fact.

The AOT symbol keeps its `scalar_mul_jac` name for the projective case; that
name predates the Edwards representations and renaming it would change the
runtime's wire contract.

Verified against the CPU backend end to end: `ed_affine * scalar` compiles and
byte-matches the zk_dtypes host ufunc, and short Weierstrass is unchanged.

## Known gap this does not close

`EllipticCurveOps.cpp` still infers a representation *from the coordinate
count* in three places — `createPointOp` (~L934) and two
`static_cast<PointKind>(getNumCoords() - 2)` sites in the folders (~L1063,
~L1153). Since `ed_affine` is 2 coords and `ed_extended` is 4, an Edwards
constant folds as short Weierstrass affine/xyzz. `AddOp`/`SubOp`/`NegateOp`/
`DoubleOp` all set `hasFolder = 1`, so those paths are live. xla already fixed
this exact class and wrote the rule down in `xla/mlir/utils/type_util.cc`
("Taken from the point kind rather than from the coordinate count, which no
longer identifies a representation"); prime-ir was never swept for it. Out of
scope here — it is a behavior fix needing its own tests — but it should be
tracked.

## Related Issues/PRs

- Follows #440 (merged), which fixed the registration half of the same class.
- The affine widening path crosses three repos; fractalyze/stablehlo#68 and
  fractalyze/xla#597 carry the companion fixes, and all three are needed before
  fractalyze/jax#276 goes green.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline

