### PR TITLE
perf(dialect/mod_arith): fold the carry before canonicalizing a full-width add

### DIFF
--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/MontReducer.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/MontReducer.cpp
@@ -96,16 +96,18 @@ Value MontReducer::getCanonicalFromExtended(Value input, uint64_t bound) {
 
 Value MontReducer::getCanonicalFromExtended(Value input, Value overflow) {
   auto cmod = createModulusConst(input.getType(), input);
-  // Canonicalize `overflow·2^w + input` (input ∈ [0, 2p)) in 3 ALU ops, not 4.
-  // `min(input - p, input)` picks input when input < p (the subtract wraps up)
-  // and input - p when input ≥ p — folding the compare into a minui; overflow
-  // forces the subtract branch. Byte-identical to the old
-  // `(input >= p || overflow) ? input - p : input`, minus the cmpi+ori. Uses
-  // subtract-of-p, not getCanonicalDiff's add-of-p, so min stays safe.
+  // Fold the carry first, then one conditional subtract on the selected value:
+  // `s2 = overflow ? input - p : input; min(s2 - p, s2)`. Not the shorter
+  // `overflow ? input - p : min(input - p, input)`: that keeps the carry
+  // predicate live across the minui and ptxas -O3 schedules it into the
+  // register ceiling (255 registers with spills vs 88, fractalyze/xla#655).
+  // Shorter spellings get rewritten into that form by InstCombine or the NVPTX
+  // backend; this one has no select arm equal to a minui operand, so it stays.
   auto sub = arith::SubIOp::create(b, input, cmod);
-  auto min = arith::MinUIOp::create(b, sub, input);
-  auto select = arith::SelectOp::create(b, overflow, sub, min);
-  return select.getResult();
+  auto folded = arith::SelectOp::create(b, overflow, sub, input);
+  auto sub2 = arith::SubIOp::create(b, folded, cmod);
+  auto min = arith::MinUIOp::create(b, sub2, folded);
+  return min.getResult();
 }
 
 Value MontReducer::getCanonicalDiff(Value lhs, Value rhs) {

--- a/tests/Dialect/ModArith/mod_arith_to_arith.mlir
+++ b/tests/Dialect/ModArith/mod_arith_to_arith.mlir
@@ -347,13 +347,14 @@ func.func @test_lower_sub_goldilocks(%lhs : !Gp, %rhs : !Gp) -> !Gp {
 func.func @test_lower_add_goldilocks(%lhs : !Gadd, %rhs : !Gadd) -> !Gadd {
   // CHECK-NOT: mod_arith.add
   // CHECK: %[[SUM:.*]], %[[OVF:.*]] = arith.addui_extended %[[LHS]], %[[RHS]] : [[T]], i1
-  // The old cmpi + ori canonicalize must not appear anywhere in the add slice.
-  // CHECK-NOT: arith.cmpi
-  // CHECK-NOT: arith.ori
   // CHECK: %[[CMOD:.*]] = arith.constant -4294967295 : [[T]]
   // CHECK: %[[SUB:.*]] = arith.subi %[[SUM]], %[[CMOD]] : [[T]]
-  // CHECK: %[[MIN:.*]] = arith.minui %[[SUB]], %[[SUM]] : [[T]]
-  // CHECK: %[[RES:.*]] = arith.select %[[OVF]], %[[SUB]], %[[MIN]] : [[T]]
+  // Select first, then minui on the selected value — never `ovf ? sub :
+  // min(sub, sum)`, which ptxas schedules into the register ceiling
+  // (fractalyze/xla#655).
+  // CHECK: %[[S2:.*]] = arith.select %[[OVF]], %[[SUB]], %[[SUM]] : [[T]]
+  // CHECK: %[[SUB2:.*]] = arith.subi %[[S2]], %[[CMOD]] : [[T]]
+  // CHECK: %[[RES:.*]] = arith.minui %[[SUB2]], %[[S2]] : [[T]]
   // CHECK-NOT: arith.cmpi
   // CHECK-NOT: arith.ori
   // CHECK: return %[[RES]] : [[T]]


### PR DESCRIPTION
## Description

The canonical full-width add (Goldilocks) lowered its tail as `overflow ? sum - p : min(sum - p, sum)`. ptxas -O2/-O3 (CUDA 12.9–13.3, sm_120a) schedules that spelling into the register ceiling: with 16 lanes of these interleaved the carry predicate stays live across the minui, ptxas runs out of predicate registers, packs them into GPR bitmasks and then batches multiplies while deferring their reductions. Program-order liveness of the PTX peaks near 100 registers; ptxas allocates 255 and spills. A 16-lane inline-asm reproducer shows 255 registers with spills for that form against 78–88 for any spelling that consumes the predicate first, and a Goldilocks W16 sparse-Poseidon permutation with ~1k of these adds ran 1.3x slower than the same PTX assembled at -O1 (fractalyze/xla#655).

The shorter rewrites do not survive to ptxas: InstCombine hoists the select back out of `min(sub, overflow ? sub : sum)`, and the NVPTX backend turns `(sum >= p || overflow) ? sub : sum` into nested selects and folds the inner one to umin. Both were confirmed in xla's `ir-with-opt` dumps. The two-stage form here — fold the carry with a select, then canonicalize the selected value as `min(s2 - p, s2)` — has no select arm equal to a minui operand, so nothing hoists it. One ALU op more per add. The multiply path (`SolinasReducer`) already had this order, which is why only the add was affected.

Measured through xla with this branch as a repository override, Goldilocks W16, RTX 5090:

| | before | after |
|---|---|---|
| emitted sparse-Poseidon permute, registers / spills | 255 / ~3.4 KB each way | 88 / 0 |
| permute kernel, 1M rows | 3.71 ms | 3.01 ms |
| permute kernel, 4096 rows | 103.7 us | 109.5 us |
| merkle_damgard sponge, 1M rows | — | 8.36 ms |
| Poseidon2 W16 on xla's CPU emitter, 262,144 rows | 348–369 ms | 246–289 ms |

The 4096-row launch is 5% slower: that regime is instruction-fetch bound and the add is one instruction longer. The CPU line is the check on the extra op: x86 codegen is the same length in scalar code and two instructions longer in AVX-512, yet the kernel is faster with it too; the old form is awkward for cmov scheduling as well. xla's CPU Poseidon/sponge/field tests pass against this branch.

## Related Issues/PRs

- fractalyze/xla#655 — the register-pressure investigation this closes the root cause of
- #446, #447 — the `field.powui` work that ruled out the other candidates

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
