### PR TITLE
build: add a real MODULE.bazel and bzlmod CI lanes

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,4 @@
+# A standalone Bazel module used to verify that prime_ir resolves as a non-root
+# dependency. It has its own MODULE.bazel and is built by its own CI lane, so
+# the repository's own `//...` must not descend into it.
+bazel/bzlmod_consumer

--- a/.bazelrc
+++ b/.bazelrc
@@ -13,9 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# NOTE: Currently, building with Bzlmod causes a python_repository attribute error
-# (e.g., missing python_version_kind).
+# The WORKSPACE build is the default so that Bazel 7 consumers stay green.
 common --noenable_bzlmod
+
+# The opt-in bzlmod lane. Ignores WORKSPACE.bazel entirely and resolves through
+# MODULE.bazel instead. It builds prime_ir as the *root* module, where
+# `archive_override` still applies, so it does not by itself prove what a
+# consumer gets — //bazel/bzlmod_consumer covers that.
+common:bzlmod --enable_bzlmod
+common:bzlmod --noenable_workspace
 
 build --cxxopt=-std=c++17
 build --host_cxxopt=-std=c++17

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,52 @@ jobs:
         if: ${{ failure() }}
         uses: fractalyze/.github/.github/actions/upload-bazel-testlogs@main
 
+  # The same tests, resolved through MODULE.bazel instead of WORKSPACE.bazel.
+  # Always the full suite: bazel-diff hashes the WORKSPACE lane's targets, and
+  # the two lanes' repository names differ, so its impacted-target set does not
+  # carry over.
+  build-and-test-bzlmod:
+    runs-on: [self-hosted, cpu]
+    steps:
+      - name: Checkout PrimeIR
+        uses: actions/checkout@v4
+
+      - name: Run `bazel test`
+        run: |
+          bazel --bazelrc=.bazelrc.ci test \
+            --config=ci \
+            --config=bzlmod \
+            //...
+
+      - name: Upload bazel test logs
+        if: ${{ failure() }}
+        uses: fractalyze/.github/.github/actions/upload-bazel-testlogs@main
+
+  # PrimeIR's own bzlmod lane builds it as the *root* module, where
+  # `archive_override` and patches still apply; a consumer resolves it as a
+  # non-root module, where they do not. Only a separate module can tell the two
+  # apart, so this lane builds one — the second acceptance criterion of #455.
+  bzlmod-consumer:
+    runs-on: [self-hosted, cpu]
+    steps:
+      - name: Checkout PrimeIR
+        uses: actions/checkout@v4
+
+      - name: Run `bazel test` in the consumer module
+        working-directory: bazel/bzlmod_consumer
+        run: bazel test --config=ci //...
+
+      - name: Resolve every PrimeIR target as a dependency
+        working-directory: bazel/bzlmod_consumer
+        run: |
+          bazel build --config=ci \
+            @prime_ir//prime_ir/... \
+            @prime_ir//tools/...
+
+      - name: Upload bazel test logs
+        if: ${{ failure() }}
+        uses: fractalyze/.github/.github/actions/upload-bazel-testlogs@main
+
   pre-commit-style:
     if: github.actor != 'fractalyze-dev'
     runs-on: [self-hosted, cpu]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,8 @@ jobs:
   # PrimeIR's own bzlmod lane builds it as the *root* module, where
   # `archive_override` and patches still apply; a consumer resolves it as a
   # non-root module, where they do not. Only a separate module can tell the two
-  # apart, so this lane builds one — the second acceptance criterion of #455.
+  # apart, so this lane builds one, and proves that a project can `bazel_dep` on
+  # PrimeIR and resolve every target it references.
   bzlmod-consumer:
     runs-on: [self-hosted, cpu]
     steps:
@@ -85,12 +86,12 @@ jobs:
 
       - name: Run `bazel test` in the consumer module
         working-directory: bazel/bzlmod_consumer
-        run: bazel test --config=ci //...
+        run: bazel --bazelrc=.bazelrc.ci test --config=ci //...
 
       - name: Resolve every PrimeIR target as a dependency
         working-directory: bazel/bzlmod_consumer
         run: |
-          bazel build --config=ci \
+          bazel --bazelrc=.bazelrc.ci build --config=ci \
             @prime_ir//prime_ir/... \
             @prime_ir//tools/...
 

--- a/.github/workflows/pin-bump.yml
+++ b/.github/workflows/pin-bump.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           upstream_repo: zk_dtypes
           upstream_commit: ${{ github.event.client_payload.commit }}
-          pin_file: third_party/zk_dtypes/workspace.bzl
+          # Both lanes pin zk_dtypes and must move together; MODULE.bazel
+          # cannot load() the WORKSPACE lane's pin, so it spells out its own.
+          # //third_party/zk_dtypes:pin_sync_test fails if they drift.
+          pin_file: |
+            third_party/zk_dtypes/workspace.bzl
+            MODULE.bazel
           var_prefix: ZK_DTYPES
           github_token: ${{ secrets.BUMPER_GH_PAT }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,15 @@
 # website: https://bazel.build/
 
 # Ignore all bazel-* symlinks. There is no full list since this can change
-# based on the name of the directory bazel is cloned into.
+# based on the name of the directory bazel is cloned into. The second pattern
+# covers nested Bazel modules such as bazel/bzlmod_consumer.
 /bazel-*
+**/bazel-*
+
+# Resolution artifact of the bazel/bzlmod_consumer fixture. Deliberately not
+# pinned: the fixture exists to check what a consumer resolves today, and a
+# checked-in lockfile would mask a change in that resolution.
+/bazel/bzlmod_consumer/MODULE.bazel.lock
 
 # Directories for the Bazel IntelliJ plugin containing the generated
 # IntelliJ project files and plugin configuration. Seperate directories are

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -15,6 +15,10 @@
 
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 
+# Read by //third_party/zk_dtypes:pin_sync_test, which compares the zk_dtypes
+# pin declared here against the one the WORKSPACE lane uses.
+exports_files(["MODULE.bazel"])
+
 bool_flag(
     name = "has_avx512",
     build_setting_default = False,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,10 +15,11 @@ refresh the patches we carry in this repository.
 
 1. Point Bazel to the local clone while you iterate:
 
-   - Uncomment the `http_archive(name = "llvm-raw", …)` stanza in
-     `WORKSPACE.bazel`.
+   - Comment out the `http_archive(name = "llvm-raw", …)` stanza in
+     `third_party/llvm-project/workspace.bzl`. Both dependency lanes call that
+     file, so the swap covers `--config=bzlmod` as well.
 
-   - Uncomment the `new_local_repository` entry:
+   - Uncomment the `new_local_repository` entry below it:
 
      ```
      new_local_repository(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,129 @@
+# Copyright 2026 The PrimeIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""PrimeIR as a Bazel module.
+
+The WORKSPACE build stays the default; `--config=bzlmod` builds through this
+file, which is also what a consumer gets when it declares a `bazel_dep` on
+prime_ir. `WORKSPACE.bazel` is the other half of that pairing and has to be kept
+in step: every repository named here is declared either as a `bazel_dep` or by a
+module extension that wraps the same `.bzl` the WORKSPACE build calls, so a
+dependency added to one lane has one obvious home in the other.
+
+Nothing here may carry a patch or a `single_version_override`. Bazel applies
+both only for the root module, so a consumer would silently resolve the
+unpatched dependency. The patched LLVM is safe because its patches hang off an
+`http_archive` inside a module extension, which runs identically for every root
+module — see `//bazel:llvm_deps.bzl`.
+
+`archive_override` is root-only for the same reason, so a consumer of prime_ir
+has to repeat the zk_dtypes override below alongside its own override of
+prime_ir: neither fork is in a registry, and a non-root module cannot pull a
+dependency in from outside one. `//bazel/bzlmod_consumer` is a worked example.
+"""
+
+module(
+    # Tracks the repository's release tags; bump both together.
+    name = "prime_ir",
+    version = "2.0.0",
+    compatibility_level = 1,
+)
+
+# Repo names match the WORKSPACE build so that first-party BUILD files read the
+# same under both. Versions are the WORKSPACE pins where the registry carries
+# them; every deviation is noted at the dependency.
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.13")
+bazel_dep(name = "rules_python", version = "1.6.0")
+bazel_dep(name = "abseil-cpp", version = "20250814.0", repo_name = "com_google_absl")
+bazel_dep(name = "googletest", version = "1.17.0", repo_name = "com_google_googletest")
+
+# Not loaded by any first-party file. LLVM's Bazel overlay loads `sh_binary`
+# from it, and `@llvm-project` is a module-extension repository, so it resolves
+# `@rules_shell` through *this* module's mapping — which only a `bazel_dep`
+# here puts it in.
+bazel_dep(name = "rules_shell", version = "0.2.0")
+
+# Not in any registry, so a `bazel_dep` alone cannot resolve it. The override
+# pins the same archive `//third_party/zk_dtypes:workspace.bzl` fetches on the
+# WORKSPACE lane; the two are checked against each other by
+# `//third_party/zk_dtypes:pin_sync_test`.
+bazel_dep(name = "zk_dtypes", version = "0.0.17")
+archive_override(
+    module_name = "zk_dtypes",
+    integrity = "sha256-8pEUJbq+GJCpyE/VGRcU6cMJUxgyUTO1dpOWiVY7yRw=",
+    strip_prefix = "zk_dtypes-7a42ac4f9c3213925ac523c6871b580db96f9b8d",
+    urls = ["https://github.com/fractalyze/zk_dtypes/archive/7a42ac4f9c3213925ac523c6871b580db96f9b8d/zk_dtypes-7a42ac4f9c3213925ac523c6871b580db96f9b8d.tar.gz"],
+)
+
+# `bazel_features` and `rules_java` have no `bazel_dep`. The WORKSPACE build
+# declares both only to order and complete its own macro chain — `bazel_features`
+# ahead of zk_dtypes' python setup, because http_archive resolution is
+# first-wins, and `rules_java` to run the setup macros rules_python's WORKSPACE
+# path leaves to the caller. Under bzlmod version resolution does the ordering
+# and rules_python brings its own Java support in, and no first-party file loads
+# from either repository.
+#
+# `rules_cuda` likewise has none. The WORKSPACE build registers a CUDA toolchain,
+# but no target in this repository is a CUDA rule, so the registration has
+# nothing to apply to. A first CUDA target needs a `bazel_dep` plus a
+# `register_toolchains` here, not just the archive.
+
+non_module_deps = use_extension("//bazel:non_module_deps.bzl", "non_module_deps")
+use_repo(
+    non_module_deps,
+    "local_config_omp",
+    "nanobind",
+    "pybind11",
+    "robin_map",
+)
+
+llvm_deps = use_extension("//bazel:llvm_deps.bzl", "llvm_deps")
+use_repo(llvm_deps, "llvm-raw", "llvm_zlib", "llvm_zstd")
+
+# Second, and after the `use_repo` above: this extension's `.bzl` loads out of
+# `@llvm-raw`, so that repository has to be in this module's mapping first.
+llvm_project = use_extension("//bazel:llvm_configure.bzl", "llvm_project")
+use_repo(llvm_project, "llvm-project")
+
+dev_deps = use_extension("//bazel:dev_deps.bzl", "dev_deps", dev_dependency = True)
+use_repo(dev_deps, "hedron_compile_commands")
+
+# The WORKSPACE build reaches hermetic Python through zk_dtypes' `python_init_*`
+# macros, which wrap these same rules_python extensions and add
+# `@python_version_repo`. That repository exists only for the pywrap rules
+# vendored in `//third_party/rules_pywrap`, which no build target loads — it is
+# listed as a `bzl_library` source and nothing more — so the bzlmod lane does
+# without it.
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(
+    is_default = True,
+    python_version = "3.11",
+)
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+pip.parse(
+    hub_name = "prime_ir_pypi",
+    python_version = "3.11",
+    requirements_lock = "//:requirements_lock_3_11.txt",
+)
+
+# The hub cannot be named `pypi` outright: rules_python keys hubs across the
+# whole module graph and rejects a second one by the same name ("Duplicate
+# cross-module pip hub named 'pypi'"), which zk_dtypes already declares.
+# Aliasing here keeps the `@pypi` labels in first-party BUILD files reading the
+# same on both lanes.
+use_repo(pip, pypi = "prime_ir_pypi")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -59,14 +59,26 @@ bazel_dep(name = "rules_shell", version = "0.2.0")
 
 # Not in any registry, so a `bazel_dep` alone cannot resolve it. The override
 # pins the same archive `//third_party/zk_dtypes:workspace.bzl` fetches on the
-# WORKSPACE lane; the two are checked against each other by
-# `//third_party/zk_dtypes:pin_sync_test`.
+# WORKSPACE lane. MODULE.bazel cannot `load()`, so that pin cannot be shared
+# between the two lanes and is spelled out again here; the pair is held together
+# from both ends — `//third_party/zk_dtypes:pin_sync_test` fails if they drift,
+# and `.github/workflows/pin-bump.yml` lists both files so an automated bump
+# moves them in one commit. The prefixed variable names are what let that
+# substitution find the pin in either file, so keep this shape.
+#
+# `archive_override` takes `integrity` and not the `sha256` the
+# WORKSPACE lane's `http_archive` takes: the same digest, base64 rather than
+# hex. `pin_sync_test` converts between the two before comparing.
+ZK_DTYPES_COMMIT = "7a42ac4f9c3213925ac523c6871b580db96f9b8d"
+
+ZK_DTYPES_INTEGRITY = "sha256-8pEUJbq+GJCpyE/VGRcU6cMJUxgyUTO1dpOWiVY7yRw="
+
 bazel_dep(name = "zk_dtypes", version = "0.0.17")
 archive_override(
     module_name = "zk_dtypes",
-    integrity = "sha256-8pEUJbq+GJCpyE/VGRcU6cMJUxgyUTO1dpOWiVY7yRw=",
-    strip_prefix = "zk_dtypes-7a42ac4f9c3213925ac523c6871b580db96f9b8d",
-    urls = ["https://github.com/fractalyze/zk_dtypes/archive/7a42ac4f9c3213925ac523c6871b580db96f9b8d/zk_dtypes-7a42ac4f9c3213925ac523c6871b580db96f9b8d.tar.gz"],
+    integrity = ZK_DTYPES_INTEGRITY,
+    strip_prefix = "zk_dtypes-" + ZK_DTYPES_COMMIT,
+    urls = ["https://github.com/fractalyze/zk_dtypes/archive/{commit}/zk_dtypes-{commit}.tar.gz".format(commit = ZK_DTYPES_COMMIT)],
 )
 
 # `bazel_features` and `rules_java` have no `bazel_dep`. The WORKSPACE build

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -215,7 +215,7 @@
     },
     "//bazel:llvm_deps.bzl%llvm_deps": {
       "general": {
-        "bzlTransitiveDigest": "M4KtxpRFI9BUdknqxYVHcwod/hb19IcVRGwmC4ncVmU=",
+        "bzlTransitiveDigest": "6ZmNRtA5fSiza7gZgNDTNJmughZBYGbsowY+3ElClsI=",
         "usagesDigest": "A+FIwusu1QtSKzvBNGPEMYQivz4R7XyFQKYz/k1oxHA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -7,16 +7,25 @@
     "https://bcr.bazel.build/modules/abseil-cpp/20230125.1/MODULE.bazel": "89047429cb0207707b2dface14ba7f8df85273d484c2572755be4bab7ce9c3a0",
     "https://bcr.bazel.build/modules/abseil-cpp/20230802.0.bcr.1/MODULE.bazel": "1c8cec495288dccd14fdae6e3f95f772c1c91857047a098fad772034264cc8cb",
     "https://bcr.bazel.build/modules/abseil-cpp/20230802.0/MODULE.bazel": "d253ae36a8bd9ee3c5955384096ccb6baf16a1b1e93e858370da0a3b94f77c16",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.1/MODULE.bazel": "fa92e2eb41a04df73cdabeec37107316f7e5272650f81d6cc096418fe647b915",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/MODULE.bazel": "37bcdb4440fbb61df6a1c296ae01b327f19e9bb521f9b8e26ec854b6f97309ed",
     "https://bcr.bazel.build/modules/abseil-cpp/20240116.2/MODULE.bazel": "73939767a4686cd9a520d16af5ab440071ed75cec1a876bf2fcfaf1f71987a16",
-    "https://bcr.bazel.build/modules/abseil-cpp/20250127.0/MODULE.bazel": "d1086e248cda6576862b4b3fe9ad76a214e08c189af5b42557a6e1888812c5d5",
-    "https://bcr.bazel.build/modules/abseil-cpp/20250127.0/source.json": "1b996859f840d8efc7c720efc61dcf2a84b1261cb3974cbbe9b6666ebf567775",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250127.1/MODULE.bazel": "c4a89e7ceb9bf1e25cf84a9f830ff6b817b72874088bf5141b314726e46a57c1",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250814.0/MODULE.bazel": "c43c16ca2c432566cdb78913964497259903ebe8fb7d9b57b38e9f1425b427b8",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250814.0/source.json": "b88bff599ceaf0f56c264c749b1606f8485cec3b8c38ba30f88a4df9af142861",
     "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
     "https://bcr.bazel.build/modules/apple_support/1.15.1/source.json": "517f2b77430084c541bc9be2db63fdcbb7102938c5f64c17ee60ffda2e5cf07b",
     "https://bcr.bazel.build/modules/apple_support/1.5.0/MODULE.bazel": "50341a62efbc483e8a2a6aec30994a58749bd7b885e18dd96aa8c33031e558ef",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
+    "https://bcr.bazel.build/modules/bazel_features/1.15.0/MODULE.bazel": "d38ff6e517149dc509406aca0db3ad1efdd890a85e049585b7234d04238e2a4d",
+    "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
+    "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
     "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
-    "https://bcr.bazel.build/modules/bazel_features/1.19.0/source.json": "d7bf14517c1b25b9d9c580b0f8795fceeae08a7590f507b76aace528e941375d",
+    "https://bcr.bazel.build/modules/bazel_features/1.21.0/MODULE.bazel": "675642261665d8eea09989aa3b8afb5c37627f1be178382c320d1b46afba5e3b",
+    "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
+    "https://bcr.bazel.build/modules/bazel_features/1.28.0/source.json": "16a3fc5b4483cb307643791f5a4b7365fa98d2e70da7c378cdbde55f0c0b32cf",
+    "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
     "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
     "https://bcr.bazel.build/modules/bazel_skylib/1.1.1/MODULE.bazel": "1add3e7d93ff2e6998f9e118022c84d163917d912f5afafb3058e3d2f1545b5e",
@@ -24,87 +33,893 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.2.1/MODULE.bazel": "f35baf9da0efe45fa3da1696ae906eea3d615ad41e2e3def4aeb4e8bc0ef9a7a",
     "https://bcr.bazel.build/modules/bazel_skylib/1.3.0/MODULE.bazel": "20228b92868bf5cfc41bda7afc8a8ba2a543201851de39d990ec957b513579c5",
     "https://bcr.bazel.build/modules/bazel_skylib/1.4.1/MODULE.bazel": "a0dcb779424be33100dcae821e9e27e4f2901d9dfd5333efe5ac6a8d7ab75e1d",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.4.2/MODULE.bazel": "3bd40978e7a1fac911d5989e6b09d8f64921865a45822d8b09e815eaa726a651",
     "https://bcr.bazel.build/modules/bazel_skylib/1.5.0/MODULE.bazel": "32880f5e2945ce6a03d1fbd588e9198c0a959bb42297b2cfaf1685b7bc32e138",
     "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/MODULE.bazel": "8fdee2dbaace6c252131c00e1de4b165dc65af02ea278476187765e1a617b917",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.0/MODULE.bazel": "0db596f4563de7938de764cc8deeabec291f55e8ec15299718b93c4423e9796d",
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
-    "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/source.json": "f121b43eeefc7c29efbd51b83d08631e2347297c95aac9764a701f2a6a2bb953",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/MODULE.bazel": "88ade7293becda963e0e3ea33e7d54d3425127e0a326e0d17da085a5f1f03ff6",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/source.json": "7ebaefba0b03efe59cac88ed5bbc67bcf59a3eff33af937345ede2a38b2d368a",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
-    "https://bcr.bazel.build/modules/google_benchmark/1.9.1/MODULE.bazel": "1abfd0395aea2db11943d817afb6c03208bee28b2e47eccc3042f67a22d3ce1b",
-    "https://bcr.bazel.build/modules/google_benchmark/1.9.1/source.json": "5d68196f85589340f5ca834d0bea3a49129d8cebf486d51b3d29419b0437bbbc",
+    "https://bcr.bazel.build/modules/google_benchmark/1.8.2/source.json": "c5ec7882c4122369f645139400fa6a1ce5092cec12893bf90bcc32914a38508b",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
     "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
     "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
     "https://bcr.bazel.build/modules/googletest/1.15.2/MODULE.bazel": "6de1edc1d26cafb0ea1a6ab3f4d4192d91a312fd2d360b63adaa213cd00b2108",
-    "https://bcr.bazel.build/modules/googletest/1.16.0/MODULE.bazel": "a175623c69e94fca4ca7acbc12031e637b0c489318cd4805606981d4d7adb34a",
-    "https://bcr.bazel.build/modules/googletest/1.16.0/source.json": "dd011b202542efcd4c0e3df34b1558d41598c6f287846728315ded5f7984b77a",
+    "https://bcr.bazel.build/modules/googletest/1.17.0/MODULE.bazel": "dbec758171594a705933a29fcf69293d2468c49ec1f2ebca65c36f504d72df46",
+    "https://bcr.bazel.build/modules/googletest/1.17.0/source.json": "38e4454b25fc30f15439c0378e57909ab1fd0a443158aa35aec685da727cd713",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/source.json": "caaffb3ac2b59b8aac456917a4ecf3167d40478ee79f15ab7a877ec9273937c9",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
-    "https://bcr.bazel.build/modules/platforms/0.0.10/source.json": "f22828ff4cf021a6b577f1bf6341cb9dcd7965092a439f64fc1bb3b7a5ae4bd5",
+    "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
     "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
     "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
     "https://bcr.bazel.build/modules/platforms/0.0.7/MODULE.bazel": "72fd4a0ede9ee5c021f6a8dd92b503e089f46c227ba2813ff183b71616034814",
     "https://bcr.bazel.build/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
     "https://bcr.bazel.build/modules/platforms/0.0.9/MODULE.bazel": "4a87a60c927b56ddd67db50c89acaa62f4ce2a1d2149ccb63ffd871d5ce29ebc",
+    "https://bcr.bazel.build/modules/platforms/1.0.0/MODULE.bazel": "f05feb42b48f1b3c225e4ccf351f367be0371411a803198ec34a389fb22aa580",
+    "https://bcr.bazel.build/modules/platforms/1.0.0/source.json": "f4ff1fd412e0246fd38c82328eb209130ead81d62dcd5a9e40910f867f733d96",
     "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
     "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
-    "https://bcr.bazel.build/modules/protobuf/27.0/source.json": "1acf3d080c728d42f423fde5422fd0a1a24f44c15908124ce12363a253384193",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc3/MODULE.bazel": "33c2dfa286578573afc55a7acaea3cada4122b9631007c594bf0729f41c8de92",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc3/source.json": "c16a6488fb279ef578da7098e605082d72ed85fc8d843eaae81e7d27d0f4625d",
     "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
     "https://bcr.bazel.build/modules/protobuf/3.19.6/MODULE.bazel": "9233edc5e1f2ee276a60de3eaa47ac4132302ef9643238f23128fea53ea12858",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/source.json": "6900fdc8a9e95866b8c0d4ad4aba4d4236317b5c1cd04c502df3f0d33afed680",
     "https://bcr.bazel.build/modules/re2/2023-09-01/MODULE.bazel": "cb3d511531b16cfc78a225a9e2136007a48cf8a677e4264baeab57fe78a80206",
+    "https://bcr.bazel.build/modules/re2/2024-07-02.bcr.1/MODULE.bazel": "b4963dda9b31080be1905ef085ecd7dd6cd47c05c79b9cdf83ade83ab2ab271a",
+    "https://bcr.bazel.build/modules/re2/2024-07-02.bcr.1/source.json": "2ff292be6ef3340325ce8a045ecc326e92cbfab47c7cbab4bd85d28971b97ac4",
     "https://bcr.bazel.build/modules/re2/2024-07-02/MODULE.bazel": "0eadc4395959969297cbcf31a249ff457f2f1d456228c67719480205aa306daa",
-    "https://bcr.bazel.build/modules/re2/2024-07-02/source.json": "547d0111a9d4f362db32196fef805abbf3676e8d6afbe44d395d87816c1130ca",
+    "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
+    "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
     "https://bcr.bazel.build/modules/rules_cc/0.0.17/MODULE.bazel": "2ae1d8f4238ec67d7185d8861cb0a2cdf4bc608697c331b95bf990e69b62e64a",
-    "https://bcr.bazel.build/modules/rules_cc/0.0.17/source.json": "4db99b3f55c90ab28d14552aa0632533e3e8e5e9aea0f5c24ac0014282c2a7c5",
     "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
     "https://bcr.bazel.build/modules/rules_cc/0.0.6/MODULE.bazel": "abf360251023dfe3efcef65ab9d56beefa8394d4176dd29529750e1c57eaa33f",
     "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
-    "https://bcr.bazel.build/modules/rules_foreign_cc/0.10.1/MODULE.bazel": "b9527010e5fef060af92b6724edb3691970a5b1f76f74b21d39f7d433641be60",
-    "https://bcr.bazel.build/modules/rules_foreign_cc/0.10.1/source.json": "9300e71df0cdde0952f10afff1401fa664e9fc5d9ae6204660ba1b158d90d6a6",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.0/MODULE.bazel": "b5c17f90458caae90d2ccd114c81970062946f49f355610ed89bebf954f5783c",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.13/MODULE.bazel": "eecdd666eda6be16a8d9dc15e44b5c75133405e820f620a234acc4b1fdc5aa37",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.13/source.json": "f872e892c5265c5532e526857532f4868708f88d64e5ebe517ea72e09da61bdb",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
+    "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/source.json": "8be72488e3139bdca3af856fecc3860d0c480ba52e67b4035d0741b19e6d96d7",
+    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
+    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
     "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
+    "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
+    "https://bcr.bazel.build/modules/rules_java/7.10.0/MODULE.bazel": "530c3beb3067e870561739f1144329a21c851ff771cd752a49e06e3dc9c2e71a",
+    "https://bcr.bazel.build/modules/rules_java/7.12.2/MODULE.bazel": "579c505165ee757a4280ef83cda0150eea193eed3bef50b1004ba88b99da6de6",
+    "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
+    "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
     "https://bcr.bazel.build/modules/rules_java/7.6.5/MODULE.bazel": "481164be5e02e4cab6e77a36927683263be56b7e36fef918b458d7a8a1ebadb1",
-    "https://bcr.bazel.build/modules/rules_java/7.6.5/source.json": "a805b889531d1690e3c72a7a7e47a870d00323186a9904b36af83aa3d053ee8d",
+    "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
+    "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
+    "https://bcr.bazel.build/modules/rules_java/8.5.1/source.json": "db1a77d81b059e0f84985db67a22f3f579a529a86b7997605be3d214a0abe38e",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
-    "https://bcr.bazel.build/modules/rules_jvm_external/5.1/source.json": "5abb45cc9beb27b77aec6a65a11855ef2b55d95dfdc358e9f312b78ae0ba32d5",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/MODULE.bazel": "c998e060b85f71e00de5ec552019347c8bca255062c990ac02d051bb80a38df0",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/source.json": "6f5f5a5a4419ae4e37c35a5bb0a6ae657ed40b7abc5a5189111b47fcebe43197",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/MODULE.bazel": "d269a01a18ee74d0335450b10f62c9ed81f2321d7958a2934e44272fe82dcef3",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/source.json": "2faa4794364282db7c06600b7e5e34867a564ae91bda7cae7c29c64e9466b7d5",
     "https://bcr.bazel.build/modules/rules_license/0.0.3/MODULE.bazel": "627e9ab0247f7d1e05736b59dbb1b6871373de5ad31c3011880b4133cafd4bd0",
     "https://bcr.bazel.build/modules/rules_license/0.0.7/MODULE.bazel": "088fbeb0b6a419005b89cf93fe62d9517c0a2b8bb56af3244af65ecfe37e7d5d",
-    "https://bcr.bazel.build/modules/rules_license/0.0.7/source.json": "355cc5737a0f294e560d52b1b7a6492d4fff2caf0bef1a315df5a298fca2d34a",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/MODULE.bazel": "a7fda60eefdf3d8c827262ba499957e4df06f659330bbe6cdbdb975b768bb65c",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/source.json": "a52c89e54cc311196e478f8382df91c15f7a2bfdf4c6cd0e2675cc2ff0b56efb",
     "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
-    "https://bcr.bazel.build/modules/rules_pkg/0.7.0/source.json": "c2557066e0c0342223ba592510ad3d812d4963b9024831f7f66fd0584dd8c66c",
+    "https://bcr.bazel.build/modules/rules_pkg/1.0.1/MODULE.bazel": "5b1df97dbc29623bccdf2b0dcd0f5cb08e2f2c9050aab1092fd39a41e82686ff",
+    "https://bcr.bazel.build/modules/rules_pkg/1.0.1/source.json": "bd82e5d7b9ce2d31e380dd9f50c111d678c3bdaca190cb76b0e1c71b05e1ba8a",
     "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
     "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
     "https://bcr.bazel.build/modules/rules_proto/6.0.0-rc1/MODULE.bazel": "1e5b502e2e1a9e825eef74476a5a1ee524a92297085015a052510b09a1a09483",
-    "https://bcr.bazel.build/modules/rules_proto/6.0.0-rc1/source.json": "8d8448e71706df7450ced227ca6b3812407ff5e2ccad74a43a9fbe79c84e34e0",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.2/source.json": "17a2e195f56cb28d6bbf763e49973d13890487c6945311ed141e196fb660426d",
     "https://bcr.bazel.build/modules/rules_python/0.10.2/MODULE.bazel": "cc82bc96f2997baa545ab3ce73f196d040ffb8756fd2d66125a530031cd90e5f",
-    "https://bcr.bazel.build/modules/rules_python/0.20.0/MODULE.bazel": "bfe14d17f20e3fe900b9588f526f52c967a6f281e47a1d6b988679bd15082286",
     "https://bcr.bazel.build/modules/rules_python/0.22.1/MODULE.bazel": "26114f0c0b5e93018c0c066d6673f1a2c3737c7e90af95eff30cfee38d0bbac7",
+    "https://bcr.bazel.build/modules/rules_python/0.23.1/MODULE.bazel": "49ffccf0511cb8414de28321f5fcf2a31312b47c40cc21577144b7447f2bf300",
     "https://bcr.bazel.build/modules/rules_python/0.25.0/MODULE.bazel": "72f1506841c920a1afec76975b35312410eea3aa7b63267436bfb1dd91d2d382",
+    "https://bcr.bazel.build/modules/rules_python/0.28.0/MODULE.bazel": "cba2573d870babc976664a912539b320cbaa7114cd3e8f053c720171cde331ed",
     "https://bcr.bazel.build/modules/rules_python/0.31.0/MODULE.bazel": "93a43dc47ee570e6ec9f5779b2e64c1476a6ce921c48cc9a1678a91dd5f8fd58",
     "https://bcr.bazel.build/modules/rules_python/0.33.2/MODULE.bazel": "3e036c4ad8d804a4dad897d333d8dce200d943df4827cb849840055be8d2e937",
-    "https://bcr.bazel.build/modules/rules_python/0.33.2/source.json": "e539592cd3aae4492032cecea510e46ca16eeb972271560b922cae9893944e2f",
     "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
+    "https://bcr.bazel.build/modules/rules_python/1.6.0/MODULE.bazel": "7e04ad8f8d5bea40451cf80b1bd8262552aa73f841415d20db96b7241bd027d8",
+    "https://bcr.bazel.build/modules/rules_python/1.6.0/source.json": "e980f654cf66ec4928672f41fc66c4102b5ea54286acf4aecd23256c84211be6",
+    "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
+    "https://bcr.bazel.build/modules/rules_shell/0.2.0/source.json": "7f27af3c28037d9701487c4744b5448d26537cc66cdef0d8df7ae85411f8de95",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
     "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
-    "https://bcr.bazel.build/modules/stardoc/0.5.3/source.json": "cd53fe968dc8cd98197c052db3db6d82562960c87b61e7a90ee96f8e4e0dda97",
+    "https://bcr.bazel.build/modules/stardoc/0.7.0/MODULE.bazel": "05e3d6d30c099b6770e97da986c53bd31844d7f13d41412480ea265ac9e8079c",
+    "https://bcr.bazel.build/modules/stardoc/0.7.2/MODULE.bazel": "fc152419aa2ea0f51c29583fab1e8c99ddefd5b3778421845606ee628629e0e5",
+    "https://bcr.bazel.build/modules/stardoc/0.7.2/source.json": "58b029e5e901d6802967754adf0a9056747e8176f017cfe3607c0851f4d42216",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
     "https://bcr.bazel.build/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/MODULE.bazel": "af322bc08976524477c79d1e45e241b6efbeb918c497e8840b8ab116802dda79",
-    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/source.json": "2be409ac3c7601245958cd4fcdff4288be79ed23bd690b4b951f500d54ee6e7d"
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/source.json": "2be409ac3c7601245958cd4fcdff4288be79ed23bd690b4b951f500d54ee6e7d",
+    "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
   },
   "selectedYankedVersions": {},
-  "moduleExtensions": {}
+  "moduleExtensions": {
+    "//bazel:dev_deps.bzl%dev_deps": {
+      "general": {
+        "bzlTransitiveDigest": "ZF8M8gWp2usD033OYToKhZsO9qWqdbi+3T+xxS2kpGY=",
+        "usagesDigest": "ZNNm4PVtwwJg8eCBktEc7/Gt+Wis1o/9FPkMu5MGxRk=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "hedron_compile_commands": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "patch_args": [
+                "-p1"
+              ],
+              "patches": [
+                "@@zk_dtypes~//third_party/bazel-compile-commands-extractor:allow_header_as_a_source_file.patch"
+              ],
+              "strip_prefix": "bazel-compile-commands-extractor-ed994039a951b736091776d677f324b3903ef939",
+              "url": "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/ed994039a951b736091776d677f324b3903ef939.tar.gz"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "",
+            "zk_dtypes",
+            "zk_dtypes~"
+          ]
+        ]
+      }
+    },
+    "//bazel:llvm_configure.bzl%llvm_project": {
+      "general": {
+        "bzlTransitiveDigest": "uQzQa03qn77EDIGS/t0ssk+G5581OzBDqQvx4iBnWxY=",
+        "usagesDigest": "oFP5uAt4ilwX/dlXCJltFVisv8OsVt8eFVb+78wfky8=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "llvm-project": {
+            "bzlFile": "@@_main~llvm_deps~llvm-raw//utils/bazel:configure.bzl",
+            "ruleClassName": "llvm_configure",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "llvm-raw",
+            "_main~llvm_deps~llvm-raw"
+          ]
+        ]
+      }
+    },
+    "//bazel:llvm_deps.bzl%llvm_deps": {
+      "general": {
+        "bzlTransitiveDigest": "M4KtxpRFI9BUdknqxYVHcwod/hb19IcVRGwmC4ncVmU=",
+        "usagesDigest": "A+FIwusu1QtSKzvBNGPEMYQivz4R7XyFQKYz/k1oxHA=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "llvm-raw": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file_content": "# empty",
+              "patch_args": [
+                "-p1"
+              ],
+              "patches": [
+                "@@//third_party/llvm-project:affine_loop_fusion_visited_set.patch",
+                "@@//third_party/llvm-project:affine_dependence_path_lookup_cache.patch",
+                "@@//third_party/llvm-project:linalg_type_support.patch",
+                "@@//third_party/llvm-project:tensor_type_support.patch",
+                "@@//third_party/llvm-project:vector_type_support.patch",
+                "@@//third_party/llvm-project:lazy_linking.patch",
+                "@@//third_party/llvm-project:elementwise_op_fusion_constant_support.patch",
+                "@@//third_party/llvm-project:constant_like_interface.patch",
+                "@@//third_party/llvm-project:asm_parser_rewind.patch"
+              ],
+              "sha256": "bbc6fa4993162bdc7dd39b53927906a455940b87c782d0a37e00127f8bf8c696",
+              "strip_prefix": "llvm-project-815edc3ff646392bfee2b381d37dd35e4b04f9c5",
+              "urls": [
+                "https://github.com/llvm/llvm-project/archive/815edc3ff646392bfee2b381d37dd35e4b04f9c5.tar.gz"
+              ]
+            }
+          },
+          "llvm_zstd": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file": "@@_main~llvm_deps~llvm-raw//utils/bazel/third_party_build:zstd.BUILD",
+              "sha256": "7c42d56fac126929a6a85dbc73ff1db2411d04f104fae9bdea51305663a83fd0",
+              "strip_prefix": "zstd-1.5.2",
+              "urls": [
+                "https://github.com/facebook/zstd/releases/download/v1.5.2/zstd-1.5.2.tar.gz"
+              ]
+            }
+          },
+          "llvm_zlib": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file": "@@_main~llvm_deps~llvm-raw//utils/bazel/third_party_build:zlib-ng.BUILD",
+              "sha256": "e36bb346c00472a1f9ff2a0a4643e590a254be6379da7cddd9daeb9a7f296731",
+              "strip_prefix": "zlib-ng-2.0.7",
+              "urls": [
+                "https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.0.7.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "//bazel:non_module_deps.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "Tbhg9hwKwGHoEkd5mpioAdL6HDIXHm/ASFQQTXa9n4I=",
+        "usagesDigest": "UAB19ytQbp8kxvfACzeYzWxVu0JY92zHe6ORCEWRfcs=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_config_omp": {
+            "bzlFile": "@@//third_party/omp:omp_configure.bzl",
+            "ruleClassName": "omp_configure",
+            "attributes": {}
+          },
+          "nanobind": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "strip_prefix": "nanobind-2.9.2",
+              "sha256": "8ce3667dce3e64fc06bfb9b778b6f48731482362fb89a43da156632266cd5a90",
+              "urls": [
+                "https://github.com/wjakob/nanobind/archive/refs/tags/v2.9.2.tar.gz"
+              ],
+              "build_file": "@@//third_party/nanobind:nanobind.BUILD"
+            }
+          },
+          "robin_map": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "strip_prefix": "robin-map-1.3.0",
+              "sha256": "a8424ad3b0affd4c57ed26f0f3d8a29604f0e1f2ef2089f497f614b1c94c7236",
+              "urls": [
+                "https://github.com/Tessil/robin-map/archive/refs/tags/v1.3.0.tar.gz"
+              ],
+              "build_file": "@@//third_party/robin_map:robin_map.BUILD"
+            }
+          },
+          "pybind11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "strip_prefix": "pybind11-2.10.3",
+              "sha256": "201966a61dc826f1b1879a24a3317a1ec9214a918c8eb035be2f30c3e9cfbdcb",
+              "urls": [
+                "https://github.com/pybind/pybind11/archive/v2.10.3.zip"
+              ],
+              "build_file": "@@//third_party/pybind11:pybind11.BUILD"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@apple_support~//crosstool:setup.bzl%apple_cc_configure_extension": {
+      "general": {
+        "bzlTransitiveDigest": "ltCGFbl/LQQZXn/LEMXfKX7pGwyqNiOCHcmiQW0tmjM=",
+        "usagesDigest": "2Jj0sTGzjx2KfYRjWYbL6DZ1bi8HL2roIAGfOViiul8=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_config_apple_cc_toolchains": {
+            "bzlFile": "@@apple_support~//crosstool:setup.bzl",
+            "ruleClassName": "_apple_cc_autoconf_toolchains",
+            "attributes": {}
+          },
+          "local_config_apple_cc": {
+            "bzlFile": "@@apple_support~//crosstool:setup.bzl",
+            "ruleClassName": "_apple_cc_autoconf",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "apple_support~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@pybind11_bazel~//:internal_configure.bzl%internal_configure_extension": {
+      "general": {
+        "bzlTransitiveDigest": "CyAKLVVonohnkTSqg9II/HA7M49sOlnMkgMHL3CmDuc=",
+        "usagesDigest": "mFrTHX5eCiNU/OIIGVHH3cOILY9Zmjqk8RQYv8o6Thk=",
+        "recordedFileInputs": {
+          "@@pybind11_bazel~//MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34"
+        },
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "pybind11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file": "@@pybind11_bazel~//:pybind11-BUILD.bazel",
+              "strip_prefix": "pybind11-2.12.0",
+              "urls": [
+                "https://github.com/pybind/pybind11/archive/v2.12.0.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "pybind11_bazel~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_foreign_cc~//foreign_cc:extensions.bzl%ext": {
+      "general": {
+        "bzlTransitiveDigest": "O4g9NkzPtu3cOJQcFYhMlGPgJAMkXwZik4LSOm60W5c=",
+        "usagesDigest": "E0n+lYnrXx2HdIbfSm53eY9h93ZfYIVuC65si52pi9A=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "rules_foreign_cc_framework_toolchain_linux": {
+            "bzlFile": "@@rules_foreign_cc~//foreign_cc/private/framework:toolchain.bzl",
+            "ruleClassName": "framework_toolchain_repository",
+            "attributes": {
+              "commands_src": "@rules_foreign_cc//foreign_cc/private/framework/toolchains:linux_commands.bzl",
+              "exec_compatible_with": [
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rules_foreign_cc_framework_toolchain_freebsd": {
+            "bzlFile": "@@rules_foreign_cc~//foreign_cc/private/framework:toolchain.bzl",
+            "ruleClassName": "framework_toolchain_repository",
+            "attributes": {
+              "commands_src": "@rules_foreign_cc//foreign_cc/private/framework/toolchains:freebsd_commands.bzl",
+              "exec_compatible_with": [
+                "@platforms//os:freebsd"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rules_foreign_cc_framework_toolchain_windows": {
+            "bzlFile": "@@rules_foreign_cc~//foreign_cc/private/framework:toolchain.bzl",
+            "ruleClassName": "framework_toolchain_repository",
+            "attributes": {
+              "commands_src": "@rules_foreign_cc//foreign_cc/private/framework/toolchains:windows_commands.bzl",
+              "exec_compatible_with": [
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rules_foreign_cc_framework_toolchain_macos": {
+            "bzlFile": "@@rules_foreign_cc~//foreign_cc/private/framework:toolchain.bzl",
+            "ruleClassName": "framework_toolchain_repository",
+            "attributes": {
+              "commands_src": "@rules_foreign_cc//foreign_cc/private/framework/toolchains:macos_commands.bzl",
+              "exec_compatible_with": [
+                "@platforms//os:macos"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "cmake-3.23.2-linux-aarch64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/Kitware/CMake/releases/download/v3.23.2/cmake-3.23.2-linux-aarch64.tar.gz"
+              ],
+              "sha256": "f2654bf780b53f170bbbec44d8ac67d401d24788e590faa53036a89476efa91e",
+              "strip_prefix": "cmake-3.23.2-linux-aarch64",
+              "build_file_content": "load(\"@rules_foreign_cc//toolchains/native_tools:native_tools_toolchain.bzl\", \"native_tool_toolchain\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nfilegroup(\n    name = \"cmake_data\",\n    srcs = glob(\n        [\n            \"**\",\n        ],\n        exclude = [\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n        ],\n    ),\n)\n\nnative_tool_toolchain(\n    name = \"cmake_tool\",\n    path = \"bin/cmake\",\n    target = \":cmake_data\",\n)\n"
+            }
+          },
+          "cmake-3.23.2-linux-x86_64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/Kitware/CMake/releases/download/v3.23.2/cmake-3.23.2-linux-x86_64.tar.gz"
+              ],
+              "sha256": "aaced6f745b86ce853661a595bdac6c5314a60f8181b6912a0a4920acfa32708",
+              "strip_prefix": "cmake-3.23.2-linux-x86_64",
+              "build_file_content": "load(\"@rules_foreign_cc//toolchains/native_tools:native_tools_toolchain.bzl\", \"native_tool_toolchain\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nfilegroup(\n    name = \"cmake_data\",\n    srcs = glob(\n        [\n            \"**\",\n        ],\n        exclude = [\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n        ],\n    ),\n)\n\nnative_tool_toolchain(\n    name = \"cmake_tool\",\n    path = \"bin/cmake\",\n    target = \":cmake_data\",\n)\n"
+            }
+          },
+          "cmake-3.23.2-macos-universal": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/Kitware/CMake/releases/download/v3.23.2/cmake-3.23.2-macos-universal.tar.gz"
+              ],
+              "sha256": "853a0f9af148c5ef47282ffffee06c4c9f257be2635936755f39ca13c3286c88",
+              "strip_prefix": "cmake-3.23.2-macos-universal/CMake.app/Contents",
+              "build_file_content": "load(\"@rules_foreign_cc//toolchains/native_tools:native_tools_toolchain.bzl\", \"native_tool_toolchain\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nfilegroup(\n    name = \"cmake_data\",\n    srcs = glob(\n        [\n            \"**\",\n        ],\n        exclude = [\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n        ],\n    ),\n)\n\nnative_tool_toolchain(\n    name = \"cmake_tool\",\n    path = \"bin/cmake\",\n    target = \":cmake_data\",\n)\n"
+            }
+          },
+          "cmake-3.23.2-windows-i386": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/Kitware/CMake/releases/download/v3.23.2/cmake-3.23.2-windows-i386.zip"
+              ],
+              "sha256": "6a4fcd6a2315b93cb23c93507efccacc30c449c2bf98f14d6032bb226c582e07",
+              "strip_prefix": "cmake-3.23.2-windows-i386",
+              "build_file_content": "load(\"@rules_foreign_cc//toolchains/native_tools:native_tools_toolchain.bzl\", \"native_tool_toolchain\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nfilegroup(\n    name = \"cmake_data\",\n    srcs = glob(\n        [\n            \"**\",\n        ],\n        exclude = [\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n        ],\n    ),\n)\n\nnative_tool_toolchain(\n    name = \"cmake_tool\",\n    path = \"bin/cmake.exe\",\n    target = \":cmake_data\",\n)\n"
+            }
+          },
+          "cmake-3.23.2-windows-x86_64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/Kitware/CMake/releases/download/v3.23.2/cmake-3.23.2-windows-x86_64.zip"
+              ],
+              "sha256": "2329387f3166b84c25091c86389fb891193967740c9bcf01e7f6d3306f7ffda0",
+              "strip_prefix": "cmake-3.23.2-windows-x86_64",
+              "build_file_content": "load(\"@rules_foreign_cc//toolchains/native_tools:native_tools_toolchain.bzl\", \"native_tool_toolchain\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nfilegroup(\n    name = \"cmake_data\",\n    srcs = glob(\n        [\n            \"**\",\n        ],\n        exclude = [\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n        ],\n    ),\n)\n\nnative_tool_toolchain(\n    name = \"cmake_tool\",\n    path = \"bin/cmake.exe\",\n    target = \":cmake_data\",\n)\n"
+            }
+          },
+          "cmake_3.23.2_toolchains": {
+            "bzlFile": "@@rules_foreign_cc~//toolchains:prebuilt_toolchains_repository.bzl",
+            "ruleClassName": "prebuilt_toolchains_repository",
+            "attributes": {
+              "repos": {
+                "cmake-3.23.2-linux-aarch64": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "cmake-3.23.2-linux-x86_64": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "cmake-3.23.2-macos-universal": [
+                  "@platforms//os:macos"
+                ],
+                "cmake-3.23.2-windows-i386": [
+                  "@platforms//cpu:x86_32",
+                  "@platforms//os:windows"
+                ],
+                "cmake-3.23.2-windows-x86_64": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ]
+              },
+              "tool": "cmake"
+            }
+          },
+          "ninja_1.11.0_linux": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/ninja-build/ninja/releases/download/v1.11.0/ninja-linux.zip"
+              ],
+              "sha256": "9726e730d5b8599f82654dc80265e64a10a8a817552c34153361ed0c017f9f02",
+              "strip_prefix": "",
+              "build_file_content": "load(\"@rules_foreign_cc//toolchains/native_tools:native_tools_toolchain.bzl\", \"native_tool_toolchain\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nfilegroup(\n    name = \"ninja_bin\",\n    srcs = [\"ninja\"],\n)\n\nnative_tool_toolchain(\n    name = \"ninja_tool\",\n    env = {\"NINJA\": \"$(execpath :ninja_bin)\"},\n    path = \"$(execpath :ninja_bin)\",\n    target = \":ninja_bin\",\n)\n"
+            }
+          },
+          "ninja_1.11.0_mac": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/ninja-build/ninja/releases/download/v1.11.0/ninja-mac.zip"
+              ],
+              "sha256": "21915277db59756bfc61f6f281c1f5e3897760b63776fd3d360f77dd7364137f",
+              "strip_prefix": "",
+              "build_file_content": "load(\"@rules_foreign_cc//toolchains/native_tools:native_tools_toolchain.bzl\", \"native_tool_toolchain\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nfilegroup(\n    name = \"ninja_bin\",\n    srcs = [\"ninja\"],\n)\n\nnative_tool_toolchain(\n    name = \"ninja_tool\",\n    env = {\"NINJA\": \"$(execpath :ninja_bin)\"},\n    path = \"$(execpath :ninja_bin)\",\n    target = \":ninja_bin\",\n)\n"
+            }
+          },
+          "ninja_1.11.0_win": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/ninja-build/ninja/releases/download/v1.11.0/ninja-win.zip"
+              ],
+              "sha256": "d0ee3da143211aa447e750085876c9b9d7bcdd637ab5b2c5b41349c617f22f3b",
+              "strip_prefix": "",
+              "build_file_content": "load(\"@rules_foreign_cc//toolchains/native_tools:native_tools_toolchain.bzl\", \"native_tool_toolchain\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nfilegroup(\n    name = \"ninja_bin\",\n    srcs = [\"ninja.exe\"],\n)\n\nnative_tool_toolchain(\n    name = \"ninja_tool\",\n    env = {\"NINJA\": \"$(execpath :ninja_bin)\"},\n    path = \"$(execpath :ninja_bin)\",\n    target = \":ninja_bin\",\n)\n"
+            }
+          },
+          "ninja_1.11.0_toolchains": {
+            "bzlFile": "@@rules_foreign_cc~//toolchains:prebuilt_toolchains_repository.bzl",
+            "ruleClassName": "prebuilt_toolchains_repository",
+            "attributes": {
+              "repos": {
+                "ninja_1.11.0_linux": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "ninja_1.11.0_mac": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:macos"
+                ],
+                "ninja_1.11.0_win": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ]
+              },
+              "tool": "ninja"
+            }
+          },
+          "cmake_src": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file_content": "filegroup(\n    name = \"all_srcs\",\n    srcs = glob([\"**\"]),\n    visibility = [\"//visibility:public\"],\n)\n",
+              "sha256": "f316b40053466f9a416adf981efda41b160ca859e97f6a484b447ea299ff26aa",
+              "strip_prefix": "cmake-3.23.2",
+              "urls": [
+                "https://github.com/Kitware/CMake/releases/download/v3.23.2/cmake-3.23.2.tar.gz"
+              ]
+            }
+          },
+          "gnumake_src": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file_content": "filegroup(\n    name = \"all_srcs\",\n    srcs = glob([\"**\"]),\n    visibility = [\"//visibility:public\"],\n)\n",
+              "patches": [
+                "@@rules_foreign_cc~//toolchains:make-reproducible-bootstrap.patch"
+              ],
+              "sha256": "e05fdde47c5f7ca45cb697e973894ff4f5d79e13b750ed57d7b66d8defc78e19",
+              "strip_prefix": "make-4.3",
+              "urls": [
+                "https://mirror.bazel.build/ftpmirror.gnu.org/gnu/make/make-4.3.tar.gz",
+                "http://ftpmirror.gnu.org/gnu/make/make-4.3.tar.gz"
+              ]
+            }
+          },
+          "ninja_build_src": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file_content": "filegroup(\n    name = \"all_srcs\",\n    srcs = glob([\"**\"]),\n    visibility = [\"//visibility:public\"],\n)\n",
+              "sha256": "3c6ba2e66400fe3f1ae83deb4b235faf3137ec20bd5b08c29bfc368db143e4c6",
+              "strip_prefix": "ninja-1.11.0",
+              "urls": [
+                "https://github.com/ninja-build/ninja/archive/v1.11.0.tar.gz"
+              ]
+            }
+          },
+          "bazel_skylib": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz"
+              ],
+              "sha256": "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728"
+            }
+          },
+          "rules_python": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5fa3c738d33acca3b97622a13a741129f67ef43f5fdfcec63b29374cc0574c29",
+              "strip_prefix": "rules_python-0.9.0",
+              "url": "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.9.0.tar.gz"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_foreign_cc~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_foreign_cc~",
+            "rules_foreign_cc",
+            "rules_foreign_cc~"
+          ]
+        ]
+      }
+    },
+    "@@rules_fuzzing~//fuzzing/private:extensions.bzl%non_module_dependencies": {
+      "general": {
+        "bzlTransitiveDigest": "hVgJRQ3Er45/UUAgNn1Yp2Khcp/Y8WyafA2kXIYmQ5M=",
+        "usagesDigest": "YnIrdgwnf3iCLfChsltBdZ7yOJh706lpa2vww/i2pDI=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "platforms": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz",
+                "https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz"
+              ],
+              "sha256": "8150406605389ececb6da07cbcb509d5637a3ab9a24bc69b1101531367d89d74"
+            }
+          },
+          "rules_python": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d70cd72a7a4880f0000a6346253414825c19cdd40a28289bdf67b8e6480edff8",
+              "strip_prefix": "rules_python-0.28.0",
+              "url": "https://github.com/bazelbuild/rules_python/releases/download/0.28.0/rules_python-0.28.0.tar.gz"
+            }
+          },
+          "bazel_skylib": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz"
+              ]
+            }
+          },
+          "com_google_absl": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/abseil/abseil-cpp/archive/refs/tags/20240116.1.zip"
+              ],
+              "strip_prefix": "abseil-cpp-20240116.1",
+              "integrity": "sha256-7capMWOvWyoYbUaHF/b+I2U6XLMaHmky8KugWvfXYuk="
+            }
+          },
+          "rules_fuzzing_oss_fuzz": {
+            "bzlFile": "@@rules_fuzzing~//fuzzing/private/oss_fuzz:repository.bzl",
+            "ruleClassName": "oss_fuzz_repository",
+            "attributes": {}
+          },
+          "honggfuzz": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file": "@@rules_fuzzing~//:honggfuzz.BUILD",
+              "sha256": "6b18ba13bc1f36b7b950c72d80f19ea67fbadc0ac0bb297ec89ad91f2eaa423e",
+              "url": "https://github.com/google/honggfuzz/archive/2.5.zip",
+              "strip_prefix": "honggfuzz-2.5"
+            }
+          },
+          "rules_fuzzing_jazzer": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_jar",
+            "attributes": {
+              "sha256": "ee6feb569d88962d59cb59e8a31eb9d007c82683f3ebc64955fd5b96f277eec2",
+              "url": "https://repo1.maven.org/maven2/com/code-intelligence/jazzer/0.20.1/jazzer-0.20.1.jar"
+            }
+          },
+          "rules_fuzzing_jazzer_api": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_jar",
+            "attributes": {
+              "sha256": "f5a60242bc408f7fa20fccf10d6c5c5ea1fcb3c6f44642fec5af88373ae7aa1b",
+              "url": "https://repo1.maven.org/maven2/com/code-intelligence/jazzer-api/0.20.1/jazzer-api-0.20.1.jar"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_fuzzing~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_java~//java:rules_java_deps.bzl%compatibility_proxy": {
+      "general": {
+        "bzlTransitiveDigest": "KIX40nDfygEWbU+rq3nYpt3tVgTK/iO8PKh5VMBlN7M=",
+        "usagesDigest": "pwHZ+26iLgQdwvdZeA5wnAjKnNI3y6XO2VbhOTeo5h8=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "compatibility_proxy": {
+            "bzlFile": "@@rules_java~//java:rules_java_deps.bzl",
+            "ruleClassName": "_compatibility_proxy_repo_rule",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_java~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_kotlin~//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
+      "general": {
+        "bzlTransitiveDigest": "fus14IFJ/1LGWWGKPH/U18VnJCoMjfDt1ckahqCnM0A=",
+        "usagesDigest": "aJF6fLy82rR95Ff5CZPAqxNoFgOMLMN5ImfBS0nhnkg=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_github_jetbrains_kotlin_git": {
+            "bzlFile": "@@rules_kotlin~//src/main/starlark/core/repositories:compiler.bzl",
+            "ruleClassName": "kotlin_compiler_git_repository",
+            "attributes": {
+              "urls": [
+                "https://github.com/JetBrains/kotlin/releases/download/v1.9.23/kotlin-compiler-1.9.23.zip"
+              ],
+              "sha256": "93137d3aab9afa9b27cb06a824c2324195c6b6f6179d8a8653f440f5bd58be88"
+            }
+          },
+          "com_github_jetbrains_kotlin": {
+            "bzlFile": "@@rules_kotlin~//src/main/starlark/core/repositories:compiler.bzl",
+            "ruleClassName": "kotlin_capabilities_repository",
+            "attributes": {
+              "git_repository_name": "com_github_jetbrains_kotlin_git",
+              "compiler_version": "1.9.23"
+            }
+          },
+          "com_github_google_ksp": {
+            "bzlFile": "@@rules_kotlin~//src/main/starlark/core/repositories:ksp.bzl",
+            "ruleClassName": "ksp_compiler_plugin_repository",
+            "attributes": {
+              "urls": [
+                "https://github.com/google/ksp/releases/download/1.9.23-1.0.20/artifacts.zip"
+              ],
+              "sha256": "ee0618755913ef7fd6511288a232e8fad24838b9af6ea73972a76e81053c8c2d",
+              "strip_version": "1.9.23-1.0.20"
+            }
+          },
+          "com_github_pinterest_ktlint": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "sha256": "01b2e0ef893383a50dbeb13970fe7fa3be36ca3e83259e01649945b09d736985",
+              "urls": [
+                "https://github.com/pinterest/ktlint/releases/download/1.3.0/ktlint"
+              ],
+              "executable": true
+            }
+          },
+          "rules_android": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
+              "strip_prefix": "rules_android-0.1.1",
+              "urls": [
+                "https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_kotlin~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_python~//python/uv:uv.bzl%uv": {
+      "general": {
+        "bzlTransitiveDigest": "mxPY/VBQrSC9LvYeRrlxD+0IkDTQ4+36NGMnGWlN/Vw=",
+        "usagesDigest": "2i8W0baJ5gflw8UyZLMTK8V524DgyUmgWq4fI+slQsk=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "uv": {
+            "bzlFile": "@@rules_python~//python/uv/private:uv_toolchains_repo.bzl",
+            "ruleClassName": "uv_toolchains_repo",
+            "attributes": {
+              "toolchain_type": "'@@rules_python~//python/uv:uv_toolchain_type'",
+              "toolchain_names": [
+                "none"
+              ],
+              "toolchain_implementations": {
+                "none": "'@@rules_python~//python:none'"
+              },
+              "toolchain_compatible_with": {
+                "none": [
+                  "@platforms//:incompatible"
+                ]
+              },
+              "toolchain_target_settings": {}
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_python~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@zk_dtypes~//bazel:non_module_deps.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "CZHNAv7tfLEcmo1dNW3F/RX0UlrGo0E1jsBW/EH7b9s=",
+        "usagesDigest": "cMvbm9XlZJfivh3WRl5Uu9gGJiczGQCKzqQDK2DfHvk=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "eigen_archive": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file": "@@zk_dtypes~//third_party/eigen3:eigen_archive.BUILD",
+              "sha256": "1a432ccbd597ea7b9faa1557b1752328d6adc1a3db8969f6fe793ff704be3bf0",
+              "strip_prefix": "eigen-4c38131a16803130b66266a912029504f2cf23cd",
+              "urls": [
+                "https://gitlab.com/libeigen/eigen/-/archive/4c38131a16803130b66266a912029504f2cf23cd/eigen-4c38131a16803130b66266a912029504f2cf23cd.tar.gz"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "zk_dtypes~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    }
+  }
 }

--- a/README.md
+++ b/README.md
@@ -124,6 +124,21 @@ retains both performance and correctness across a wide range of devices.
    bazel build //...
    ```
 
+   That resolves dependencies through `WORKSPACE.bazel`, which is the default.
+   `MODULE.bazel` describes the same dependencies for Bazel's module system, and
+   `--config=bzlmod` builds through it instead:
+
+   ```sh
+   bazel build --config=bzlmod //...
+   ```
+
+   A project that wants to depend on PrimeIR uses that second path: declare a
+   `bazel_dep` on `prime_ir` plus an `archive_override` pointing at a revision
+   of this repository, and repeat the `zk_dtypes` override PrimeIR's own
+   `MODULE.bazel` carries — Bazel honours overrides only in the root module, and
+   neither fork is in a registry. `bazel/bzlmod_consumer` is a worked example
+   that CI builds.
+
 1. Run a test optimization:
 
    Create a test input file `negate.mlir`:

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -86,65 +86,17 @@ load("//bazel:prime_ir_deps.bzl", "prime_ir_deps")
 
 prime_ir_deps()
 
-load("//third_party/llvm-project:workspace.bzl", "LLVM_COMMIT", "LLVM_PATCHES", "LLVM_SHA256")
+load("//third_party/llvm-project:workspace.bzl", llvm_project = "repo")
 
-http_archive(
-    name = "llvm-raw",
-    build_file_content = "# empty",
-    patch_args = ["-p1"],
-    patches = LLVM_PATCHES,
-    sha256 = LLVM_SHA256,
-    strip_prefix = "llvm-project-" + LLVM_COMMIT,
-    urls = ["https://github.com/llvm/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT)],
-)
-
-# Uncomment this (and comment the llvm-raw http_archive above) when following the
-# llvm patch workflow from CONTRIBUTING.md to point Bazel at a local clone.
-# new_local_repository(
-#     name = "llvm-raw",
-#     build_file_content = "# empty",
-#     path = "../llvm-project",
-# )
-
-# This is needed since https://reviews.llvm.org/D143344.
-# Not sure if it's a bug or a feature, but it doesn't hurt to keep an additional
-# dependency here.
-http_archive(
-    name = "llvm_zstd",
-    build_file = "@llvm-raw//utils/bazel/third_party_build:zstd.BUILD",
-    sha256 = "7c42d56fac126929a6a85dbc73ff1db2411d04f104fae9bdea51305663a83fd0",
-    strip_prefix = "zstd-1.5.2",
-    urls = [
-        "https://github.com/facebook/zstd/releases/download/v1.5.2/zstd-1.5.2.tar.gz",
-    ],
-)
-
-# This is needed since https://reviews.llvm.org/D143320
-# Not sure if it's a bug or a feature, but it doesn't hurt to keep an additional
-# dependency here.
-http_archive(
-    name = "llvm_zlib",
-    build_file = "@llvm-raw//utils/bazel/third_party_build:zlib-ng.BUILD",
-    sha256 = "e36bb346c00472a1f9ff2a0a4643e590a254be6379da7cddd9daeb9a7f296731",
-    strip_prefix = "zlib-ng-2.0.7",
-    urls = [
-        "https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.0.7.zip",
-    ],
-)
+llvm_project()
 
 load("@llvm-raw//utils/bazel:configure.bzl", "llvm_configure")
 
 llvm_configure(name = "llvm-project")
 
-# Hedron's Compile Commands Extractor for Bazel
-# https://github.com/hedronvision/bazel-compile-commands-extractor
-http_archive(
-    name = "hedron_compile_commands",
-    patch_args = ["-p1"],
-    patches = ["@zk_dtypes//third_party/bazel-compile-commands-extractor:allow_header_as_a_source_file.patch"],
-    strip_prefix = "bazel-compile-commands-extractor-ed994039a951b736091776d677f324b3903ef939",
-    url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/ed994039a951b736091776d677f324b3903ef939.tar.gz",
-)
+load("//bazel:dev_deps.bzl", "prime_ir_dev_deps")
+
+prime_ir_dev_deps()
 
 load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
 

--- a/bazel/bzlmod_consumer/.bazelrc
+++ b/bazel/bzlmod_consumer/.bazelrc
@@ -1,15 +1,8 @@
 # Standalone module: this file is not the repository root's .bazelrc, and the
-# root's .bazelrc.ci cannot be reused here — its `--//:has_avx512` names a build
-# setting in whichever repository is root, which in this module is the fixture
-# rather than prime_ir. The `ci` config below is that file's content with the
-# flag re-pointed at `@prime_ir`.
+# root's does not reach a separate workspace.
 common --enable_bzlmod
 common --noenable_workspace
 
 build --cxxopt=-std=c++17
 build --host_cxxopt=-std=c++17
 build --repo_env=CC=clang
-
-build:ci --remote_cache=grpc://gpu-server:9092
-test:ci --test_output=errors
-test:ci --@prime_ir//:has_avx512

--- a/bazel/bzlmod_consumer/.bazelrc
+++ b/bazel/bzlmod_consumer/.bazelrc
@@ -1,0 +1,15 @@
+# Standalone module: this file is not the repository root's .bazelrc, and the
+# root's .bazelrc.ci cannot be reused here — its `--//:has_avx512` names a build
+# setting in whichever repository is root, which in this module is the fixture
+# rather than prime_ir. The `ci` config below is that file's content with the
+# flag re-pointed at `@prime_ir`.
+common --enable_bzlmod
+common --noenable_workspace
+
+build --cxxopt=-std=c++17
+build --host_cxxopt=-std=c++17
+build --repo_env=CC=clang
+
+build:ci --remote_cache=grpc://gpu-server:9092
+test:ci --test_output=errors
+test:ci --@prime_ir//:has_avx512

--- a/bazel/bzlmod_consumer/.bazelrc.ci
+++ b/bazel/bzlmod_consumer/.bazelrc.ci
@@ -1,0 +1,7 @@
+# The fixture's own copy of the repository root's .bazelrc.ci, which cannot be
+# reused verbatim: `--//:has_avx512` names a build setting in whichever
+# repository is root, and here that is the fixture rather than prime_ir. Passed
+# as `--bazelrc`, as the sibling lanes pass the root's.
+build:ci --remote_cache=grpc://gpu-server:9092
+test:ci --test_output=errors
+test:ci --@prime_ir//:has_avx512

--- a/bazel/bzlmod_consumer/.bazelversion
+++ b/bazel/bzlmod_consumer/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion

--- a/bazel/bzlmod_consumer/BUILD.bazel
+++ b/bazel/bzlmod_consumer/BUILD.bazel
@@ -31,9 +31,10 @@ load("@rules_cc//cc:cc_test.bzl", "cc_test")
 # There is no `@llvm-project` in the deps because a module extension's
 # repositories are not re-exported: prime_ir's MLIR is reachable through this
 # target's own dependencies, but a consumer with MLIR in its own sources — as
-# riscv-witness has — declares llvm-project for itself. `layering_check` is off
-# in this module's .bazelrc for the same reason; it would demand the direct dep
-# this fixture is showing a consumer does not need.
+# riscv-witness has — declares llvm-project for itself. This module never
+# enables `layering_check` for the same reason: it would demand the direct dep
+# this fixture is showing a consumer does not need. (The root workspace does
+# enable it, but its .bazelrc does not reach a separate workspace.)
 cc_test(
     name = "consume_prime_ir_test",
     size = "small",

--- a/bazel/bzlmod_consumer/BUILD.bazel
+++ b/bazel/bzlmod_consumer/BUILD.bazel
@@ -1,0 +1,47 @@
+# Copyright 2026 The PrimeIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+# How a consumer actually uses prime_ir: depend on dialect targets and compile
+# against them. These are the three that riscv-witness' own BUILD files name,
+# and they come as a set for a reason — `//prime_ir/IR:Attributes` is reached
+# from every dialect and calls into the EllipticCurve types, while
+# EllipticCurve depends back on Field. The cycle is broken by depending on
+# headers-only `*Hdrs` targets, which leaves those symbols to whoever performs
+# the final link. Depending on Field alone therefore fails to link, from inside
+# this repository as much as outside it.
+#
+# The CI lane additionally builds `@prime_ir//prime_ir/...` and
+# `@prime_ir//tools/...`, which covers the targets no consumer depends on
+# directly.
+#
+# There is no `@llvm-project` in the deps because a module extension's
+# repositories are not re-exported: prime_ir's MLIR is reachable through this
+# target's own dependencies, but a consumer with MLIR in its own sources — as
+# riscv-witness has — declares llvm-project for itself. `layering_check` is off
+# in this module's .bazelrc for the same reason; it would demand the direct dep
+# this fixture is showing a consumer does not need.
+cc_test(
+    name = "consume_prime_ir_test",
+    size = "small",
+    srcs = ["consume_prime_ir_test.cc"],
+    deps = [
+        "@com_google_googletest//:gtest_main",
+        "@prime_ir//prime_ir/Dialect/EllipticCurve/IR:EllipticCurve",
+        "@prime_ir//prime_ir/Dialect/Field/IR:Field",
+        "@prime_ir//prime_ir/Dialect/ModArith/IR:ModArith",
+    ],
+)

--- a/bazel/bzlmod_consumer/MODULE.bazel
+++ b/bazel/bzlmod_consumer/MODULE.bazel
@@ -1,0 +1,55 @@
+# Copyright 2026 The PrimeIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""A standalone module that depends on prime_ir, exactly as a consumer does.
+
+prime_ir's own `--config=bzlmod` lane builds it as the *root* module, where
+`archive_override` and patches still apply. A consumer resolves it as a non-root
+module, where they do not — so only a separate module like this one can show
+that `//MODULE.bazel` stands on its own. This is the second acceptance criterion
+of fractalyze/prime-ir#455.
+
+`local_path_override` stands in for the `archive_override` / `git_override` a
+real consumer writes: it pins no revision, but resolution treats prime_ir as a
+non-root dependency either way, which is the property under test.
+
+The zk_dtypes override is the part worth copying. Overrides are honoured only in
+the root module, so prime_ir's own override of zk_dtypes is ignored the moment
+prime_ir stops being root — every consumer has to restate it, for zk_dtypes and
+for each further fork the chain adds. What prime_ir does carry across that
+boundary is its module extensions: the patched LLVM, nanobind, pybind11,
+robin_map and the OpenMP config all arrive without the consumer naming them.
+"""
+
+module(name = "prime_ir_bzlmod_consumer")
+
+bazel_dep(name = "prime_ir")
+local_path_override(
+    module_name = "prime_ir",
+    path = "../..",
+)
+
+bazel_dep(name = "zk_dtypes", version = "0.0.17")
+archive_override(
+    module_name = "zk_dtypes",
+    integrity = "sha256-8pEUJbq+GJCpyE/VGRcU6cMJUxgyUTO1dpOWiVY7yRw=",
+    strip_prefix = "zk_dtypes-7a42ac4f9c3213925ac523c6871b580db96f9b8d",
+    urls = ["https://github.com/fractalyze/zk_dtypes/archive/7a42ac4f9c3213925ac523c6871b580db96f9b8d/zk_dtypes-7a42ac4f9c3213925ac523c6871b580db96f9b8d.tar.gz"],
+)
+
+# A consumer declares the rules and test framework it uses itself; none of these
+# is inherited from prime_ir.
+bazel_dep(name = "rules_cc", version = "0.2.13")
+bazel_dep(name = "googletest", version = "1.17.0", repo_name = "com_google_googletest")

--- a/bazel/bzlmod_consumer/MODULE.bazel
+++ b/bazel/bzlmod_consumer/MODULE.bazel
@@ -18,8 +18,9 @@
 prime_ir's own `--config=bzlmod` lane builds it as the *root* module, where
 `archive_override` and patches still apply. A consumer resolves it as a non-root
 module, where they do not — so only a separate module like this one can show
-that `//MODULE.bazel` stands on its own. This is the second acceptance criterion
-of fractalyze/prime-ir#455.
+that `//MODULE.bazel` stands on its own, which is what this fixture exists to
+prove: that a project can `bazel_dep` on prime_ir and resolve every target it
+references.
 
 `local_path_override` stands in for the `archive_override` / `git_override` a
 real consumer writes: it pins no revision, but resolution treats prime_ir as a

--- a/bazel/bzlmod_consumer/consume_prime_ir_test.cc
+++ b/bazel/bzlmod_consumer/consume_prime_ir_test.cc
@@ -1,0 +1,49 @@
+/* Copyright 2026 The PrimeIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Asserts that prime_ir resolves, compiles and links as a non-root Bazel
+// module. The dialect exercise is deliberately trivial: prime_ir's own suite
+// covers behaviour, and what is under test here is dependency resolution.
+//
+// Loading the dialects reaches what a consumer cannot declare for itself: MLIR,
+// which arrives from the patched @llvm-project that prime_ir's module extension
+// fetches, and zk_dtypes, which the field and curve types are built on.
+
+#include "gtest/gtest.h"
+#include "mlir/IR/MLIRContext.h"
+#include "prime_ir/Dialect/EllipticCurve/IR/EllipticCurveDialect.h"
+#include "prime_ir/Dialect/Field/IR/FieldDialect.h"
+#include "prime_ir/Dialect/ModArith/IR/ModArithDialect.h"
+
+namespace {
+
+namespace ec = mlir::prime_ir::elliptic_curve;
+namespace field = mlir::prime_ir::field;
+namespace mod_arith = mlir::prime_ir::mod_arith;
+
+TEST(ConsumePrimeIrTest, DialectsLoad) {
+  mlir::MLIRContext context;
+
+  auto *fieldDialect = context.getOrLoadDialect<field::FieldDialect>();
+  auto *ecDialect = context.getOrLoadDialect<ec::EllipticCurveDialect>();
+  auto *modArithDialect =
+      context.getOrLoadDialect<mod_arith::ModArithDialect>();
+
+  EXPECT_EQ(fieldDialect->getNamespace(), "field");
+  EXPECT_EQ(ecDialect->getNamespace(), "elliptic_curve");
+  EXPECT_EQ(modArithDialect->getNamespace(), "mod_arith");
+}
+
+} // namespace

--- a/bazel/dev_deps.bzl
+++ b/bazel/dev_deps.bzl
@@ -1,0 +1,41 @@
+# Copyright 2026 The PrimeIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tooling a contributor runs by hand; no build target depends on it.
+
+`WORKSPACE.bazel` calls `prime_ir_dev_deps()` and MODULE.bazel wraps it in a
+`dev_dependency` extension, so a consumer of prime_ir never fetches any of it.
+"""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def prime_ir_dev_deps():
+    """Declares the repositories only a contributor's own commands need."""
+
+    # Hedron's Compile Commands Extractor for Bazel, which backs
+    # `bazel run @hedron_compile_commands//:refresh_all`.
+    # https://github.com/hedronvision/bazel-compile-commands-extractor
+    http_archive(
+        name = "hedron_compile_commands",
+        patch_args = ["-p1"],
+        patches = [Label("@zk_dtypes//third_party/bazel-compile-commands-extractor:allow_header_as_a_source_file.patch")],
+        strip_prefix = "bazel-compile-commands-extractor-ed994039a951b736091776d677f324b3903ef939",
+        url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/ed994039a951b736091776d677f324b3903ef939.tar.gz",
+    )
+
+def _dev_deps_impl(_module_ctx):
+    prime_ir_dev_deps()
+
+dev_deps = module_extension(implementation = _dev_deps_impl)

--- a/bazel/llvm_configure.bzl
+++ b/bazel/llvm_configure.bzl
@@ -13,15 +13,19 @@
 # limitations under the License.
 # ==============================================================================
 
-load("@rules_python//python:py_test.bzl", "py_test")
+"""Produces the `@llvm-project` the first-party BUILD files depend on.
 
-py_test(
-    name = "pin_sync_test",
-    size = "small",
-    srcs = ["pin_sync_test.py"],
-    data = [
-        "workspace.bzl",
-        "//:MODULE.bazel",
-    ],
-    deps = ["@pypi//absl_py"],
-)
+LLVM ships no BUILD files of its own; `llvm_configure` overlays the ones under
+`utils/bazel` onto the source archive `//bazel:llvm_deps.bzl` fetched.
+
+The `load()` below is why this is a second file and a second extension: it reads
+a `.bzl` out of `@llvm-raw`, so it cannot be evaluated until that repository
+exists. MODULE.bazel declares the two in that order.
+"""
+
+load("@llvm-raw//utils/bazel:configure.bzl", "llvm_configure")
+
+def _llvm_project_impl(_module_ctx):
+    llvm_configure(name = "llvm-project")
+
+llvm_project = module_extension(implementation = _llvm_project_impl)

--- a/bazel/llvm_deps.bzl
+++ b/bazel/llvm_deps.bzl
@@ -1,0 +1,34 @@
+# Copyright 2026 The PrimeIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Fetches the patched llvm-project source archive, before it is configured.
+
+Split from `//bazel:llvm_configure.bzl` because that file has to `load()` out of
+`@llvm-raw`, which cannot exist until this extension has run. Two extensions in
+two files is what orders them: MODULE.bazel `use_repo`s `llvm-raw` from here, so
+the other file's load resolves.
+
+llvm-project is patched, and bzlmod applies `patches` only for the root module
+when they hang off a `bazel_dep` override. Here they hang off an `http_archive`
+inside a module extension, which runs the same way whoever the root module is —
+so a consumer of prime_ir gets the patched LLVM, not a silently unpatched one.
+"""
+
+load("//third_party/llvm-project:workspace.bzl", llvm_project = "repo")
+
+def _llvm_deps_impl(_module_ctx):
+    llvm_project()
+
+llvm_deps = module_extension(implementation = _llvm_deps_impl)

--- a/bazel/non_module_deps.bzl
+++ b/bazel/non_module_deps.bzl
@@ -1,0 +1,32 @@
+# Copyright 2026 The PrimeIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""The bzlmod half of `//bazel:prime_ir_deps.bzl`.
+
+`prime_ir_deps()` is what `WORKSPACE.bazel` calls; this extension calls the same
+function, so the two lanes fetch one set of pins from one place. Everything it
+declares either ships no Bazel module (nanobind, pybind11 and robin_map are
+built from BUILD files this repository carries, which a registry module would
+replace) or is generated on the host (`local_config_omp`). A dependency the
+registry does carry belongs in MODULE.bazel as a `bazel_dep` instead, so that
+consumers resolve one shared version of it with us.
+"""
+
+load("//bazel:prime_ir_deps.bzl", "prime_ir_deps")
+
+def _non_module_deps_impl(_module_ctx):
+    prime_ir_deps()
+
+non_module_deps = module_extension(implementation = _non_module_deps_impl)

--- a/tests/lit.cfg.py
+++ b/tests/lit.cfg.py
@@ -26,7 +26,7 @@ config.suffixes = [".mlir", ".v"]
 
 # lit executes relative to the directory
 #
-#   bazel-bin/tests/<test_target_name>.runfiles/prime_ir/
+#   bazel-bin/tests/<test_target_name>.runfiles/<this repository>/
 #
 # which contains tools/ and tests/ directories and the binary targets built
 # within them, brought in via the `data` attribute in the BUILD file. To
@@ -42,24 +42,46 @@ config.suffixes = [".mlir", ".v"]
 # Hence, to get lit to see tools like `prime-ir-opt`, we need to add the tools/
 # subdirectory to the PATH environment variable.
 #
-# Bazel defines RUNFILES_DIR which includes prime_ir/ and third party dependencies
-# as their own directory. Generally, it seems that $PWD == $RUNFILES_DIR/prime_ir/
+# Bazel defines RUNFILES_DIR, which holds one directory per repository. Neither
+# that directory's name nor this repository's own is a constant: on the WORKSPACE
+# lane they are the apparent names (`prime_ir`, `llvm-project`), while under
+# `--config=bzlmod` this repository is `_main` and an external one carries a
+# canonical name that prefixes the apparent one (`_main~llvm_project~llvm-project`
+# on Bazel 7, `+llvm_project+llvm-project` on Bazel 8). Both lanes are resolved
+# below rather than spelled out.
 
 runfiles_dir = Path(os.environ["RUNFILES_DIR"])
 
-mlir_tools_relpath = "llvm-project/mlir"
-mlir_tools_path = runfiles_dir.joinpath(Path(mlir_tools_relpath))
+# lit runs with this repository's own runfiles directory as the working
+# directory, which is what makes it findable without knowing its name.
+main_repo_dir = Path.cwd()
 
-tool_relpaths = [
-    mlir_tools_relpath,
-    "prime_ir/tools",
-    "llvm-project/llvm",
+
+def external_repo_dir(apparent_name):
+  """Returns the runfiles directory of the external repository so named."""
+  for path in sorted(runfiles_dir.iterdir()):
+    if not path.is_dir():
+      continue
+    if path.name == apparent_name or path.name.endswith(
+        ("~" + apparent_name, "+" + apparent_name)
+    ):
+      return path
+  raise RuntimeError(
+      f"no runfiles directory for @{apparent_name} in {runfiles_dir}"
+  )
+
+
+llvm_project_dir = external_repo_dir("llvm-project")
+mlir_tools_path = llvm_project_dir.joinpath("mlir")
+
+tool_paths = [
+    mlir_tools_path,
+    main_repo_dir.joinpath("tools"),
+    llvm_project_dir.joinpath("llvm"),
 ]
 
 config.environment["PATH"] = (
-    ":".join(str(runfiles_dir.joinpath(Path(path))) for path in tool_relpaths)
-    + ":"
-    + os.environ["PATH"]
+    ":".join(str(path) for path in tool_paths) + ":" + os.environ["PATH"]
 )
 
 substitutions = {

--- a/third_party/llvm-project/workspace.bzl
+++ b/third_party/llvm-project/workspace.bzl
@@ -22,6 +22,11 @@ patch list and their order have one home.
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# Uncommented together with the `new_local_repository` call in `repo()` below.
+# It is the Starlark rule rather than the WORKSPACE native one, so the local
+# clone works on the bzlmod lane too.
+# load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
+
 LLVM_COMMIT = "815edc3ff646392bfee2b381d37dd35e4b04f9c5"
 
 LLVM_SHA256 = "bbc6fa4993162bdc7dd39b53927906a455940b87c782d0a37e00127f8bf8c696"
@@ -70,12 +75,9 @@ def repo():
         urls = ["https://github.com/llvm/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT)],
     )
 
-    # Uncomment this, plus its load at the top of the file, and comment out the
+    # Uncomment this, and its load at the top of the file, and comment out the
     # llvm-raw http_archive above, when following the llvm patch workflow from
-    # CONTRIBUTING.md to point Bazel at a local clone. It is the Starlark
-    # `new_local_repository` rather than the WORKSPACE native one, so the swap
-    # works on the bzlmod lane too.
-    # load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
+    # CONTRIBUTING.md to point Bazel at a local clone.
     # new_local_repository(
     #     name = "llvm-raw",
     #     build_file_content = "# empty",

--- a/third_party/llvm-project/workspace.bzl
+++ b/third_party/llvm-project/workspace.bzl
@@ -12,7 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# buildifier: disable=module-docstring
+"""Loads llvm-project and the two compression libraries its Bazel overlay needs.
+
+Both dependency paths go through `repo()`: `WORKSPACE.bazel` calls it directly,
+and `//bazel:llvm_deps.bzl` wraps it in the `llvm_deps` module extension. The
+archives are declared here rather than at either call site so that the pin, the
+patch list and their order have one home.
+"""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 LLVM_COMMIT = "815edc3ff646392bfee2b381d37dd35e4b04f9c5"
 
 LLVM_SHA256 = "bbc6fa4993162bdc7dd39b53927906a455940b87c782d0a37e00127f8bf8c696"
@@ -48,3 +57,53 @@ LLVM_PATCHES = [
     # convention can't be applied).
     "@prime_ir//third_party/llvm-project:asm_parser_rewind.patch",
 ]
+
+def repo():
+    """Declares llvm-raw at the pinned revision, plus llvm_zstd and llvm_zlib."""
+    http_archive(
+        name = "llvm-raw",
+        build_file_content = "# empty",
+        patch_args = ["-p1"],
+        patches = LLVM_PATCHES,
+        sha256 = LLVM_SHA256,
+        strip_prefix = "llvm-project-" + LLVM_COMMIT,
+        urls = ["https://github.com/llvm/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT)],
+    )
+
+    # Uncomment this, plus its load at the top of the file, and comment out the
+    # llvm-raw http_archive above, when following the llvm patch workflow from
+    # CONTRIBUTING.md to point Bazel at a local clone. It is the Starlark
+    # `new_local_repository` rather than the WORKSPACE native one, so the swap
+    # works on the bzlmod lane too.
+    # load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
+    # new_local_repository(
+    #     name = "llvm-raw",
+    #     build_file_content = "# empty",
+    #     path = "../llvm-project",
+    # )
+
+    # This is needed since https://reviews.llvm.org/D143344.
+    # Not sure if it's a bug or a feature, but it doesn't hurt to keep an additional
+    # dependency here.
+    http_archive(
+        name = "llvm_zstd",
+        build_file = "@llvm-raw//utils/bazel/third_party_build:zstd.BUILD",
+        sha256 = "7c42d56fac126929a6a85dbc73ff1db2411d04f104fae9bdea51305663a83fd0",
+        strip_prefix = "zstd-1.5.2",
+        urls = [
+            "https://github.com/facebook/zstd/releases/download/v1.5.2/zstd-1.5.2.tar.gz",
+        ],
+    )
+
+    # This is needed since https://reviews.llvm.org/D143320
+    # Not sure if it's a bug or a feature, but it doesn't hurt to keep an additional
+    # dependency here.
+    http_archive(
+        name = "llvm_zlib",
+        build_file = "@llvm-raw//utils/bazel/third_party_build:zlib-ng.BUILD",
+        sha256 = "e36bb346c00472a1f9ff2a0a4643e590a254be6379da7cddd9daeb9a7f296731",
+        strip_prefix = "zlib-ng-2.0.7",
+        urls = [
+            "https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.0.7.zip",
+        ],
+    )

--- a/third_party/nanobind/workspace.bzl
+++ b/third_party/nanobind/workspace.bzl
@@ -23,5 +23,5 @@ def repo():
         strip_prefix = "nanobind-2.9.2",
         sha256 = "8ce3667dce3e64fc06bfb9b778b6f48731482362fb89a43da156632266cd5a90",
         urls = ["https://github.com/wjakob/nanobind/archive/refs/tags/v2.9.2.tar.gz"],
-        build_file = "//third_party/nanobind:nanobind.BUILD",
+        build_file = Label("//third_party/nanobind:nanobind.BUILD"),
     )

--- a/third_party/pybind11/workspace.bzl
+++ b/third_party/pybind11/workspace.bzl
@@ -23,5 +23,5 @@ def repo():
         strip_prefix = "pybind11-2.10.3",
         sha256 = "201966a61dc826f1b1879a24a3317a1ec9214a918c8eb035be2f30c3e9cfbdcb",
         urls = ["https://github.com/pybind/pybind11/archive/v2.10.3.zip"],
-        build_file = "//third_party/pybind11:pybind11.BUILD",
+        build_file = Label("//third_party/pybind11:pybind11.BUILD"),
     )

--- a/third_party/robin_map/workspace.bzl
+++ b/third_party/robin_map/workspace.bzl
@@ -23,5 +23,5 @@ def repo():
         strip_prefix = "robin-map-1.3.0",
         sha256 = "a8424ad3b0affd4c57ed26f0f3d8a29604f0e1f2ef2089f497f614b1c94c7236",
         urls = ["https://github.com/Tessil/robin-map/archive/refs/tags/v1.3.0.tar.gz"],
-        build_file = "//third_party/robin_map:robin_map.BUILD",
+        build_file = Label("//third_party/robin_map:robin_map.BUILD"),
     )

--- a/third_party/zk_dtypes/pin_sync_test.py
+++ b/third_party/zk_dtypes/pin_sync_test.py
@@ -20,6 +20,15 @@ zk_dtypes is not in any registry, so the bzlmod lane reaches it through an
 `http_archive` in `workspace.bzl`. MODULE.bazel cannot `load()`, so the pin
 cannot be single-sourced and the two copies can drift — leaving the lanes
 building different revisions of the dependency the rest of the chain hangs on.
+
+Both files put the pin behind `ZK_DTYPES_`-prefixed variables so that one
+substitution finds it in either, which is what lets
+`.github/workflows/pin-bump.yml` hand both paths to the same bump action. This
+test is the other half of that arrangement: it fails if a hand edit, or a bump
+that reached only one file, leaves them disagreeing.
+
+The digest is the same hash written two ways — `http_archive` takes hex,
+`archive_override` takes base64 — so comparing it means converting first.
 """
 
 import base64
@@ -30,12 +39,7 @@ from absl.testing import absltest
 
 _COMMIT_RE = re.compile(r'ZK_DTYPES_COMMIT = "([0-9a-f]{40})"')
 _SHA256_RE = re.compile(r'ZK_DTYPES_SHA256 = "([0-9a-f]{64})"')
-_OVERRIDE_RE = re.compile(
-    r"archive_override\(\s*"
-    r'module_name = "zk_dtypes",\s*'
-    r'integrity = "sha256-([A-Za-z0-9+/=]+)",\s*'
-    r'strip_prefix = "zk_dtypes-([0-9a-f]{40})",'
-)
+_INTEGRITY_RE = re.compile(r'ZK_DTYPES_INTEGRITY = "sha256-([A-Za-z0-9+/=]+)"')
 
 
 def _read(path):
@@ -43,28 +47,33 @@ def _read(path):
     return f.read()
 
 
+def _search(pattern, contents, path):
+  match = pattern.search(contents)
+  if not match:
+    raise AssertionError(f"{path} has no {pattern.pattern}")
+  return match.group(1)
+
+
 class PinSyncTest(absltest.TestCase):
 
   def setUp(self):
     super().setUp()
     workspace_bzl = _read("third_party/zk_dtypes/workspace.bzl")
-    self.workspace_commit = _COMMIT_RE.search(workspace_bzl).group(1)
-    self.workspace_sha256 = _SHA256_RE.search(workspace_bzl).group(1)
+    module_bazel = _read("MODULE.bazel")
 
-    override = _OVERRIDE_RE.search(_read("MODULE.bazel"))
-    self.assertIsNotNone(
-        override, "MODULE.bazel has no zk_dtypes archive_override"
-    )
-    self.module_integrity, self.module_commit = override.groups()
+    self.workspace_commit = _search(_COMMIT_RE, workspace_bzl, "workspace.bzl")
+    self.workspace_sha256 = _search(_SHA256_RE, workspace_bzl, "workspace.bzl")
+    self.module_commit = _search(_COMMIT_RE, module_bazel, "MODULE.bazel")
+    self.module_integrity = _search(_INTEGRITY_RE, module_bazel, "MODULE.bazel")
 
   def test_commits_match(self):
     self.assertEqual(self.workspace_commit, self.module_commit)
 
   def test_hashes_match(self):
-    integrity = base64.b64encode(
+    as_integrity = base64.b64encode(
         binascii.unhexlify(self.workspace_sha256)
     ).decode()
-    self.assertEqual(integrity, self.module_integrity)
+    self.assertEqual(as_integrity, self.module_integrity)
 
 
 if __name__ == "__main__":

--- a/third_party/zk_dtypes/pin_sync_test.py
+++ b/third_party/zk_dtypes/pin_sync_test.py
@@ -1,0 +1,71 @@
+# Copyright 2026 The PrimeIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Checks that both dependency lanes pin the same zk_dtypes archive.
+
+zk_dtypes is not in any registry, so the bzlmod lane reaches it through an
+`archive_override` in MODULE.bazel and the WORKSPACE lane through an
+`http_archive` in `workspace.bzl`. MODULE.bazel cannot `load()`, so the pin
+cannot be single-sourced and the two copies can drift — leaving the lanes
+building different revisions of the dependency the rest of the chain hangs on.
+"""
+
+import base64
+import binascii
+import re
+
+from absl.testing import absltest
+
+_COMMIT_RE = re.compile(r'ZK_DTYPES_COMMIT = "([0-9a-f]{40})"')
+_SHA256_RE = re.compile(r'ZK_DTYPES_SHA256 = "([0-9a-f]{64})"')
+_OVERRIDE_RE = re.compile(
+    r"archive_override\(\s*"
+    r'module_name = "zk_dtypes",\s*'
+    r'integrity = "sha256-([A-Za-z0-9+/=]+)",\s*'
+    r'strip_prefix = "zk_dtypes-([0-9a-f]{40})",'
+)
+
+
+def _read(path):
+  with open(path, encoding="utf-8") as f:
+    return f.read()
+
+
+class PinSyncTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    workspace_bzl = _read("third_party/zk_dtypes/workspace.bzl")
+    self.workspace_commit = _COMMIT_RE.search(workspace_bzl).group(1)
+    self.workspace_sha256 = _SHA256_RE.search(workspace_bzl).group(1)
+
+    override = _OVERRIDE_RE.search(_read("MODULE.bazel"))
+    self.assertIsNotNone(
+        override, "MODULE.bazel has no zk_dtypes archive_override"
+    )
+    self.module_integrity, self.module_commit = override.groups()
+
+  def test_commits_match(self):
+    self.assertEqual(self.workspace_commit, self.module_commit)
+
+  def test_hashes_match(self):
+    integrity = base64.b64encode(
+        binascii.unhexlify(self.workspace_sha256)
+    ).decode()
+    self.assertEqual(integrity, self.module_integrity)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/third_party/zk_dtypes/workspace.bzl
+++ b/third_party/zk_dtypes/workspace.bzl
@@ -17,8 +17,8 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def repo():
-    ZK_DTYPES_COMMIT = "bd9687b158b30e191a8c4874da3b2a0352181ca9"
-    ZK_DTYPES_SHA256 = "cc5b04b3be78c459e8ed2705db7830fcb742a9e89c01aaaf67c204a6b4633220"
+    ZK_DTYPES_COMMIT = "7a42ac4f9c3213925ac523c6871b580db96f9b8d"
+    ZK_DTYPES_SHA256 = "f2911425babe1890a9c84fd5191714e9c3095318325133b576939689563bc91c"
     http_archive(
         name = "zk_dtypes",
         sha256 = ZK_DTYPES_SHA256,


### PR DESCRIPTION
Second link of the bottom-up bzlmod migration (fractalyze/ci-infra#3), after fractalyze/zk_dtypes#188. `MODULE.bazel` declares the registry deps and wraps the rest in module extensions calling the same `.bzl` files `WORKSPACE.bazel` calls, so each pin keeps one home. LLVM takes two extensions because its Bazel overlay loads out of the archive the first one fetches; its patches survive for consumers by hanging off an `http_archive` inside an extension rather than an override, which Bazel honours only for the root module.

The WORKSPACE build stays the default. Verified locally: both lanes 160/160, and from `bazel/bzlmod_consumer` — a separate module, the only way to exercise the non-root resolution a consumer gets — `@prime_ir//prime_ir/...` and `@prime_ir//tools/...` build in full.

Two things that lane turned up, both noted at the code: `@llvm-project` is not re-exported to consumers, and `//prime_ir/IR:Attributes` is not independently linkable (an `Attributes` ↔ `EllipticCurve` cycle is broken through headers-only targets), so the dialects link as a set.

The zk_dtypes pin moves to `7a42ac4f`, the first revision that has a `MODULE.bazel`, and a test fails if that pin and the override drift apart. This does **not** subsume #454, which targets `bb3b74f5`, a commit newer than this one's — see the note below.

Closes #455

