### PR TITLE
fix: reduce a field.powui exponent before widening it to the order

### DIFF
--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
@@ -803,7 +803,7 @@ struct ConvertPowUI : public OpConversionPattern<PowUIOp> {
     }
 
     unsigned expBitWidth = cast<IntegerType>(exp.getType()).getWidth();
-    bool allowUnroll = op.getUnroll().value_or(true);
+    bool unroll = op.getUnroll().value_or(true);
 
     auto emitBitSerialLoop = [&](Value exp) {
       return generateBitSerialLoop(
@@ -814,7 +814,7 @@ struct ConvertPowUI : public OpConversionPattern<PowUIOp> {
           [](ImplicitLocOpBuilder &b, Value acc, Value v) {
             return MulOp::create(b, acc, v);
           },
-          allowUnroll);
+          unroll);
     };
 
     // Reduce exponent using Fermat's little theorem:

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.h"
 
+#include <algorithm>
 #include <utility>
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -802,15 +803,7 @@ struct ConvertPowUI : public OpConversionPattern<PowUIOp> {
     }
 
     unsigned expBitWidth = cast<IntegerType>(exp.getType()).getWidth();
-    unsigned modBitWidth = modulus.getBitWidth();
-    if (modBitWidth > expBitWidth) {
-      exp = arith::ExtUIOp::create(
-          b, IntegerType::get(exp.getContext(), modBitWidth), exp);
-    } else {
-      modulus = modulus.zext(expBitWidth);
-      modBitWidth = expBitWidth;
-    }
-    IntegerType intType = cast<IntegerType>(exp.getType());
+    bool allowUnroll = op.getUnroll().value_or(true);
 
     auto emitBitSerialLoop = [&](Value exp) {
       return generateBitSerialLoop(
@@ -820,15 +813,17 @@ struct ConvertPowUI : public OpConversionPattern<PowUIOp> {
           },
           [](ImplicitLocOpBuilder &b, Value acc, Value v) {
             return MulOp::create(b, acc, v);
-          });
+          },
+          allowUnroll);
     };
 
     // Reduce exponent using Fermat's little theorem:
     // x^(p-1) ≡ 1 (prime field), x^(pᵈ-1) ≡ 1 (extension field)
