### PR TITLE
fix(dialect/mod_arith): skip the signed square for full-width moduli

### DIFF
--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -457,6 +457,15 @@ void buildBoundMap(func::FuncOp funcOp, BoundMap &boundMap) {
 
 namespace {
 Value getSignedFormFromCanonical(Value input, TypedAttr modAttr) {
+  // The signed form is a value in [-p, p) read as a signed w-bit integer, which
+  // is exact only when p < 2ʷ⁻¹. For a full-width modulus (Goldilocks) a - p
+  // falls below -2ʷ⁻¹ for small a and wraps to a - p + 2ʷ ≡ a + (2ʷ mod p).
+  APInt modulus = isa<IntegerAttr>(modAttr)
+                      ? cast<IntegerAttr>(modAttr).getValue()
+                      : cast<DenseElementsAttr>(modAttr).getSplatValue<APInt>();
+  if (modulus.isSignBitSet()) {
+    return {};
+  }
   auto minOp = input.getDefiningOp<arith::MinUIOp>();
   if (!minOp) {
     return {};

--- a/tests/Dialect/ModArith/gl64_lazy_square_runner.mlir
+++ b/tests/Dialect/ModArith/gl64_lazy_square_runner.mlir
@@ -1,0 +1,59 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// RUN: prime-ir-opt '-mod-arith-to-arith=lazy-reduction=true' %s | FileCheck %s --check-prefix=CHECK-LOWERING
+
+// RUN: prime-ir-opt %s '-mod-arith-to-arith=lazy-reduction=true' -convert-to-llvm \
+// RUN:   | mlir-runner -e main -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s < %t
+
+// A lazy Goldilocks add hands the square a value in [0, 2^64), which the
+// square pre-reduces to minui(a - p, a). Reading a - p as a signed i64 is exact
+// only when p < 2^63; for Goldilocks it wraps to a + (2^64 mod p), one
+// Montgomery unit, so a signed square would compute (a + 1)^2.
+
+func.func private @printMemrefI64(memref<*xi64>) attributes { llvm.emit_c_interface }
+
+!Gl = !mod_arith.int<18446744069414584321 : i64>
+!Glm = !mod_arith.int<18446744069414584321 : i64, true>
+
+// CHECK-LOWERING-LABEL: func.func @square_of_sum(
+// CHECK-LOWERING-NOT: arith.mulsi_extended
+// CHECK-LOWERING: arith.mului_extended
+func.func @square_of_sum(%a : !Glm, %b : !Glm) -> !Glm {
+  %s = mod_arith.add %a, %b : !Glm
+  %r = mod_arith.square %s : !Glm
+  return %r : !Glm
+}
+
+func.func @main() {
+  %a = mod_arith.constant 3 : !Gl
+  %b = mod_arith.constant 11 : !Gl
+  %a_mont = mod_arith.to_mont %a : !Glm
+  %b_mont = mod_arith.to_mont %b : !Glm
+  %r_mont = func.call @square_of_sum(%a_mont, %b_mont) : (!Glm, !Glm) -> !Glm
+  %r = mod_arith.from_mont %r_mont : !Gl
+  %v = mod_arith.bitcast %r : !Gl -> i64
+  %mem = memref.alloca() : memref<1xi64>
+  %c0 = arith.constant 0 : index
+  memref.store %v, %mem[%c0] : memref<1xi64>
+  %u = memref.cast %mem : memref<1xi64> to memref<*xi64>
+  func.call @printMemrefI64(%u) : (memref<*xi64>) -> ()
+  return
+}
+
+// (3 + 11)^2 = 196; the signed square prints 225 = 15^2.
+// CHECK: [196]

--- a/tests/Dialect/ModArith/lazy_reduction.mlir
+++ b/tests/Dialect/ModArith/lazy_reduction.mlir
@@ -613,3 +613,30 @@ func.func @test_lazy_add_goldilocks(%a : !Gla, %b : !Gla, %c : !Gla) -> !Gla {
   %r = mod_arith.mul %s, %c : !Gla
   return %r : !Gla
 }
+
+// -----
+
+// A gl64-lazy add feeding a Montgomery square is pre-reduced to
+// minui(a - p, a). The signed-square shortcut must not fire on it: a - p read
+// as a signed i64 wraps for a full-width modulus (runtime check in
+// gl64_lazy_square_runner.mlir). Shaped, so the modulus reaches the signed-form
+// check as a splat.
+!Glsq = !mod_arith.int<18446744069414584321 : i64, true>
+
+// LAZY-LABEL:     @test_lazy_add_mont_square_goldilocks_shaped
+// LAZY:           arith.addui_extended
+// LAZY:           arith.minui
+// LAZY-NOT:       arith.mulsi_extended
+// LAZY:           arith.mului_extended
+// LAZY:           return
+
+// EAGER-LABEL:    @test_lazy_add_mont_square_goldilocks_shaped
+// EAGER:          arith.minui
+// EAGER-NOT:      arith.mulsi_extended
+// EAGER:          arith.mului_extended
+// EAGER:          return
+func.func @test_lazy_add_mont_square_goldilocks_shaped(%a : tensor<4x!Glsq>, %b : tensor<4x!Glsq>) -> tensor<4x!Glsq> {
+  %s = mod_arith.add %a, %b : tensor<4x!Glsq>
+  %r = mod_arith.square %s : tensor<4x!Glsq>
+  return %r : tensor<4x!Glsq>
+}


### PR DESCRIPTION
## Description

With `lazy-reduction=true`, a Goldilocks Montgomery square of a gl64-lazy add computed `(a + 1)^2`: the pre-reduced `minui(a - p, a)` matched the signed-square shortcut, and `a - p` read as a signed i64 wraps to `a + (2^64 mod p)` when p ≥ 2^63. This is the XLA GPU miscompile behind every `power(s + rc, 7)` S-box over `goldilocks_mont`. The signed form is now refused for moduli with the sign bit set; narrow moduli (BabyBear, 65537) keep `mulsi_extended`.

## Related Issues/PRs

Closes #457
Unblocks fractalyze/xla#564

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline

<!-- agent-review -->
### Agent review
Verdict: ready after 1 round (head a32c89e7c1a5)
Approach holds: the guard sits in `getSignedFormFromCanonical`, the one helper both `ConvertMontMul` (ModArithToArith.cpp:1280) and `squareExtended` (ModArithToArith.cpp:1348) use for the `mulsi_extended` shortcut, and it discriminates full-width moduli with the same `isSignBitSet` test `MontReducer` already uses for `getCanonicalDiff` and REDC (MontReducer.cpp:117, 279, 317). Nine lines, no parallel mechanism.

Coverage: `gl64_lazy_square_runner.mlir` executes the scalar case (prints 196, would print 225 on base) and `lazy_reduction.mlir:625` pins the shaped lowering, which exercises the `DenseElementsAttr` splat branch of the guard; both are picked up by `glob_lit_tests` in `tests/Dialect/ModArith/BUILD.bazel`. CI is green at a32c89e.

Prose: the source comment and both test comments state the invariant (signed w-bit read is exact only for p < 2^(w-1)) without chronology or measured figures. Commit body and PR body carry no perf claim. No findings.
<!-- /agent-review -->
