### PR TITLE
fix(dialect/field): give field.powui's unroll a builder default

### DIFF
--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
@@ -803,7 +803,7 @@ struct ConvertPowUI : public OpConversionPattern<PowUIOp> {
     }
 
     unsigned expBitWidth = cast<IntegerType>(exp.getType()).getWidth();
-    bool unroll = op.getUnroll().value_or(true);
+    bool unroll = op.getUnroll();
 
     auto emitBitSerialLoop = [&](Value exp) {
       return generateBitSerialLoop(

--- a/prime_ir/Dialect/Field/IR/FieldOps.td
+++ b/prime_ir/Dialect/Field/IR/FieldOps.td
@@ -353,15 +353,17 @@ def Field_PowUIOp : Field_Op<"powui", [TypesMatchWith<
   let description = [{
     Computes the field element a raised to the power of unsigned integer b.
 
-    The optional `unroll` attribute picks the shape of the lowered
-    square-and-multiply schedule for a compile-time-constant exponent: absent
-    or `true` emits it straight-line, `false` keeps the bit-serial loop. Each
-    rolled call site is a control-flow region LLVM has to simplify, so a caller
-    that spells out many of them (a Poseidon permutation applying one S-box per
-    round) pays for the loop in compile time and is measured to execute
-    slightly fewer instructions with it; a caller already unrolled around this
-    op wants the straight-line form and the constant folding it exposes. A
-    dynamic exponent always lowers to the loop.
+    The `unroll` attribute picks the shape of the lowered square-and-multiply
+    schedule for a compile-time-constant exponent: `true` emits it
+    straight-line, `false` keeps the bit-serial loop. It defaults to `true`, so
+    an absent attribute and a builder call that does not name it both mean
+    unrolled, and `false` is the only value a caller ever has to spell out.
+    Each rolled call site is a control-flow region LLVM has to simplify, so a
+    caller that spells out many of them (a Poseidon permutation applying one
+    S-box per round) pays for the loop in compile time and is measured to
+    execute slightly fewer instructions with it; a caller already unrolled
+    around this op wants the straight-line form and the constant folding it
+    exposes. A dynamic exponent always lowers to the loop.
 
     Example:
     ```
@@ -370,7 +372,7 @@ def Field_PowUIOp : Field_Op<"powui", [TypesMatchWith<
     ```
   }];
   let arguments = (ins FieldLike:$base, SignlessIntegerLike:$exp,
-                       OptionalAttr<BoolAttr>:$unroll);
+                       DefaultValuedOptionalAttr<BoolAttr, "true">:$unroll);
   let results = (outs FieldLike:$output);
   let assemblyFormat = "operands attr-dict `:` type($base) `,` type($exp)";
 }

--- a/tests/Dialect/Field/BUILD.bazel
+++ b/tests/Dialect/Field/BUILD.bazel
@@ -108,6 +108,18 @@ prime_ir_cc_test(
 )
 
 prime_ir_cc_test(
+    name = "PowUIOpTest",
+    srcs = ["PowUIOpTest.cpp"],
+    deps = [
+        "//prime_ir/Dialect/EllipticCurve/IR:EllipticCurve",
+        "//prime_ir/Dialect/Field/IR:Field",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+prime_ir_cc_test(
     name = "CreateFieldConstantTest",
     srcs = ["CreateFieldConstantTest.cpp"],
     deps = [

--- a/tests/Dialect/Field/PowUIOpTest.cpp
+++ b/tests/Dialect/Field/PowUIOpTest.cpp
@@ -1,0 +1,140 @@
+/* Copyright 2026 The PrimeIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// The invariant these cases hold: a `field.powui` builder call that names only
+// the operands compiles, and means unrolled.
+//
+// It is easy to break. ODS gives a plain `OptionalAttr` a *required* trailing
+// builder parameter, so declaring `unroll` that way silently turned every
+// operand-only call into a compile error — for consumers only, since prime-ir
+// has no C++ caller of its own outside this file, and no lit test can reach a
+// builder signature. Declaring it `DefaultValuedOptionalAttr` is what puts the
+// `= true` back on the parameter. The same trap waits for the next attribute
+// added to any op in this pinned dialect.
+
+#include "gtest/gtest.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "prime_ir/Dialect/Field/IR/FieldDialect.h"
+#include "prime_ir/Dialect/Field/IR/FieldOps.h"
+#include "prime_ir/Dialect/Field/IR/FieldTypes.h"
+
+namespace mlir::prime_ir::field {
+namespace {
+
+class PowUIOpTest : public testing::Test {
+protected:
+  void SetUp() override {
+    context.loadDialect<FieldDialect>();
+    module = ModuleOp::create(UnknownLoc::get(&context));
+  }
+
+  Location loc() { return UnknownLoc::get(&context); }
+
+  // A builder anchored in the module body, so created ops have somewhere to go.
+  OpBuilder bodyBuilder() {
+    OpBuilder b(&context);
+    b.setInsertionPointToStart(module->getBody());
+    return b;
+  }
+
+  // The op only needs operands of the right type, not defined values, so an
+  // unrealized cast stands in for whatever would really produce them.
+  Value makeValue(OpBuilder &b, Type type) {
+    return UnrealizedConversionCastOp::create(b, loc(), TypeRange{type},
+                                              ValueRange{})
+        .getResult(0);
+  }
+
+  PrimeFieldType fieldType() {
+    return PrimeFieldType::get(
+        &context, IntegerAttr::get(IntegerType::get(&context, 32), 7),
+        /*isMontgomery=*/false);
+  }
+
+  MLIRContext context;
+  OwningOpRef<ModuleOp> module;
+};
+
+// The regression guard. This call is exactly the shape that broke in xla's
+// Poseidon S-box emitter and `mhlo.pow` lowering: operands, no attribute.
+TEST_F(PowUIOpTest, OperandOnlyBuilderDefaultsToUnrolled) {
+  OpBuilder b = bodyBuilder();
+  Value base = makeValue(b, fieldType());
+  Value exp = makeValue(b, b.getI32Type());
+
+  auto op = PowUIOp::create(b, loc(), base, exp);
+
+  EXPECT_TRUE(op.getUnroll());
+  EXPECT_EQ(op.getOutput().getType(), base.getType());
+}
+
+// The same call through the result-typed overload, which is the one a
+// conversion pattern with an explicit target type reaches for.
+TEST_F(PowUIOpTest, ResultTypedOperandOnlyBuilderDefaultsToUnrolled) {
+  OpBuilder b = bodyBuilder();
+  Value base = makeValue(b, fieldType());
+  Value exp = makeValue(b, b.getI32Type());
+
+  auto op = PowUIOp::create(b, loc(), fieldType(), base, exp);
+
+  EXPECT_TRUE(op.getUnroll());
+}
+
+// ImplicitLocOpBuilder is what the in-tree lowerings use, so it has to drop
+// the attribute too.
+TEST_F(PowUIOpTest, ImplicitLocBuilderDefaultsToUnrolled) {
+  OpBuilder outer = bodyBuilder();
+  ImplicitLocOpBuilder b(loc(), outer);
+  Value base = makeValue(outer, fieldType());
+  Value exp = makeValue(outer, outer.getI32Type());
+
+  auto op = PowUIOp::create(b, base, exp);
+
+  EXPECT_TRUE(op.getUnroll());
+}
+
+// `false` is the only value a caller ever has to spell out, so it must survive
+// the trip through the defaulted parameter.
+TEST_F(PowUIOpTest, ExplicitFalseIsKept) {
+  OpBuilder b = bodyBuilder();
+  Value base = makeValue(b, fieldType());
+  Value exp = makeValue(b, b.getI32Type());
+
+  auto op = PowUIOp::create(b, loc(), base, exp, /*unroll=*/false);
+
+  EXPECT_FALSE(op.getUnroll());
+}
+
+// An op whose attribute is genuinely absent — every `field.powui` in a .mlir
+// file written before the attribute existed — still reads as unrolled. This is
+// the accessor's default fallback, distinct from what the builder materializes.
+TEST_F(PowUIOpTest, AbsentAttributeReadsAsUnrolled) {
+  OpBuilder b = bodyBuilder();
+  Value base = makeValue(b, fieldType());
+  Value exp = makeValue(b, b.getI32Type());
+
+  auto op = PowUIOp::create(b, loc(), base, exp, /*unroll=*/false);
+  // The attribute is inherent, so it lives in the op's properties rather than
+  // the discardable dictionary — `removeAttr` would not touch it.
+  op.removeUnrollAttr();
+
+  ASSERT_FALSE(op.getUnrollAttr());
+  EXPECT_TRUE(op.getUnroll());
+}
+
+} // namespace
+} // namespace mlir::prime_ir::field

--- a/tests/Dialect/Field/powui_unroll_roundtrip.mlir
+++ b/tests/Dialect/Field/powui_unroll_roundtrip.mlir
@@ -1,0 +1,57 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// `field.powui`'s `unroll` attribute defaults to `true`, so the assembly has
+// exactly two spellings: absent (or explicit `true`, which the printer elides)
+// and `unroll = false`. Piping through prime-ir-opt twice pins that the elided
+// form re-parses to the same op rather than drifting on each round trip.
+// The lowering these spellings select is covered by
+// bit_serial_constant_unrolling.mlir.
+
+// RUN: prime-ir-opt %s | prime-ir-opt | FileCheck %s -enable-var-scope
+
+!GL = !field.pf<18446744069414584321:i64>
+
+// CHECK-LABEL: @powui_unroll_absent
+// CHECK-SAME: (%[[BASE:.*]]: [[T:.*]], %[[EXP:.*]]: i32)
+// CHECK-NEXT: %[[RES:.*]] = field.powui %[[BASE]], %[[EXP]] : [[T]], i32
+// CHECK-NEXT: return %[[RES]] : [[T]]
+func.func @powui_unroll_absent(%base: !GL, %exp: i32) -> !GL {
+  %res = field.powui %base, %exp : !GL, i32
+  return %res : !GL
+}
+
+// An explicit `true` is the default, so it prints elided — byte for byte the
+// same line as the absent case above. That is what keeps the attribute's
+// arrival off every existing .mlir file and every FileCheck pattern written
+// before it.
+// CHECK-LABEL: @powui_unroll_true
+// CHECK-SAME: (%[[BASE:.*]]: [[T:.*]], %[[EXP:.*]]: i32)
+// CHECK-NEXT: %[[RES:.*]] = field.powui %[[BASE]], %[[EXP]] : [[T]], i32
+// CHECK-NEXT: return %[[RES]] : [[T]]
+func.func @powui_unroll_true(%base: !GL, %exp: i32) -> !GL {
+  %res = field.powui %base, %exp {unroll = true} : !GL, i32
+  return %res : !GL
+}
+
+// `false` is the only value that has to survive in the text.
+// CHECK-LABEL: @powui_unroll_false
+// CHECK-SAME: (%[[BASE:.*]]: [[T:.*]], %[[EXP:.*]]: i32)
+// CHECK-NEXT: %[[RES:.*]] = field.powui %[[BASE]], %[[EXP]] {unroll = false} : [[T]], i32
+// CHECK-NEXT: return %[[RES]] : [[T]]
+func.func @powui_unroll_false(%base: !GL, %exp: i32) -> !GL {
+  %res = field.powui %base, %exp {unroll = false} : !GL, i32
+  return %res : !GL
+}


### PR DESCRIPTION
## Description

An `OptionalAttr` in ODS is optional in the IR but **required** in the generated
C++ builders — every `create()` overload takes it with no default. So #446's new
`unroll` attribute quietly made `PowUIOp::create(b, loc, base, exp)` a compile
error for every consumer, while prime-ir's own CI stayed green: nothing in this
repo calls the builder. It surfaced two repos away, in the automated stablehlo
bump on xla (fractalyze/xla#657), where the Poseidon S-box emitter and the
`mhlo.pow` scalar lowering both failed to build.

`DefaultValuedOptionalAttr` is the fix because the op already *meant* `true` when
the attribute was absent — `getUnroll().value_or(true)` in `ConvertPowUI`. Only
the builders disagreed with the semantics, so this makes them agree rather than
changing behavior. The assembly is unaffected: the printer elides an explicit
`true`, so absent, omitted-from-the-builder and `unroll = true` all print
identically, and existing `.mlir` files and FileCheck patterns are untouched.

`PowUIOpTest.cpp` exists because no lit test can reach a builder signature — only
a C++ caller can, and this op had none in-tree. Reverting the one `.td` line
makes it fail with xla#657's exact diagnostic; I checked. It also pins that an
op whose attribute is genuinely absent still reads as unrolled, which is a
different code path from the builder's default and needs the generated
`removeUnrollAttr()` to reach (the attribute is inherent, so it lives in the op's
properties and `removeAttr` silently does nothing).

The general rule, which cost a consumer's bump PR to learn: **a new attribute on
an existing op in a pinned MLIR dialect is a source-compat change for every C++
consumer.** Declare it `DefaultValued*`, or add an explicit builder that omits
it, in the same commit.

After this merges the pin-bump bots carry it prime-ir → stablehlo → xla and
supersede fractalyze/xla#657; xla itself needs no change.

## Related Issues/PRs

- Fixes the source-compat break introduced by #446. Tracked as a draft item on
  the [fractalyze work board](https://github.com/orgs/fractalyze/projects/15)
  (drafts have no issue number, so this PR cannot auto-close it — the board item
  is flipped to Done manually on merge).
- Unblocks fractalyze/xla#657.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline

🤖 Generated with [Claude Code](https://claude.com/claude-code)