+    modulus = modulus.zext(std::max(expBitWidth, modulus.getBitWidth()));
     APInt order;
     if (auto efType = dyn_cast<ExtensionFieldType>(fieldType)) {
       unsigned degreeOverPrime = efType.getDegreeOverPrime();
-      modulus = modulus.zext(modBitWidth * degreeOverPrime);
+      modulus = modulus.zext(modulus.getBitWidth() * degreeOverPrime);
       order = modulus;
       for (unsigned i = 1; i < degreeOverPrime; ++i)
         order = order * modulus;
@@ -836,18 +831,20 @@ struct ConvertPowUI : public OpConversionPattern<PowUIOp> {
     } else {
       order = modulus - 1;
     }
+    auto intType = IntegerType::get(op.getContext(), order.getBitWidth());
 
+    // Match the literal on the exponent as the op carries it. Widening it to
+    // the order's width first would hide an `arith.constant` behind an
+    // `arith.extui`, sending every field whose modulus is wider than the
+    // exponent type down the runtime `remui` path -- and into the bit-serial
+    // loop -- for an exponent that was a literal all along.
     if (auto expConstOp = exp.getDefiningOp<arith::ConstantOp>()) {
       APInt cExp = cast<IntegerAttr>(expConstOp.getValue()).getValue();
-      cExp = cExp.zext(order.getBitWidth());
-      cExp = cExp.urem(order);
-      intType = IntegerType::get(exp.getContext(), order.getBitWidth());
-      exp = arith::ConstantIntOp::create(b, intType, cExp);
+      exp = arith::ConstantIntOp::create(
+          b, intType, cExp.zext(order.getBitWidth()).urem(order));
     } else {
-      if (order.getBitWidth() > intType.getWidth()) {
-        intType = IntegerType::get(exp.getContext(), order.getBitWidth());
+      if (order.getBitWidth() > expBitWidth)
         exp = arith::ExtUIOp::create(b, intType, exp);
-      }
       exp = arith::RemUIOp::create(
           b, exp, arith::ConstantIntOp::create(b, intType, order));
     }

--- a/prime_ir/Dialect/Field/IR/FieldOps.td
+++ b/prime_ir/Dialect/Field/IR/FieldOps.td
@@ -353,14 +353,15 @@ def Field_PowUIOp : Field_Op<"powui", [TypesMatchWith<
   let description = [{
     Computes the field element a raised to the power of unsigned integer b.
 
-    The optional `unroll` attribute selects the shape of the lowered
-    square-and-multiply schedule when the exponent is a compile-time constant.
-    Absent or `true` emits it straight-line; `false` keeps the runtime
-    bit-serial loop. Straight-line is the cheaper form for a caller that is
-    already unrolled around this op, while a caller that rolls its own rounds
-    (a Poseidon permutation applying one S-box per round) executes fewer
-    instructions with the loop, and a straight-line chain per S-box inflates
-    what LLVM has to simplify. A dynamic exponent always lowers to the loop.
+    The optional `unroll` attribute picks the shape of the lowered
+    square-and-multiply schedule for a compile-time-constant exponent: absent
+    or `true` emits it straight-line, `false` keeps the bit-serial loop. Each
+    rolled call site is a control-flow region LLVM has to simplify, so a caller
+    that spells out many of them (a Poseidon permutation applying one S-box per
+    round) pays for the loop in compile time and is measured to execute
+    slightly fewer instructions with it; a caller already unrolled around this
+    op wants the straight-line form and the constant folding it exposes. A
+    dynamic exponent always lowers to the loop.
 
     Example:
     ```

--- a/prime_ir/Dialect/Field/IR/FieldOps.td
+++ b/prime_ir/Dialect/Field/IR/FieldOps.td
@@ -353,12 +353,23 @@ def Field_PowUIOp : Field_Op<"powui", [TypesMatchWith<
   let description = [{
     Computes the field element a raised to the power of unsigned integer b.
 
+    The optional `unroll` attribute selects the shape of the lowered
+    square-and-multiply schedule when the exponent is a compile-time constant.
+    Absent or `true` emits it straight-line; `false` keeps the runtime
+    bit-serial loop. Straight-line is the cheaper form for a caller that is
+    already unrolled around this op, while a caller that rolls its own rounds
+    (a Poseidon permutation applying one S-box per round) executes fewer
+    instructions with the loop, and a straight-line chain per S-box inflates
+    what LLVM has to simplify. A dynamic exponent always lowers to the loop.
+
     Example:
     ```
     %power = field.powui %a, %b : !field.pf<primeModulus>, i32
+    %rolled = field.powui %a, %b {unroll = false} : !field.pf<primeModulus>, i32
     ```
   }];
-  let arguments = (ins FieldLike:$base, SignlessIntegerLike:$exp);
+  let arguments = (ins FieldLike:$base, SignlessIntegerLike:$exp,
+                       OptionalAttr<BoolAttr>:$unroll);
   let results = (outs FieldLike:$output);
   let assemblyFormat = "operands attr-dict `:` type($base) `,` type($exp)";
 }

--- a/prime_ir/Utils/BitSerialAlgorithm.cpp
+++ b/prime_ir/Utils/BitSerialAlgorithm.cpp
@@ -55,12 +55,14 @@ Value generateConstantUnrolled(ImplicitLocOpBuilder &b, const APInt &scalarVal,
 
 Value generateBitSerialLoop(ImplicitLocOpBuilder &b, Value scalar, Value base,
                             Value identity, DoubleCallback doubleOp,
-                            AccumulateCallback accumulateOp) {
+                            AccumulateCallback accumulateOp, bool allowUnroll) {
   // If scalar is a compile-time constant, unroll into straight-line IR.
-  if (auto constOp = scalar.getDefiningOp<arith::ConstantOp>()) {
-    APInt scalarVal = cast<IntegerAttr>(constOp.getValue()).getValue();
-    return generateConstantUnrolled(b, scalarVal, base, identity, doubleOp,
-                                    accumulateOp);
+  if (allowUnroll) {
+    if (auto constOp = scalar.getDefiningOp<arith::ConstantOp>()) {
+      APInt scalarVal = cast<IntegerAttr>(constOp.getValue()).getValue();
+      return generateConstantUnrolled(b, scalarVal, base, identity, doubleOp,
+                                      accumulateOp);
+    }
   }
 
   Type scalarType = scalar.getType();

--- a/prime_ir/Utils/BitSerialAlgorithm.cpp
+++ b/prime_ir/Utils/BitSerialAlgorithm.cpp
@@ -55,9 +55,9 @@ Value generateConstantUnrolled(ImplicitLocOpBuilder &b, const APInt &scalarVal,
 
 Value generateBitSerialLoop(ImplicitLocOpBuilder &b, Value scalar, Value base,
                             Value identity, DoubleCallback doubleOp,
-                            AccumulateCallback accumulateOp, bool allowUnroll) {
+                            AccumulateCallback accumulateOp, bool unroll) {
   // If scalar is a compile-time constant, unroll into straight-line IR.
-  if (allowUnroll) {
+  if (unroll) {
     if (auto constOp = scalar.getDefiningOp<arith::ConstantOp>()) {
       APInt scalarVal = cast<IntegerAttr>(constOp.getValue()).getValue();
       return generateConstantUnrolled(b, scalarVal, base, identity, doubleOp,

--- a/prime_ir/Utils/BitSerialAlgorithm.h
+++ b/prime_ir/Utils/BitSerialAlgorithm.h
@@ -38,10 +38,15 @@ using AccumulateCallback =
 // Generates an optimized LSB-first binary method (double-and-add /
 // square-and-multiply).
 //
-// When `scalar` is defined by an arith::ConstantOp, the loop is fully
-// unrolled into straight-line IR without scf::WhileOp or scf::IfOp.
-// When `scalar` is dynamic, a runtime scf::WhileOp loop with first-iteration
-// unrolling is generated.
+// When `scalar` is defined by an arith::ConstantOp and `allowUnroll` is set,
+// the loop is fully unrolled into straight-line IR without scf::WhileOp or
+// scf::IfOp. When `scalar` is dynamic, or `allowUnroll` is clear, a runtime
+// scf::WhileOp loop with first-iteration unrolling is generated.
+//
+// Clearing `allowUnroll` costs the caller the constant folding the unrolled
+// form exposes, and buys back the instruction count a rolled loop executes;
+// which side wins depends on whether the caller is itself unrolled around
+// this call.
 //
 // Algorithm:
 //   result = identity
@@ -54,7 +59,8 @@ using AccumulateCallback =
 //   return result
 Value generateBitSerialLoop(ImplicitLocOpBuilder &b, Value scalar, Value base,
                             Value identity, DoubleCallback doubleOp,
-                            AccumulateCallback accumulateOp);
+                            AccumulateCallback accumulateOp,
+                            bool allowUnroll = true);
 
 } // namespace mlir::prime_ir
 

--- a/prime_ir/Utils/BitSerialAlgorithm.h
+++ b/prime_ir/Utils/BitSerialAlgorithm.h
@@ -38,15 +38,15 @@ using AccumulateCallback =
 // Generates an optimized LSB-first binary method (double-and-add /
 // square-and-multiply).
 //
-// When `scalar` is defined by an arith::ConstantOp and `allowUnroll` is set,
-// the loop is fully unrolled into straight-line IR without scf::WhileOp or
-// scf::IfOp. When `scalar` is dynamic, or `allowUnroll` is clear, a runtime
+// When `scalar` is defined by an arith::ConstantOp and `unroll` is set, the
+// loop is fully unrolled into straight-line IR without scf::WhileOp or
+// scf::IfOp. When `scalar` is dynamic, or `unroll` is clear, a runtime
 // scf::WhileOp loop with first-iteration unrolling is generated.
 //
-// Clearing `allowUnroll` costs the caller the constant folding the unrolled
-// form exposes, and buys back the instruction count a rolled loop executes;
-// which side wins depends on whether the caller is itself unrolled around
-// this call.
+// Clearing `unroll` costs the caller the constant folding the straight-line
+// form exposes and the compile time every rolled control-flow region adds,
+// and buys back the instruction count a rolled loop executes; which side wins
+// depends on whether the caller is itself unrolled around this call.
 //
 // Algorithm:
 //   result = identity
@@ -60,7 +60,7 @@ using AccumulateCallback =
 Value generateBitSerialLoop(ImplicitLocOpBuilder &b, Value scalar, Value base,
                             Value identity, DoubleCallback doubleOp,
                             AccumulateCallback accumulateOp,
-                            bool allowUnroll = true);
+                            bool unroll = true);
 
 } // namespace mlir::prime_ir
 

--- a/tests/Dialect/Field/bit_serial_constant_unrolling.mlir
+++ b/tests/Dialect/Field/bit_serial_constant_unrolling.mlir
@@ -15,10 +15,13 @@
 
 // Tests that field.powui with constant exponents is unrolled into straight-line
 // IR (no scf.while/scf.if), while dynamic exponents produce a runtime loop.
+// A `unroll = false` attribute keeps the loop for a constant exponent.
 
 // RUN: prime-ir-opt -field-to-mod-arith -canonicalize %s | FileCheck %s -enable-var-scope
 
 !PF = !field.pf<7:i32>
+!GL = !field.pf<18446744069414584321:i64>
+!GL3 = !field.ef<3x!GL, 7:i64>
 
 // exp = 0 → Fermat: 0 % 6 = 0 → identity
 // CHECK-LABEL: @test_powui_const_zero
@@ -98,4 +101,48 @@ func.func @test_powui_const_seven(%base: !PF) -> !PF {
 func.func @test_powui_dynamic(%base: !PF, %exp: i32) -> !PF {
   %res = field.powui %base, %exp : !PF, i32
   return %res : !PF
+}
+
+// A modulus wider than the exponent type must still reach the constant path.
+// The exponent is reduced mod p-1 before any widening, so the literal stays
+// visible; reducing after an arith.extui hid it and fell back to the loop.
+
+// exp = 7 (111₂), p-1 = 2⁶⁴-2³² ≫ 7 → no reduction → 2 squares + 2 muls
+// CHECK-LABEL: @test_powui_wide_modulus_const_seven
+// CHECK-SAME: (%[[BASE:.*]]: [[T:.*]]) -> [[T]]
+// CHECK-NEXT: %[[SQ1:.*]] = mod_arith.square %[[BASE]] : [[T]]
+// CHECK-NEXT: %[[MUL1:.*]] = mod_arith.mul %[[BASE]], %[[SQ1]] : [[T]]
+// CHECK-NEXT: %[[SQ2:.*]] = mod_arith.square %[[SQ1]] : [[T]]
+// CHECK-NEXT: %[[MUL2:.*]] = mod_arith.mul %[[MUL1]], %[[SQ2]] : [[T]]
+// CHECK-NEXT: return %[[MUL2]] : [[T]]
+func.func @test_powui_wide_modulus_const_seven(%base: !GL) -> !GL {
+  %exp = arith.constant 7 : i32
+  %res = field.powui %base, %exp : !GL, i32
+  return %res : !GL
+}
+
+// The order is p³-1 here, wider still than both the modulus and the exponent.
+// CHECK-LABEL: @test_powui_wide_extension_const_five
+// CHECK-NOT: scf.while
+// CHECK: return
+func.func @test_powui_wide_extension_const_five(%base: !GL3) -> !GL3 {
+  %exp = arith.constant 5 : i32
+  %res = field.powui %base, %exp : !GL3, i32
+  return %res : !GL3
+}
+
+// unroll = false keeps the loop even though the exponent is a literal. The
+// reduced exponent still reaches it as a constant — 3 is 7 >> 1, the trip
+// counter after the loop's first-iteration unrolling.
+// CHECK-LABEL: @test_powui_const_no_unroll
+// CHECK-NOT: mod_arith.square
+// CHECK: %[[C3:.*]] = arith.constant 3 : i64
+// CHECK: scf.while (%{{.*}} = %[[C3]]
+// CHECK: mod_arith.square
+// CHECK: scf.if
+// CHECK: mod_arith.mul
+func.func @test_powui_const_no_unroll(%base: !GL) -> !GL {
+  %exp = arith.constant 7 : i32
+  %res = field.powui %base, %exp {unroll = false} : !GL, i32
+  return %res : !GL
 }

--- a/tests/Utils/BitSerialAlgorithmTest.cpp
+++ b/tests/Utils/BitSerialAlgorithmTest.cpp
@@ -67,7 +67,8 @@ protected:
   }
 
   // Builds a ModuleOp with constant scalar and calls generateBitSerialLoop.
-  OwningOpRef<ModuleOp> buildConstantScalarTest(int64_t scalarVal) {
+  OwningOpRef<ModuleOp> buildConstantScalarTest(int64_t scalarVal,
+                                                bool allowUnroll = true) {
     auto i32Type = IntegerType::get(&context, 32);
     OwningOpRef<ModuleOp> module = ModuleOp::create(loc);
     Block *body = module->getBody();
@@ -78,7 +79,7 @@ protected:
     Value identity = b.create<arith::ConstantIntOp>(i32Type, 0);
 
     generateBitSerialLoop(b, scalar, base, identity, getDoubleCallback(),
-                          getAccumulateCallback());
+                          getAccumulateCallback(), allowUnroll);
     return module;
   }
 
@@ -171,6 +172,18 @@ TEST_F(BitSerialAlgorithmTest, DynamicScalar) {
   auto counts = countOps(*module);
   EXPECT_EQ(counts.whileOp, 1);
   EXPECT_GE(counts.ifOp, 1);
+}
+
+// A caller that rolls its own rounds asks for the loop even though the trip
+// count is known: only the two ops of one loop body are emitted, against the
+// three accumulates and two doubles the unrolled form spells out for 7.
+TEST_F(BitSerialAlgorithmTest, ConstantScalarUnrollDisabled) {
+  auto module = buildConstantScalarTest(7, /*allowUnroll=*/false);
+  auto counts = countOps(*module);
+  EXPECT_EQ(counts.whileOp, 1);
+  EXPECT_GE(counts.ifOp, 1);
+  EXPECT_EQ(counts.addIOp, 2);
+  EXPECT_EQ(counts.mulIOp, 1);
 }
 
 } // namespace mlir::prime_ir

--- a/tests/Utils/BitSerialAlgorithmTest.cpp
+++ b/tests/Utils/BitSerialAlgorithmTest.cpp
@@ -68,7 +68,7 @@ protected:
 
   // Builds a ModuleOp with constant scalar and calls generateBitSerialLoop.
   OwningOpRef<ModuleOp> buildConstantScalarTest(int64_t scalarVal,
-                                                bool allowUnroll = true) {
+                                                bool unroll = true) {
     auto i32Type = IntegerType::get(&context, 32);
     OwningOpRef<ModuleOp> module = ModuleOp::create(loc);
     Block *body = module->getBody();
@@ -79,7 +79,7 @@ protected:
     Value identity = b.create<arith::ConstantIntOp>(i32Type, 0);
 
     generateBitSerialLoop(b, scalar, base, identity, getDoubleCallback(),
-                          getAccumulateCallback(), allowUnroll);
+                          getAccumulateCallback(), unroll);
     return module;
   }
 
@@ -178,7 +178,7 @@ TEST_F(BitSerialAlgorithmTest, DynamicScalar) {
 // count is known: only the two ops of one loop body are emitted, against the
 // three accumulates and two doubles the unrolled form spells out for 7.
 TEST_F(BitSerialAlgorithmTest, ConstantScalarUnrollDisabled) {
-  auto module = buildConstantScalarTest(7, /*allowUnroll=*/false);
+  auto module = buildConstantScalarTest(7, /*unroll=*/false);
   auto counts = countOps(*module);
   EXPECT_EQ(counts.whileOp, 1);
   EXPECT_GE(counts.ifOp, 1);


### PR DESCRIPTION
## Description

The constant-exponent fast path was reachable only on a field whose modulus is
no wider than the exponent type. Everywhere else the exponent got widened to
the modulus width first, and the resulting `arith.extui` hid the literal from
the match that rebuilds the reduced exponent as a constant — so Goldilocks,
secp256k1 and the BN254 scalar field with the usual `i32` exponent all lowered
a literal exponent to the runtime bit-serial loop. Reducing mod the group order
before any widening keeps the literal visible, and the dynamic path is
unchanged.

Making the unrolled form unconditional is not free, which is why the `unroll`
attribute comes with the fix rather than after it. Measured on an RTX 5090
(sm_120a), Goldilocks W16 sparse Poseidon executes ~4.5% more instructions per
warp with a straight-line chain per S-box than with the loop (4-8% of kernel
time depending on shape) — a permutation that rolls its own rounds does not
want its S-box unrolled, while a caller already unrolled around the op does.
The mechanism behind that measurement is still unexplained; the attribute lets
both sides pick without waiting on it.

The consumer side is not wired up here: nothing sets `unroll = false` yet, so
this repo's behavior change is the compile-time fix alone.

## Related Issues/PRs

Closes #445

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline